### PR TITLE
fix(credits): restore Credits tile in mobile launchers

### DIFF
--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.247.0+1756529734
+version: 1.248.0+1756529735
 
 
 
@@ -210,7 +210,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.251.0.0
+  msix_version: 1.252.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.246.0+1756529733
+version: 1.247.0+1756529734
 
 
 
@@ -210,7 +210,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.250.0.0
+  msix_version: 1.251.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.248.0+1756529735
+version: 1.249.0+1756529736
 
 
 
@@ -210,7 +210,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.252.0.0
+  msix_version: 1.253.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.249.0+1756529736
+version: 1.250.0+1756529737
 
 
 
@@ -210,7 +210,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.253.0.0
+  msix_version: 1.254.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/open-sources/turso_dart/CHANGELOG.md
+++ b/open-sources/turso_dart/CHANGELOG.md
@@ -1,5 +1,11 @@
+## 0.1.0+flipper.1
+- Fix Android 16 KB ELF alignment: pass max-page-size via
+  `CARGO_TARGET_*_RUSTFLAGS` in the build hook (`.cargo/config.toml` alone is
+  ignored when cargo is invoked with `--manifest-path` from another cwd).
+
 ## 0.1.0
 - Expose isolate.dart as async alternative to be used in flutter project
+- Flipper: Android 16 KB page-size linker flags (see README)
 
 ## 0.0.2
 - fix possible memory leaks

--- a/open-sources/turso_dart/README.md
+++ b/open-sources/turso_dart/README.md
@@ -7,8 +7,12 @@ Android builds pass `-Wl,-z,max-page-size=16384` (and `common-page-size`) so
 4 KB alignment, which Google Play rejects for apps targeting API 35+.
 
 Patch:
-- `rust/.cargo/config.toml` — linker flags for Android Cargo target triples only
-  (safe for web: those triples are never used, and the hook must not read
-  `input.config.code` which is null on web).
+
+- `hook/build.dart` — sets `CARGO_TARGET_*_LINUX_ANDROID_RUSTFLAGS` for the
+  three Android triples. Required because `native_toolchain_rust` invokes
+  `cargo` with `--manifest-path` and does not `cd` into `rust/`, so Cargo never
+  loads `rust/.cargo/config.toml` (config discovery is cwd-based).
+- `rust/.cargo/config.toml` — same flags for local `cd rust && cargo build
+  --target …` workflows; not used by the Flutter native-assets hook.
 
 Remove this fork when upstream publishes a 16 KB-aligned release.

--- a/open-sources/turso_dart/hook/build.dart
+++ b/open-sources/turso_dart/hook/build.dart
@@ -1,13 +1,28 @@
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_rust/native_toolchain_rust.dart';
 
-/// Android 16 KB ELF alignment is set in `rust/.cargo/config.toml` for
-/// Android target triples only. Do not read [HookConfig.code] here — web
-/// builds invoke this hook without a code-assets extension and would null-crash.
+/// Android 16 KB ELF alignment for Google Play (targetSdk 35+).
+///
+/// `native_toolchain_rust` runs `cargo build --manifest-path …` without setting
+/// cwd to the crate, so Cargo never reads `rust/.cargo/config.toml` (config is
+/// discovered from cwd, not the manifest). Pass flags via target RUSTFLAGS env
+/// vars instead. Do not read [HookConfig.code] here — web builds invoke this
+/// hook without a code-assets extension and would null-crash.
+const _android16KbRustflags =
+    '-C link-arg=-Wl,-z,max-page-size=16384 '
+    '-C link-arg=-Wl,-z,common-page-size=16384';
+
+const _android16KbEnv = <String, String>{
+  'CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS': _android16KbRustflags,
+  'CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_RUSTFLAGS': _android16KbRustflags,
+  'CARGO_TARGET_X86_64_LINUX_ANDROID_RUSTFLAGS': _android16KbRustflags,
+};
+
 void main(List<String> args) async {
   await build(args, (input, output) async {
     await const RustBuilder(
       assetName: 'src/ffi.g.dart',
+      extraCargoEnvironmentVariables: _android16KbEnv,
     ).run(input: input, output: output);
   });
 }

--- a/open-sources/turso_dart/pubspec.yaml
+++ b/open-sources/turso_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: turso_dart
 description: "Dart binding for the new-gen Turso (Flipper fork: Android 16KB ELF alignment)"
-version: 0.1.0
+version: 0.1.0+flipper.1
 repository: https://github.com/dikatok/turso_dart
 topics: [turso, sqlite, database, local, sync]
 publish_to: none

--- a/packages/edges/supabase/functions/generateReceiptUrl/index.ts
+++ b/packages/edges/supabase/functions/generateReceiptUrl/index.ts
@@ -111,6 +111,8 @@ async function queueReceiptSms(
       text: messageText,
       phone_number: phone,
       branch_id: branchUuid,
+      message_source: "sms",
+      message_type: "text",
     })
     .select("id")
     .single();

--- a/packages/edges/supabase/functions/sendSms/index.ts
+++ b/packages/edges/supabase/functions/sendSms/index.ts
@@ -137,12 +137,13 @@ async function processPendingSMS() {
     console.log("Starting to process pending SMS messages...");
 
     try {
-        // Fetch pending messages, including branch_id
-        const { data, error } = await supabase
+        // Fetch pending messages; skip WhatsApp audit rows (delivered via OpenWA).
+        // Legacy SMS rows may have message_source null or 'ai'.
+        const { data: pendingRows, error } = await supabase
             .from('messages')
-            .select('id, text, phone_number, delivered, branch_id')
+            .select('id, text, phone_number, delivered, branch_id, message_source')
             .eq('delivered', false)
-            .limit(10);
+            .limit(20);
 
         if (error) {
             console.error("Error fetching pending SMS:", error);
@@ -153,6 +154,10 @@ async function processPendingSMS() {
                 error: `Database fetch error: ${error.message}`
             };
         }
+
+        const data = (pendingRows ?? []).filter(
+            (row) => row.message_source !== 'whatsapp',
+        ).slice(0, 10);
 
         console.log(`Found ${data.length} pending SMS messages to process`);
 

--- a/packages/flipper_ai_feature/lib/src/providers/whatsapp_message_provider.dart
+++ b/packages/flipper_ai_feature/lib/src/providers/whatsapp_message_provider.dart
@@ -1,18 +1,265 @@
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flipper_services/whatsapp_ditto_inbox.dart';
 import 'package:flipper_services/whatsapp_message_sync_service.dart';
-import 'package:flipper_services/proxy.dart';
+import 'package:flipper_services/data_connector_url.dart';
+import 'package:flipper_web/services/ditto_service.dart';
 import 'package:flutter_riverpod/legacy.dart';
+import 'package:http/http.dart' as http;
 
-/// Provider for WhatsApp message sync service
+import 'whatsapp_connection_provider.dart';
+
+String _normalizeBase(String url) {
+  var u = url.trim();
+  if (!u.endsWith('/')) u = '$u/';
+  // Treat localhost and 127.0.0.1 as the same host so we don't try both.
+  u = u.replaceFirst('://localhost:', '://127.0.0.1:');
+  return u;
+}
+
+bool _isLoopbackBase(String base) {
+  final host = Uri.tryParse(base)?.host;
+  return host == '127.0.0.1' || host == 'localhost';
+}
+
+/// Sticky base after the first successful poll — avoids re-trying dead URLs.
+String? _workingBase;
+
+/// Prefer EBM / cached URL (e.g. https://prod.api.yegobox.com/), then local, then alias.
+Future<List<String>> _candidateBases() async {
+  final out = <String>[];
+  void add(String? raw) {
+    if (raw == null || raw.trim().isEmpty) return;
+    final n = _normalizeBase(raw);
+    if (!out.contains(n)) out.add(n);
+  }
+
+  add(await resolveEbmDataConnectorUrl());
+  if (kDebugMode && !out.any(_isLoopbackBase)) {
+    add('http://127.0.0.1:8084/');
+  }
+  add('https://data-connector.yegobox.com/');
+  add('https://prod.api.yegobox.com/');
+  return out;
+}
+
+Future<List<Map<String, dynamic>>> _fetchLocalDocs() async {
+  final store = DittoService.instance.store;
+  if (store == null) return const [];
+  try {
+    final result = await store.execute('SELECT * FROM whatsapp_messages');
+    final out = <Map<String, dynamic>>[];
+    for (final item in result.items) {
+      try {
+        out.add(Map<String, dynamic>.from(item.value as Map));
+      } catch (_) {}
+    }
+    return out;
+  } catch (e) {
+    debugPrint('local whatsapp_messages read failed: $e');
+    return const [];
+  }
+}
+
+Future<List<Map<String, dynamic>>> _fetchRemoteDocs({
+  required http.Client client,
+  required String phoneNumberId,
+}) async {
+  final bases = await _candidateBases();
+  final ordered = <String>[
+    if (_workingBase != null && bases.contains(_workingBase)) _workingBase!,
+    ...bases.where((b) => b != _workingBase),
+  ];
+
+  // Skip known-dead loopback quickly when nothing is listening.
+  final tryBases = ordered.where((b) {
+    if (!_isLoopbackBase(b)) return true;
+    // Still try loopback, but with a short timeout below.
+    return true;
+  }).toList();
+
+  Future<List<Map<String, dynamic>>?> attempt(String base) async {
+    final uri = Uri.parse('${base}api/whatsapp/messages').replace(
+      queryParameters: {
+        'phone_number_id': phoneNumberId,
+        'limit': '1000',
+      },
+    );
+    final timeout = _isLoopbackBase(base)
+        ? const Duration(seconds: 2)
+        : const Duration(seconds: 15);
+    try {
+      final response = await client.get(uri).timeout(timeout);
+      if (response.statusCode != 200) {
+        debugPrint(
+          'WhatsApp inbox HTTP ${response.statusCode} @ $base',
+        );
+        return null;
+      }
+      final root = jsonDecode(response.body) as Map<String, dynamic>;
+      final msgs = (root['messages'] as List<dynamic>? ?? const [])
+          .whereType<Map>()
+          .map((e) => Map<String, dynamic>.from(e))
+          .toList();
+      debugPrint(
+        'WhatsApp inbox HTTP ok: base=$base count=${msgs.length}',
+      );
+      return msgs;
+    } catch (e) {
+      debugPrint('WhatsApp inbox HTTP failed @ $base: $e');
+      return null;
+    }
+  }
+
+  // Prefer sticky base first (sequential), then race the rest.
+  if (_workingBase != null && tryBases.contains(_workingBase)) {
+    final hit = await attempt(_workingBase!);
+    if (hit != null) return hit;
+    _workingBase = null;
+  }
+
+  final rest = tryBases.where((b) => b != _workingBase).toList();
+  if (rest.isEmpty) {
+    throw StateError('whatsapp/messages unreachable: no candidates');
+  }
+
+  final completer = Completer<List<Map<String, dynamic>>>();
+  var pending = rest.length;
+
+  for (final base in rest) {
+    unawaited(() async {
+      final hit = await attempt(base);
+      if (hit != null) {
+        if (!completer.isCompleted) {
+          _workingBase = base;
+          completer.complete(hit);
+        }
+        return;
+      }
+      pending -= 1;
+      if (pending == 0 && !completer.isCompleted) {
+        completer.completeError(
+          StateError('whatsapp/messages unreachable on all candidates'),
+        );
+      }
+    }());
+  }
+
+  return completer.future;
+}
+
+List<Map<String, dynamic>> _mergeDocs(
+  List<Map<String, dynamic>> remote,
+  List<Map<String, dynamic>> local,
+  String phoneNumberId,
+) {
+  final byId = <String, Map<String, dynamic>>{};
+
+  void put(Map<String, dynamic> doc) {
+    final id = (doc['_id'] ?? doc['id'] ?? doc['messageId'] ?? '').toString();
+    if (id.isEmpty) return;
+    final pid =
+        (doc['phoneNumberId'] ?? doc['phone_number_id'] ?? '').toString();
+    if (pid.isNotEmpty && pid != phoneNumberId) return;
+
+    final prev = byId[id];
+    if (prev == null) {
+      byId[id] = Map<String, dynamic>.from(doc);
+      return;
+    }
+
+    final deleted = WhatsAppDittoMessage.isDeletedDoc(prev) ||
+        WhatsAppDittoMessage.isDeletedDoc(doc);
+    final merged = Map<String, dynamic>.from(doc);
+    if (deleted) {
+      merged['deleted'] = true;
+      merged['status'] = 'deleted';
+    }
+    byId[id] = merged;
+  }
+
+  // Local first, remote last — webhook store wins when reachable.
+  for (final d in local) {
+    put(d);
+  }
+  for (final d in remote) {
+    put(d);
+  }
+
+  return byId.values
+      .where((d) => !WhatsAppDittoMessage.isDeletedDoc(d))
+      .toList();
+}
+
+/// Inbox: data-connector HTTP when reachable; always merges local Ditto so a
+/// timeout never blanks the UI.
+final whatsappDittoThreadsProvider =
+    StreamProvider<List<WhatsAppDittoThread>>((ref) async* {
+  ref.keepAlive();
+  ref.watch(whatsAppConnectionStateProvider);
+
+  final phoneNumberId = await resolveWhatsAppPhoneNumberId();
+  if (phoneNumberId == null || phoneNumberId.isEmpty) {
+    yield const [];
+    return;
+  }
+
+  final client = http.Client();
+  ref.onDispose(client.close);
+
+  List<WhatsAppDittoThread>? lastOk;
+
+  while (true) {
+    final local = await _fetchLocalDocs();
+    List<Map<String, dynamic>> remote = const [];
+    try {
+      remote = await _fetchRemoteDocs(
+        client: client,
+        phoneNumberId: phoneNumberId,
+      );
+    } catch (e, st) {
+      debugPrint(
+        'whatsappDittoThreadsProvider HTTP failed (using local Ditto): $e\n$st',
+      );
+    }
+
+    final merged = _mergeDocs(remote, local, phoneNumberId);
+    final threads = WhatsAppDittoInbox.groupThreadsFromDocs(merged);
+    if (threads.isNotEmpty || remote.isNotEmpty || local.isNotEmpty) {
+      lastOk = threads;
+    }
+    debugPrint(
+      'WhatsApp inbox: remote=${remote.length} local=${local.length} '
+      'merged=${merged.length} threads=${threads.length}',
+    );
+    // Prefer fresh merge; if both sources empty but we had data, keep last.
+    if (threads.isNotEmpty || lastOk == null) {
+      yield threads;
+    } else {
+      yield lastOk;
+    }
+
+    await Future<void>.delayed(const Duration(seconds: 2));
+  }
+});
+
+final whatsappDittoInboxProvider = Provider<WhatsAppDittoInbox>((ref) {
+  final inbox = WhatsAppDittoInbox();
+  ref.onDispose(() {
+    unawaited(inbox.dispose());
+  });
+  return inbox;
+});
+
 final whatsappMessageSyncProvider = StateNotifierProvider<
     WhatsAppMessageSyncNotifier, AsyncValue<WhatsAppSyncState>>((ref) {
   ref.keepAlive();
   return WhatsAppMessageSyncNotifier();
 });
 
-/// Notifier to manage WhatsApp message sync service lifecycle
 class WhatsAppMessageSyncNotifier
     extends StateNotifier<AsyncValue<WhatsAppSyncState>> {
   WhatsAppMessageSyncService? _service;
@@ -22,53 +269,28 @@ class WhatsAppMessageSyncNotifier
     _initialize();
   }
 
-  /// Initialize the sync service with the business's WhatsApp phone number ID
   Future<void> _initialize() async {
     try {
-      // Clear any existing subscription to prevent leaks
       await _stateSubscription?.cancel();
       _stateSubscription = null;
 
-      // Get the current business
-      final businessId = ProxyService.box.getBusinessId();
-      if (businessId == null) {
-        state = AsyncValue.error('Business ID not found', StackTrace.current);
-        return;
-      }
-
-      // Get business to retrieve WhatsApp phoneNumberId
-      final business = await ProxyService.strategy.getBusiness(
-        businessId: businessId,
-      );
-
-      if (business == null) {
-        state = AsyncValue.data(WhatsAppSyncState.idle());
-        return;
-      }
-
-      final phoneNumberId = business.getWhatsAppPhoneNumberId();
-
+      final phoneNumberId = await resolveWhatsAppPhoneNumberId();
       if (phoneNumberId == null || phoneNumberId.isEmpty) {
-        // No WhatsApp configured, that's okay - just idle
         state = AsyncValue.data(WhatsAppSyncState.idle());
         return;
       }
 
-      // Initialize the sync service
       _service = WhatsAppMessageSyncService();
       await _service!.initialize(phoneNumberId);
 
-      // Listen to service state changes - store the subscription
       _stateSubscription = _service!.stateStream.listen((syncState) {
         state = AsyncValue.data(syncState);
       });
-      // Removed the immediate idle state assignment to allow stream to control initial state
     } catch (e, stack) {
       state = AsyncValue.error(e, stack);
     }
   }
 
-  /// Manually trigger a refresh of the sync service
   Future<void> refresh() async {
     await _initialize();
   }

--- a/packages/flipper_ai_feature/lib/src/screens/ai_screen.dart
+++ b/packages/flipper_ai_feature/lib/src/screens/ai_screen.dart
@@ -503,8 +503,10 @@ class _AiScreenState extends ConsumerState<AiScreen> with WidgetsBindingObserver
     showDialog<void>(
       context: context,
       builder: (_) => WhatsAppConnectionDialog(
-        onConnectionChanged: () =>
-            ref.invalidate(whatsAppConnectionStateProvider),
+        onConnectionChanged: () {
+          ref.invalidate(whatsAppConnectionStateProvider);
+          ref.read(whatsappMessageSyncProvider.notifier).refresh();
+        },
       ),
     );
   }

--- a/packages/flipper_ai_feature/lib/src/services/whatsapp_connection_service.dart
+++ b/packages/flipper_ai_feature/lib/src/services/whatsapp_connection_service.dart
@@ -1,5 +1,6 @@
 import 'package:flipper_services/proxy.dart';
 import 'package:flipper_services/whatsapp_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:supabase_models/brick/models/all_models.dart';
 import 'package:supabase_models/brick/repository.dart';
 import 'package:brick_offline_first/brick_offline_first.dart';
@@ -37,7 +38,10 @@ class WhatsAppConnectionState {
   }
 }
 
-/// Service for managing WhatsApp connection business logic
+/// Service for managing WhatsApp connection business logic.
+///
+/// Source of truth is [Business.messagingChannels] on Supabase.
+/// Local Brick + prefs mirror it for offline / this device.
 class WhatsAppConnectionService {
   final WhatsAppService _whatsappService;
   final Repository _repository;
@@ -48,35 +52,46 @@ class WhatsAppConnectionService {
   })  : _whatsappService = whatsappService ?? WhatsAppService(),
         _repository = repository ?? Repository();
 
-  /// Get current connection state from Business model (single source of truth)
+  Future<Business?> _currentBusiness({bool hydrateRemote = false}) async {
+    final businessId = ProxyService.box.getBusinessId();
+    if (businessId == null || businessId.isEmpty) return null;
+
+    final query = Query(where: [Where('id').isExactly(businessId)]);
+    final result = await _repository.get<Business>(
+      query: query,
+      policy: hydrateRemote
+          ? OfflineFirstGetPolicy.alwaysHydrate
+          : OfflineFirstGetPolicy.localOnly,
+    );
+    return result.firstOrNull;
+  }
+
   Future<WhatsAppConnectionState> getConnectionState() async {
     try {
-      final businessId = ProxyService.box.getBusinessId();
-      if (businessId == null) {
-        return const WhatsAppConnectionState(isConnected: false);
+      final business = await _currentBusiness(hydrateRemote: true);
+      var phoneNumberId = business?.getWhatsAppPhoneNumberId();
+
+      // Prefs fallback (older connects that never reached Supabase).
+      if (phoneNumberId == null || phoneNumberId.isEmpty) {
+        final fromPrefs = ProxyService.box.whatsAppPhoneNumberId();
+        if (fromPrefs != null && fromPrefs.isNotEmpty) {
+          phoneNumberId = fromPrefs;
+          // Heal remote / local Business so next launch doesn't depend on prefs.
+          try {
+            await _updateBusinessMessagingChannels(phoneNumberId);
+          } catch (_) {}
+        }
       }
 
-      final query = Query(where: [Where('serverId').isExactly(businessId)]);
-      final result = await _repository.get<Business>(
-        query: query,
-        policy: OfflineFirstGetPolicy.localOnly,
-      );
-      final business = result.firstOrNull;
-
-      if (business != null) {
-        final phoneNumberId = business.getWhatsAppPhoneNumberId();
-        if (phoneNumberId != null && phoneNumberId.isNotEmpty) {
-          // Sync to local storage for backward compatibility
-          await ProxyService.box.writeString(
-            key: 'whatsAppPhoneNumberId',
-            value: phoneNumberId,
-          );
-
-          return WhatsAppConnectionState(
-            isConnected: true,
-            phoneNumberId: phoneNumberId,
-          );
-        }
+      if (phoneNumberId != null && phoneNumberId.isNotEmpty) {
+        await ProxyService.box.writeString(
+          key: 'whatsAppPhoneNumberId',
+          value: phoneNumberId,
+        );
+        return WhatsAppConnectionState(
+          isConnected: true,
+          phoneNumberId: phoneNumberId,
+        );
       }
 
       return const WhatsAppConnectionState(isConnected: false);
@@ -85,7 +100,6 @@ class WhatsAppConnectionService {
     }
   }
 
-  /// Validate and connect WhatsApp account
   Future<WhatsAppConnectionState> connect(String phoneNumberId) async {
     if (phoneNumberId.isEmpty) {
       return const WhatsAppConnectionState(
@@ -106,21 +120,18 @@ class WhatsAppConnectionService {
         );
       }
 
-      // Save to local storage
+      await _updateBusinessMessagingChannels(phoneNumberId);
+
       await ProxyService.box.writeString(
         key: 'whatsAppPhoneNumberId',
         value: phoneNumberId,
       );
-
-      // Save to Business model in Supabase
-      await _updateBusinessMessagingChannels(phoneNumberId);
 
       return WhatsAppConnectionState(
         isConnected: true,
         phoneNumberId: phoneNumberId,
       );
     } catch (e) {
-      // Rollback the local storage write to maintain consistency on failure
       await ProxyService.box.writeString(
         key: 'whatsAppPhoneNumberId',
         value: '',
@@ -133,13 +144,10 @@ class WhatsAppConnectionService {
     }
   }
 
-  /// Disconnect WhatsApp account
   Future<WhatsAppConnectionState> disconnect() async {
     try {
-      // Clear from Business model first
       await _updateBusinessMessagingChannels(null);
 
-      // Clear from local storage
       await ProxyService.box.writeString(
         key: 'whatsAppPhoneNumberId',
         value: '',
@@ -154,33 +162,33 @@ class WhatsAppConnectionService {
     }
   }
 
-  /// Update Business model with WhatsApp phone number ID
-  /// Throws exception on failure to allow caller to handle errors appropriately
+  /// Persist Phone Number ID on Business locally and on Supabase.
   Future<void> _updateBusinessMessagingChannels(String? phoneNumberId) async {
-    try {
-      final businessId = ProxyService.box.getBusinessId();
-      if (businessId == null) return; // Nothing to update if no business ID
-
-      final query = Query(where: [Where('serverId').isExactly(businessId)]);
-      final result = await _repository.get<Business>(
-        query: query,
-        policy: OfflineFirstGetPolicy.localOnly,
-      );
-      final business = result.firstOrNull;
-
-      if (business != null) {
-        final updatedBusiness = business.setWhatsAppPhoneNumberId(
-          phoneNumberId,
-        );
-        await _repository.upsert<Business>(
-          updatedBusiness,
-          policy: OfflineFirstUpsertPolicy.optimisticLocal,
-        );
-      }
-    } catch (e) {
-      // Log error and rethrow to allow caller to handle errors appropriately
-      print('Error updating business messaging channels: $e');
-      rethrow;
+    final businessId = ProxyService.box.getBusinessId();
+    if (businessId == null || businessId.isEmpty) {
+      throw Exception('No business selected — cannot save WhatsApp connection');
     }
+
+    final business = await _currentBusiness(hydrateRemote: false);
+    if (business == null) {
+      throw Exception('Business not found — cannot save WhatsApp connection');
+    }
+
+    // Mutate in place (avoids broken Business.copyWith field drops).
+    business.setWhatsAppPhoneNumberId(phoneNumberId);
+    final channels = business.messagingChannelsMap();
+
+    // Direct jsonb write — Brick serializes messaging_channels as a JSON string,
+    // which PostgREST can reject / store incorrectly for jsonb columns.
+    await Supabase.instance.client
+        .from('businesses')
+        .update({'messaging_channels': channels})
+        .eq('id', businessId);
+
+    // Keep local Brick / Turso in sync for offline reads.
+    await _repository.upsert<Business>(
+      business,
+      policy: OfflineFirstUpsertPolicy.localOnly,
+    );
   }
 }

--- a/packages/flipper_ai_feature/lib/src/widgets/flo/flo_header.dart
+++ b/packages/flipper_ai_feature/lib/src/widgets/flo/flo_header.dart
@@ -261,7 +261,7 @@ class _ModeTab extends StatelessWidget {
                   constraints: const BoxConstraints(minWidth: 18, minHeight: 18),
                   padding: const EdgeInsets.symmetric(horizontal: 5),
                   decoration: BoxDecoration(
-                    color: FloTheme.wa,
+                    color: FloTheme.blue,
                     borderRadius: BorderRadius.circular(9),
                   ),
                   alignment: Alignment.center,
@@ -307,7 +307,7 @@ class _HeaderChips extends StatelessWidget {
         whatsAppConnected
             ? _ChanChip(
                 label: 'WhatsApp',
-                icon: FloIcons.whatsApp(size: 14, color: FloTheme.waDeep),
+                icon: FloIcons.whatsApp(size: 14, color: FloTheme.blueDeep),
                 connected: true,
                 isWhatsApp: true,
                 onTap: onConnectWhatsApp,
@@ -337,11 +337,11 @@ class _ChanChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bg = isWhatsApp ? FloTheme.waTint : FloTheme.surface;
-    final border = isWhatsApp ? const Color(0xFFBCE7CC) : FloTheme.line;
-    final fg = isWhatsApp ? FloTheme.waDeep : FloTheme.ink2;
-    final dotColor = isWhatsApp ? FloTheme.wa : FloTheme.gain;
-    final dotGlow = isWhatsApp ? const Color(0xFFCFF0DC) : FloTheme.gainTint;
+    final bg = isWhatsApp ? FloTheme.blueTint : FloTheme.surface;
+    final border = isWhatsApp ? FloTheme.blueTint2 : FloTheme.line;
+    final fg = isWhatsApp ? FloTheme.blueDeep : FloTheme.ink2;
+    final dotColor = isWhatsApp ? FloTheme.blue : FloTheme.gain;
+    final dotGlow = isWhatsApp ? FloTheme.blueTint2 : FloTheme.gainTint;
 
     return InkWell(
       onTap: onTap,
@@ -401,7 +401,7 @@ class _ConnectChip extends StatelessWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              FloIcons.whatsApp(size: 14, color: FloTheme.wa),
+              FloIcons.whatsApp(size: 14, color: FloTheme.blue),
               const SizedBox(width: 6),
               const Text(
                 'Connect WhatsApp',
@@ -508,8 +508,8 @@ class FloMenuPopover extends StatelessWidget {
           ),
           const Divider(height: 12, color: FloTheme.lineSoft),
           _MenuItem(
-            icon: FloIcons.whatsApp(size: 16, color: FloTheme.waDeep),
-            iconBg: FloTheme.waTint,
+            icon: FloIcons.whatsApp(size: 16, color: FloTheme.blueDeep),
+            iconBg: FloTheme.blueTint,
             title: 'Connect WhatsApp',
             subtitle: 'Chat with Flo & customers',
             badge: whatsAppConnected ? 'On' : 'Off',
@@ -598,7 +598,7 @@ class _MenuItem extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
                   decoration: BoxDecoration(
-                    color: badgeOn ? FloTheme.waTint : FloTheme.surface2,
+                    color: badgeOn ? FloTheme.blueTint : FloTheme.surface2,
                     borderRadius: BorderRadius.circular(FloTheme.radiusPill),
                     border: badgeOn ? null : Border.all(color: FloTheme.line),
                   ),
@@ -607,7 +607,7 @@ class _MenuItem extends StatelessWidget {
                     style: TextStyle(
                       fontSize: 10,
                       fontWeight: FontWeight.w700,
-                      color: badgeOn ? FloTheme.waDeep : FloTheme.ink3,
+                      color: badgeOn ? FloTheme.blueDeep : FloTheme.ink3,
                     ),
                   ),
                 ),

--- a/packages/flipper_ai_feature/lib/src/widgets/flo/flo_home_view.dart
+++ b/packages/flipper_ai_feature/lib/src/widgets/flo/flo_home_view.dart
@@ -592,12 +592,12 @@ class _ChannelCard extends StatelessWidget {
             height: 40,
             alignment: Alignment.center,
             decoration: BoxDecoration(
-              color: isData ? FloTheme.blueTint : FloTheme.waTint,
+              color: FloTheme.blueTint,
               borderRadius: BorderRadius.circular(11),
             ),
             child: isData
                 ? FloIcons.database(size: 21, color: FloTheme.blue)
-                : FloIcons.whatsApp(size: 21, color: FloTheme.waDeep),
+                : FloIcons.whatsApp(size: 21, color: FloTheme.blueDeep),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -656,20 +656,9 @@ class _ChannelCard extends StatelessWidget {
                       height: 34,
                       padding: const EdgeInsets.symmetric(horizontal: 14),
                       decoration: BoxDecoration(
-                        gradient: const LinearGradient(
-                          begin: Alignment.topCenter,
-                          end: Alignment.bottomCenter,
-                          colors: [Color(0xFF25BD60), FloTheme.waDeep],
-                        ),
+                        gradient: FloTheme.gradBtn,
                         borderRadius: BorderRadius.circular(10),
-                        boxShadow: const [
-                          BoxShadow(
-                            color: Color(0x990E8A47),
-                            blurRadius: 18,
-                            offset: Offset(0, 8),
-                            spreadRadius: -8,
-                          ),
-                        ],
+                        boxShadow: const [FloTheme.shBlue],
                       ),
                       child: Row(
                         mainAxisSize: MainAxisSize.min,

--- a/packages/flipper_ai_feature/lib/src/widgets/flo/flo_inbox_view.dart
+++ b/packages/flipper_ai_feature/lib/src/widgets/flo/flo_inbox_view.dart
@@ -1,18 +1,23 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flipper_services/data_connector_url.dart';
 import 'package:flipper_services/proxy.dart';
+import 'package:flipper_services/whatsapp_ditto_inbox.dart';
 import 'package:flipper_services/whatsapp_service.dart';
-import 'package:supabase_models/brick/models/conversation.model.dart';
-import 'package:supabase_models/brick/models/message.model.dart';
-import 'package:supabase_models/brick/repository.dart';
+import 'package:http/http.dart' as http;
 
-import '../../models/flo_models.dart';
-import '../../providers/conversation_provider.dart';
+import '../../providers/whatsapp_message_provider.dart';
 import '../../services/flo_chat_service.dart';
 import '../../theme/flo_theme.dart';
+import 'flo_icons.dart';
 import 'flo_mark.dart';
 
-/// WhatsApp Messages inbox (Handover §11) — master-detail when connected.
+/// WhatsApp Messages inbox — reads Ditto `whatsapp_messages` directly.
 class FloInboxView extends ConsumerStatefulWidget {
   const FloInboxView({
     super.key,
@@ -30,10 +35,11 @@ class FloInboxView extends ConsumerStatefulWidget {
 }
 
 class _FloInboxViewState extends ConsumerState<FloInboxView> {
-  String? _selectedConversationId;
-  FloWhatsAppDraft? _draft;
+  String? _selectedWaId;
+  String? _draftText;
   final _replyController = TextEditingController();
   bool _draftLoading = false;
+  bool _sending = false;
 
   @override
   void dispose() {
@@ -47,127 +53,176 @@ class _FloInboxViewState extends ConsumerState<FloInboxView> {
       return _LockedState(onConnect: widget.onConnect);
     }
 
-    final conversations = ref.watch(conversationProvider).value ?? [];
-    final waConversations = conversations
-        .where((c) => c.useCase == 'business')
-        .toList();
-
+    final threadsAsync = ref.watch(whatsappDittoThreadsProvider);
     final isMobile =
         MediaQuery.sizeOf(context).width < FloTheme.mobileBreakpoint;
 
-    if (isMobile && _selectedConversationId != null) {
-      return _ThreadPane(
-        conversationId: _selectedConversationId!,
-        draft: _draft,
-        draftLoading: _draftLoading,
-        replyController: _replyController,
-        onBack: () => setState(() => _selectedConversationId = null),
-        onSend: _sendReply,
-        onDraft: () => _loadDraft(_selectedConversationId!),
-        chatService: widget.chatService,
-      );
-    }
-
-    return Row(
-      children: [
-        SizedBox(
-          width: isMobile ? double.infinity : 326,
-          child: _ListPane(
-            conversations: waConversations,
-            selectedId: _selectedConversationId,
-            onSelect: (id) {
-              setState(() {
-                _selectedConversationId = id;
-                _draft = null;
-              });
-              _loadDraft(id);
-            },
+    return threadsAsync.when(
+      loading: () => const Center(
+        child: CircularProgressIndicator(
+          valueColor: AlwaysStoppedAnimation(FloTheme.blue),
+        ),
+      ),
+      error: (e, _) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.error_outline, color: FloTheme.loss, size: 32),
+              const SizedBox(height: 12),
+              Text(
+                'Could not read Ditto whatsapp_messages\n$e',
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: FloTheme.ink2, fontSize: 13),
+              ),
+              const SizedBox(height: 12),
+              TextButton(
+                onPressed: () => ref.invalidate(whatsappDittoThreadsProvider),
+                child: const Text('Retry'),
+              ),
+            ],
           ),
         ),
-        if (!isMobile)
-          Expanded(
-            child: _selectedConversationId == null
-                ? const Center(
-                    child: Text(
-                      'Select a conversation',
-                      style: TextStyle(color: FloTheme.ink3),
-                    ),
-                  )
-                : _ThreadPane(
-                    conversationId: _selectedConversationId!,
-                    draft: _draft,
-                    draftLoading: _draftLoading,
-                    replyController: _replyController,
-                    onBack: null,
-                    onSend: _sendReply,
-                    onDraft: () => _loadDraft(_selectedConversationId!),
-                    chatService: widget.chatService,
-                  ),
-          ),
-      ],
+      ),
+      data: (threads) {
+        final selected = _selectedWaId == null
+            ? null
+            : threads.cast<WhatsAppDittoThread?>().firstWhere(
+                  (t) => t?.waId == _selectedWaId,
+                  orElse: () => null,
+                );
+
+        if (isMobile && selected != null) {
+          return _ThreadPane(
+            thread: selected,
+            draftText: _draftText,
+            draftLoading: _draftLoading,
+            sending: _sending,
+            replyController: _replyController,
+            onBack: () => setState(() => _selectedWaId = null),
+            onSend: () => _sendReply(selected),
+            onDraft: () => _loadDraft(selected),
+          );
+        }
+
+        return Row(
+          children: [
+            SizedBox(
+              width: isMobile ? double.infinity : 340,
+              child: _ListPane(
+                threads: threads,
+                selectedWaId: _selectedWaId,
+                onSelect: (waId) {
+                  setState(() {
+                    _selectedWaId = waId;
+                    _draftText = null;
+                  });
+                  final t = threads.cast<WhatsAppDittoThread?>().firstWhere(
+                        (x) => x?.waId == waId,
+                        orElse: () => null,
+                      );
+                  if (t != null) _loadDraft(t);
+                },
+              ),
+            ),
+            if (!isMobile) ...[
+              const VerticalDivider(width: 1, color: FloTheme.line),
+              Expanded(
+                child: selected == null
+                    ? const _EmptyThreadHint()
+                    : _ThreadPane(
+                        thread: selected,
+                        draftText: _draftText,
+                        draftLoading: _draftLoading,
+                        sending: _sending,
+                        replyController: _replyController,
+                        onBack: null,
+                        onSend: () => _sendReply(selected),
+                        onDraft: () => _loadDraft(selected),
+                      ),
+              ),
+            ],
+          ],
+        );
+      },
     );
   }
 
-  Future<void> _loadDraft(String conversationId) async {
+  Future<void> _loadDraft(WhatsAppDittoThread thread) async {
     setState(() => _draftLoading = true);
     try {
       final branchId = ProxyService.box.getBranchId();
       if (branchId == null) return;
-      final repo = Repository();
-      final msgs = await repo.get<Message>(
-        query: Query(
-          where: [Where('conversationId').isExactly(conversationId)],
-          orderBy: [OrderBy('timestamp', ascending: false)],
-          limit: 5,
-        ),
-      );
-      final inbound = msgs.cast<Message?>().firstWhere(
-            (m) => m?.messageSource == 'whatsapp' && m?.role == 'user',
+      final inbound = thread.messages.reversed.cast<WhatsAppDittoMessage?>().firstWhere(
+            (m) => m != null && !m.outbound,
             orElse: () => null,
           );
       if (inbound == null) return;
       final draft = await widget.chatService.requestDraft(
         branchId: branchId,
-        customerMessage: inbound.text,
+        customerMessage: inbound.body,
       );
-      if (mounted) setState(() => _draft = draft);
+      if (mounted) {
+        setState(() => _draftText = draft.draft);
+        _replyController.text = draft.draft;
+      }
     } catch (_) {
     } finally {
       if (mounted) setState(() => _draftLoading = false);
     }
   }
 
-  Future<void> _sendReply() async {
+  Future<void> _sendReply(WhatsAppDittoThread thread) async {
     final text = _replyController.text.trim();
-    if (text.isEmpty || _selectedConversationId == null) return;
-    final branchId = ProxyService.box.getBranchId();
+    if (text.isEmpty || _sending) return;
     final businessId = ProxyService.box.getBusinessId();
-    if (branchId == null || businessId == null) return;
+    if (businessId == null) return;
 
-    await ProxyService.strategy.saveMessage(
-      text: text,
-      phoneNumber: ProxyService.box.getUserPhone() ?? '',
-      branchId: branchId,
-      role: 'user',
-      conversationId: _selectedConversationId!,
-      messageSource: 'whatsapp',
-    );
-
+    setState(() => _sending = true);
     try {
-      final business =
-          await ProxyService.strategy.getBusiness(businessId: businessId);
-      final phoneNumberId = business?.getWhatsAppPhoneNumberId();
-      if (phoneNumberId != null) {
-        await WhatsAppService().sendWhatsAppMessage(
-          phoneNumberId: phoneNumberId,
-          recipientPhone: ProxyService.box.getUserPhone() ?? '',
-          messageBody: text,
+      final phoneNumberId = await resolveWhatsAppPhoneNumberId();
+      if (phoneNumberId == null) return;
+
+      final sendResult = await WhatsAppService().sendWhatsAppMessage(
+        phoneNumberId: phoneNumberId,
+        recipientPhone: thread.waId,
+        messageBody: text,
+      );
+      final metaMessageId = () {
+        final messages = sendResult['messages'];
+        if (messages is List && messages.isNotEmpty) {
+          final first = messages.first;
+          if (first is Map && first['id'] != null) {
+            return first['id'].toString();
+          }
+        }
+        return null;
+      }();
+
+      // Persist with Meta wamid so inbound reactions attach to this bubble.
+      await ref.read(whatsappDittoInboxProvider).appendOutbound(
+            phoneNumberId: phoneNumberId,
+            waId: thread.waId,
+            body: text,
+            contactName: thread.displayName,
+            messageId: metaMessageId,
+          );
+
+      _replyController.clear();
+      setState(() => _draftText = null);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Send failed: $e'),
+            backgroundColor: FloTheme.loss,
+          ),
         );
       }
-    } catch (_) {}
-
-    _replyController.clear();
-    setState(() => _draft = null);
+    } finally {
+      if (mounted) setState(() => _sending = false);
+    }
   }
 }
 
@@ -183,7 +238,16 @@ class _LockedState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.chat, size: 48, color: FloTheme.wa.withValues(alpha: 0.8)),
+            Container(
+              width: 56,
+              height: 56,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: FloTheme.blueTint,
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: FloIcons.whatsApp(size: 28, color: FloTheme.blueDeep),
+            ),
             const SizedBox(height: 16),
             const Text(
               'Answer customers on WhatsApp',
@@ -200,10 +264,38 @@ class _LockedState extends StatelessWidget {
               style: TextStyle(color: FloTheme.ink2),
             ),
             const SizedBox(height: 20),
-            FilledButton(
-              onPressed: onConnect,
-              style: FilledButton.styleFrom(backgroundColor: FloTheme.wa),
-              child: const Text('Connect WhatsApp'),
+            SizedBox(
+              height: 44,
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  onTap: onConnect,
+                  borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+                  child: Ink(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    decoration: BoxDecoration(
+                      gradient: FloTheme.gradBtn,
+                      borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+                      boxShadow: const [FloTheme.shBlue],
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        FloIcons.link(size: 16, color: Colors.white),
+                        const SizedBox(width: 8),
+                        const Text(
+                          'Connect WhatsApp',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
             ),
           ],
         ),
@@ -212,178 +304,977 @@ class _LockedState extends StatelessWidget {
   }
 }
 
-class _ListPane extends StatelessWidget {
-  const _ListPane({
-    required this.conversations,
-    required this.selectedId,
-    required this.onSelect,
-  });
-
-  final List<Conversation> conversations;
-  final String? selectedId;
-  final ValueChanged<String> onSelect;
+class _EmptyThreadHint extends StatelessWidget {
+  const _EmptyThreadHint();
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Padding(
-          padding: EdgeInsets.all(16),
-          child: Text(
-            'Customers · via WhatsApp',
-            style: TextStyle(fontWeight: FontWeight.w700, color: FloTheme.ink1),
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 52,
+            height: 52,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: FloTheme.surface2,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: FloTheme.line),
+            ),
+            child: FloIcons.whatsApp(size: 24, color: FloTheme.ink3),
           ),
-        ),
-        Expanded(
-          child: ListView.builder(
-            itemCount: conversations.length,
-            itemBuilder: (context, i) {
-              final c = conversations[i];
-              final selected = c.id == selectedId;
-              return ListTile(
-                selected: selected,
-                title: Text(c.title ?? 'Customer'),
-                subtitle: Text(c.useCase ?? ''),
-                onTap: () => onSelect(c.id),
-              );
-            },
+          const SizedBox(height: 14),
+          const Text(
+            'Select a customer',
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: FloTheme.ink1,
+            ),
           ),
-        ),
-      ],
+          const SizedBox(height: 6),
+          const Text(
+            'WhatsApp inbox · data-connector + Ditto',
+            style: TextStyle(fontSize: 13, color: FloTheme.ink3),
+          ),
+        ],
+      ),
     );
   }
 }
 
-class _ThreadPane extends StatelessWidget {
-  const _ThreadPane({
-    required this.conversationId,
-    required this.draft,
-    required this.draftLoading,
-    required this.replyController,
-    this.onBack,
-    required this.onSend,
-    required this.onDraft,
-    required this.chatService,
+class _ListPane extends StatelessWidget {
+  const _ListPane({
+    required this.threads,
+    required this.selectedWaId,
+    required this.onSelect,
   });
 
-  final String conversationId;
-  final FloWhatsAppDraft? draft;
-  final bool draftLoading;
-  final TextEditingController replyController;
-  final VoidCallback? onBack;
-  final VoidCallback onSend;
-  final VoidCallback onDraft;
-  final FloChatService chatService;
+  final List<WhatsAppDittoThread> threads;
+  final String? selectedWaId;
+  final ValueChanged<String> onSelect;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        if (onBack != null)
-          ListTile(
-            leading: IconButton(
-              icon: const Icon(Icons.arrow_back),
-              onPressed: onBack,
-            ),
-            title: const Text('WhatsApp thread'),
-          ),
-        Expanded(
-          child: StreamBuilder<List<Message>>(
-            stream: ProxyService.strategy.subscribeToMessages(conversationId),
-            builder: (context, snap) {
-              final msgs = snap.data ?? [];
-              return ListView.builder(
-                padding: const EdgeInsets.all(16),
-                itemCount: msgs.length,
-                itemBuilder: (context, i) {
-                  final m = msgs[i];
-                  final outbound = m.role == 'user';
-                  return Align(
-                    alignment:
-                        outbound ? Alignment.centerRight : Alignment.centerLeft,
-                    child: Container(
-                      margin: const EdgeInsets.only(bottom: 8),
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: outbound ? FloTheme.waTint : FloTheme.surface,
-                        borderRadius: BorderRadius.circular(16),
-                        border: Border.all(color: FloTheme.line),
-                      ),
-                      child: Text(m.text),
-                    ),
-                  );
-                },
-              );
-            },
-          ),
-        ),
-        if (draft != null)
-          Container(
-            margin: const EdgeInsets.all(12),
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: FloTheme.blueTint,
-              borderRadius: BorderRadius.circular(FloTheme.radiusMd),
-              border: Border.all(color: FloTheme.line),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+    return ColoredBox(
+      color: FloTheme.surface,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+            child: Row(
               children: [
-                const Row(
-                  children: [
-                    FloMark(size: 20),
-                    SizedBox(width: 8),
-                    Text(
-                      'Flo suggested reply',
-                      style: TextStyle(fontWeight: FontWeight.w700),
+                FloIcons.whatsApp(size: 16, color: FloTheme.blueDeep),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    'Customers · WhatsApp',
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: -0.01,
+                      color: FloTheme.ink1,
                     ),
-                  ],
+                  ),
                 ),
-                const SizedBox(height: 8),
-                Text(draft!.src, style: const TextStyle(fontSize: 11, color: FloTheme.ink3)),
-                const SizedBox(height: 6),
-                Text(draft!.draft),
-                Row(
-                  children: [
-                    TextButton(
-                      onPressed: () {
-                        replyController.text = draft!.draft;
-                        onSend();
-                      },
-                      child: const Text('Send reply'),
-                    ),
-                    TextButton(
-                      onPressed: () => replyController.text = draft!.draft,
-                      child: const Text('Edit first'),
-                    ),
-                  ],
+                Text(
+                  '${threads.length}',
+                  style: FloTheme.mono(12).copyWith(color: FloTheme.ink3),
                 ),
               ],
             ),
           ),
-        Padding(
-          padding: const EdgeInsets.all(12),
-          child: Row(
-            children: [
-              TextButton(onPressed: draftLoading ? null : onDraft, child: const Text('Draft')),
-              Expanded(
-                child: TextField(
-                  controller: replyController,
-                  decoration: const InputDecoration(
-                    hintText: 'Reply on WhatsApp…',
-                    border: OutlineInputBorder(),
+          const Divider(height: 1, color: FloTheme.line),
+          Expanded(
+            child: threads.isEmpty
+                ? const _EmptyCustomerList()
+                : ListView.separated(
+                    itemCount: threads.length,
+                    separatorBuilder: (_, __) =>
+                        const Divider(height: 1, color: FloTheme.lineSoft),
+                    itemBuilder: (context, i) {
+                      final t = threads[i];
+                      final selected = t.waId == selectedWaId;
+                      return Material(
+                        color: selected ? FloTheme.blueTint : FloTheme.surface,
+                        child: InkWell(
+                          onTap: () => onSelect(t.waId),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 14,
+                              vertical: 12,
+                            ),
+                            child: Row(
+                              children: [
+                                _Avatar(label: t.displayName),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        t.displayName,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: const TextStyle(
+                                          fontSize: 14,
+                                          fontWeight: FontWeight.w600,
+                                          color: FloTheme.ink1,
+                                        ),
+                                      ),
+                                      const SizedBox(height: 2),
+                                      Text(
+                                        t.lastPreview ?? t.waId,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: const TextStyle(
+                                          fontSize: 12,
+                                          color: FloTheme.ink3,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Text(
+                                  _relativeTime(t.lastMessageAt),
+                                  style: const TextStyle(
+                                    fontSize: 11,
+                                    color: FloTheme.ink4,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _relativeTime(DateTime at) {
+    final local = at.toLocal();
+    final now = DateTime.now();
+    final diff = now.difference(local);
+    if (diff.inMinutes < 1) return 'now';
+    if (diff.inHours < 1) return '${diff.inMinutes}m';
+    if (diff.inDays < 1) {
+      final h = local.hour.toString().padLeft(2, '0');
+      final m = local.minute.toString().padLeft(2, '0');
+      return '$h:$m';
+    }
+    if (diff.inDays < 7) return '${diff.inDays}d';
+    return '${local.day}/${local.month}';
+  }
+}
+
+class _EmptyCustomerList extends StatelessWidget {
+  const _EmptyCustomerList();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.chat_bubble_outline_rounded,
+                size: 36, color: FloTheme.ink4),
+            SizedBox(height: 12),
+            Text(
+              'No WhatsApp messages yet',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: FloTheme.ink1,
+              ),
+            ),
+            SizedBox(height: 6),
+            Text(
+              'Inbound messages load from data-connector (local Ditto is a backup). When Meta posts to the webhook they appear here within a few seconds.',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 12.5, height: 1.4, color: FloTheme.ink3),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final initial = label.isNotEmpty ? label[0].toUpperCase() : '?';
+    return Container(
+      width: 40,
+      height: 40,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: FloTheme.blueTint,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FloTheme.blueTint2),
+      ),
+      child: Text(
+        initial,
+        style: const TextStyle(
+          fontSize: 15,
+          fontWeight: FontWeight.w700,
+          color: FloTheme.blueDeep,
+        ),
+      ),
+    );
+  }
+}
+
+class _ThreadPane extends StatefulWidget {
+  const _ThreadPane({
+    required this.thread,
+    required this.draftText,
+    required this.draftLoading,
+    required this.sending,
+    required this.replyController,
+    this.onBack,
+    required this.onSend,
+    required this.onDraft,
+  });
+
+  final WhatsAppDittoThread thread;
+  final String? draftText;
+  final bool draftLoading;
+  final bool sending;
+  final TextEditingController replyController;
+  final VoidCallback? onBack;
+  final VoidCallback onSend;
+  final VoidCallback onDraft;
+
+  @override
+  State<_ThreadPane> createState() => _ThreadPaneState();
+}
+
+class _ThreadPaneState extends State<_ThreadPane> {
+  final _scroll = ScrollController();
+  String? _trackedWaId;
+  String? _lastMessageId;
+  int _lastMessageCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _trackedWaId = widget.thread.waId;
+    _syncMessageCursor(forceScroll: true);
+  }
+
+  @override
+  void didUpdateWidget(covariant _ThreadPane oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.thread.waId != _trackedWaId) {
+      _trackedWaId = widget.thread.waId;
+      _lastMessageId = null;
+      _lastMessageCount = 0;
+      _syncMessageCursor(forceScroll: true);
+      return;
+    }
+    _syncMessageCursor(forceScroll: false);
+  }
+
+  void _syncMessageCursor({required bool forceScroll}) {
+    final msgs = widget.thread.messages;
+    final lastId = msgs.isEmpty ? null : msgs.last.id;
+    final grew =
+        msgs.length > _lastMessageCount || lastId != _lastMessageId;
+    _lastMessageCount = msgs.length;
+    _lastMessageId = lastId;
+    if (forceScroll || grew) {
+      _scrollToLatest(animate: !forceScroll);
+    }
+  }
+
+  void _scrollToLatest({required bool animate}) {
+    void jump() {
+      if (!mounted || !_scroll.hasClients) return;
+      final max = _scroll.position.maxScrollExtent;
+      if (animate) {
+        _scroll.animateTo(
+          max,
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOut,
+        );
+      } else {
+        _scroll.jumpTo(max);
+      }
+    }
+
+    // Layout may need two frames after the list grows.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      jump();
+      WidgetsBinding.instance.addPostFrameCallback((_) => jump());
+    });
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final thread = widget.thread;
+    return ColoredBox(
+      color: FloTheme.chatBg,
+      child: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: const BoxDecoration(
+              color: FloTheme.surface,
+              border: Border(bottom: BorderSide(color: FloTheme.line)),
+            ),
+            child: Row(
+              children: [
+                if (widget.onBack != null)
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back_rounded, size: 20),
+                    onPressed: widget.onBack,
+                    color: FloTheme.ink2,
+                  ),
+                _Avatar(label: thread.displayName),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        thread.displayName,
+                        style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w700,
+                          color: FloTheme.ink1,
+                        ),
+                      ),
+                      Text(
+                        thread.waId,
+                        style:
+                            FloTheme.mono(11.5).copyWith(color: FloTheme.ink3),
+                      ),
+                    ],
                   ),
                 ),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: FloTheme.blueTint,
+                    borderRadius: BorderRadius.circular(FloTheme.radiusPill),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      FloIcons.whatsApp(size: 12, color: FloTheme.blueDeep),
+                      const SizedBox(width: 4),
+                      Text(
+                        '${thread.messages.length}',
+                        style: FloTheme.mono(11).copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: FloTheme.blueDeep,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: thread.messages.isEmpty
+                ? const Center(
+                    child: Text(
+                      'No messages in this thread yet',
+                      style: TextStyle(color: FloTheme.ink3),
+                    ),
+                  )
+                : ListView.builder(
+                    controller: _scroll,
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                    itemCount: thread.messages.length,
+                    itemBuilder: (context, i) {
+                      final m = thread.messages[i];
+                      return _Bubble(message: m);
+                    },
+                  ),
+          ),
+          if (widget.draftText != null && widget.draftText!.isNotEmpty)
+            _DraftCard(
+              draft: widget.draftText!,
+              replyController: widget.replyController,
+              onSend: widget.onSend,
+            ),
+          _ComposerBar(
+            replyController: widget.replyController,
+            draftLoading: widget.draftLoading,
+            sending: widget.sending,
+            onDraft: widget.onDraft,
+            onSend: widget.onSend,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Bubble extends StatelessWidget {
+  const _Bubble({required this.message});
+  final WhatsAppDittoMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    final fromUs = message.outbound;
+    final reactions = message.reactions;
+    final onBlue = fromUs;
+    return Align(
+      alignment: fromUs ? Alignment.centerRight : Alignment.centerLeft,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.sizeOf(context).width * 0.72,
+        ),
+        child: Padding(
+          padding: EdgeInsets.only(bottom: reactions.isEmpty ? 10 : 4),
+          child: Column(
+            crossAxisAlignment:
+                fromUs ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                decoration: BoxDecoration(
+                  color: fromUs ? FloTheme.blue : FloTheme.surface,
+                  borderRadius: BorderRadius.only(
+                    topLeft: const Radius.circular(16),
+                    topRight: const Radius.circular(16),
+                    bottomLeft: Radius.circular(fromUs ? 16 : 4),
+                    bottomRight: Radius.circular(fromUs ? 4 : 16),
+                  ),
+                  border: fromUs ? null : Border.all(color: FloTheme.line),
+                  boxShadow: const [FloTheme.sh1],
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (message.isDocument) ...[
+                      _PdfAttachment(message: message, onBlue: onBlue),
+                      if (_captionForDocument(message) != null) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          _captionForDocument(message)!,
+                          style: TextStyle(
+                            fontSize: 14,
+                            height: 1.4,
+                            color: onBlue ? Colors.white : FloTheme.ink1,
+                          ),
+                        ),
+                      ],
+                    ] else
+                      Text(
+                        message.body,
+                        style: TextStyle(
+                          fontSize: 14,
+                          height: 1.4,
+                          color: onBlue ? Colors.white : FloTheme.ink1,
+                        ),
+                      ),
+                    const SizedBox(height: 4),
+                    Text(
+                      _formatTime(message.timestamp),
+                      style: TextStyle(
+                        fontSize: 10.5,
+                        color: onBlue
+                            ? Colors.white.withValues(alpha: 0.75)
+                            : FloTheme.ink4,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-              IconButton(
-                onPressed: onSend,
-                icon: const Icon(Icons.send, color: FloTheme.wa),
-              ),
+              if (reactions.isNotEmpty)
+                Transform.translate(
+                  offset: const Offset(0, -6),
+                  child: _ReactionChips(
+                    reactions: reactions,
+                    alignEnd: fromUs,
+                  ),
+                ),
             ],
           ),
         ),
-      ],
+      ),
+    );
+  }
+
+  static String? _captionForDocument(WhatsAppDittoMessage m) {
+    final body = m.body.trim();
+    if (body.isEmpty) return null;
+    final name = m.displayFilename;
+    if (body == name || body == '[${m.messageType}]') return null;
+    if (body.toLowerCase() == 'document') return null;
+    return body;
+  }
+
+  static String _formatTime(DateTime t) {
+    final local = t.toLocal();
+    final h = local.hour.toString().padLeft(2, '0');
+    final m = local.minute.toString().padLeft(2, '0');
+    return '$h:$m';
+  }
+}
+
+class _PdfAttachment extends StatefulWidget {
+  const _PdfAttachment({
+    required this.message,
+    required this.onBlue,
+  });
+
+  final WhatsAppDittoMessage message;
+  final bool onBlue;
+
+  @override
+  State<_PdfAttachment> createState() => _PdfAttachmentState();
+}
+
+class _PdfAttachmentState extends State<_PdfAttachment> {
+  bool _busy = false;
+
+  Future<void> _download() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      final bytes = await _loadPdfBytes(widget.message);
+      if (!mounted) return;
+      if (bytes == null || bytes.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Could not download this PDF'),
+            backgroundColor: FloTheme.loss,
+          ),
+        );
+        return;
+      }
+
+      final fileName = widget.message.displayFilename.endsWith('.pdf')
+          ? widget.message.displayFilename
+          : '${widget.message.displayFilename}.pdf';
+
+      final savedPath = await FilePicker.platform.saveFile(
+        dialogTitle: 'Save PDF',
+        fileName: fileName,
+        type: FileType.custom,
+        allowedExtensions: const ['pdf'],
+        bytes: bytes,
+      );
+      if (!mounted) return;
+      if (savedPath == null) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Saved $fileName'),
+          backgroundColor: FloTheme.blueDeep,
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Download failed: $e'),
+          backgroundColor: FloTheme.loss,
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final onBlue = widget.onBlue;
+    final name = widget.message.displayFilename;
+    final canDownload = widget.message.hasDownloadableMedia;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: canDownload && !_busy ? _download : null,
+        borderRadius: BorderRadius.circular(10),
+        child: Ink(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+          decoration: BoxDecoration(
+            color: onBlue
+                ? Colors.white.withValues(alpha: 0.14)
+                : FloTheme.blueTint,
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: onBlue
+                  ? Colors.white.withValues(alpha: 0.22)
+                  : FloTheme.line,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: onBlue
+                      ? Colors.white.withValues(alpha: 0.18)
+                      : FloTheme.surface,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  Icons.picture_as_pdf_rounded,
+                  size: 22,
+                  color: onBlue ? Colors.white : FloTheme.loss,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Flexible(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      name,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 13.5,
+                        fontWeight: FontWeight.w700,
+                        color: onBlue ? Colors.white : FloTheme.ink1,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'PDF document',
+                      style: TextStyle(
+                        fontSize: 11.5,
+                        color: onBlue
+                            ? Colors.white.withValues(alpha: 0.75)
+                            : FloTheme.ink3,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              if (_busy)
+                SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: onBlue ? Colors.white : FloTheme.blue,
+                  ),
+                )
+              else
+                Icon(
+                  Icons.download_rounded,
+                  size: 20,
+                  color: onBlue
+                      ? Colors.white.withValues(alpha: 0.9)
+                      : FloTheme.blueDeep,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<Uint8List?> _loadPdfBytes(WhatsAppDittoMessage message) async {
+  final embedded = message.mediaBase64?.trim();
+  if (embedded != null && embedded.isNotEmpty) {
+    try {
+      return Uint8List.fromList(base64Decode(embedded));
+    } catch (_) {}
+  }
+
+  final direct = message.mediaUrl?.trim();
+  if (direct != null && direct.isNotEmpty) {
+    final response =
+        await http.get(Uri.parse(direct)).timeout(const Duration(seconds: 45));
+    if (response.statusCode >= 200 && response.statusCode < 400) {
+      return response.bodyBytes;
+    }
+  }
+
+  for (final base in await _mediaCandidateBases()) {
+    final uri = Uri.parse('${base}api/whatsapp/inbound-media').replace(
+      queryParameters: {
+        if (message.id.isNotEmpty) 'message_id': message.id,
+        if ((message.mediaId ?? '').isNotEmpty) 'media_id': message.mediaId!,
+      },
+    );
+    try {
+      final response =
+          await http.get(uri).timeout(const Duration(seconds: 45));
+      if (response.statusCode == 200 && response.bodyBytes.isNotEmpty) {
+        return response.bodyBytes;
+      }
+    } catch (_) {}
+  }
+  return null;
+}
+
+Future<List<String>> _mediaCandidateBases() async {
+  String normalize(String url) {
+    var u = url.trim();
+    if (!u.endsWith('/')) u = '$u/';
+    return u.replaceFirst('://localhost:', '://127.0.0.1:');
+  }
+
+  final out = <String>[];
+  void add(String? raw) {
+    if (raw == null || raw.trim().isEmpty) return;
+    final n = normalize(raw);
+    if (!out.contains(n)) out.add(n);
+  }
+
+  add(await resolveEbmDataConnectorUrl());
+  if (kDebugMode) add('http://127.0.0.1:8084/');
+  add('https://data-connector.yegobox.com/');
+  return out;
+}
+
+class _ReactionChips extends StatelessWidget {
+  const _ReactionChips({
+    required this.reactions,
+    required this.alignEnd,
+  });
+
+  final List<WhatsAppReaction> reactions;
+  final bool alignEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    // Collapse duplicate emojis with counts (WhatsApp-style).
+    final counts = <String, int>{};
+    for (final r in reactions) {
+      counts.update(r.emoji, (v) => v + 1, ifAbsent: () => 1);
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Wrap(
+        alignment: alignEnd ? WrapAlignment.end : WrapAlignment.start,
+        spacing: 4,
+        runSpacing: 4,
+        children: [
+          for (final e in counts.entries)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+              decoration: BoxDecoration(
+                color: FloTheme.surface,
+                borderRadius: BorderRadius.circular(FloTheme.radiusPill),
+                border: Border.all(color: FloTheme.line),
+                boxShadow: const [FloTheme.sh1],
+              ),
+              child: Text(
+                e.value > 1 ? '${e.key} ${e.value}' : e.key,
+                style: const TextStyle(fontSize: 13, height: 1.1),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DraftCard extends StatelessWidget {
+  const _DraftCard({
+    required this.draft,
+    required this.replyController,
+    required this.onSend,
+  });
+
+  final String draft;
+  final TextEditingController replyController;
+  final VoidCallback onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: FloTheme.surface,
+        borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+        border: Border.all(color: FloTheme.blueTint2),
+        boxShadow: const [FloTheme.sh1],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Row(
+            children: [
+              FloMark(size: 18),
+              SizedBox(width: 8),
+              Text(
+                'Flo suggested reply',
+                style: TextStyle(
+                  fontWeight: FontWeight.w700,
+                  fontSize: 13,
+                  color: FloTheme.ink1,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            draft,
+            style: const TextStyle(
+              fontSize: 13.5,
+              height: 1.4,
+              color: FloTheme.ink2,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              TextButton(
+                onPressed: () {
+                  replyController.text = draft;
+                  onSend();
+                },
+                child: const Text('Send'),
+              ),
+              TextButton(
+                onPressed: () => replyController.text = draft,
+                child: const Text('Edit first'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ComposerBar extends StatelessWidget {
+  const _ComposerBar({
+    required this.replyController,
+    required this.draftLoading,
+    required this.sending,
+    required this.onDraft,
+    required this.onSend,
+  });
+
+  final TextEditingController replyController;
+  final bool draftLoading;
+  final bool sending;
+  final VoidCallback onDraft;
+  final VoidCallback onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 14),
+      decoration: const BoxDecoration(
+        color: FloTheme.surface,
+        border: Border(top: BorderSide(color: FloTheme.line)),
+      ),
+      child: Row(
+        children: [
+          TextButton(
+            onPressed: draftLoading ? null : onDraft,
+            style: TextButton.styleFrom(
+              foregroundColor: FloTheme.blueDeep,
+              padding: const EdgeInsets.symmetric(horizontal: 10),
+            ),
+            child: draftLoading
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Draft'),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: TextField(
+              controller: replyController,
+              minLines: 1,
+              maxLines: 4,
+              enabled: !sending,
+              decoration: InputDecoration(
+                hintText: 'Reply on WhatsApp…',
+                hintStyle: const TextStyle(color: FloTheme.ink4),
+                filled: true,
+                fillColor: FloTheme.surface2,
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 12,
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+                  borderSide: const BorderSide(color: FloTheme.line),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+                  borderSide: const BorderSide(color: FloTheme.line),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+                  borderSide:
+                      const BorderSide(color: FloTheme.blue, width: 1.5),
+                ),
+              ),
+              onSubmitted: (_) => onSend(),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: sending ? null : onSend,
+              borderRadius: BorderRadius.circular(12),
+              child: Ink(
+                width: 42,
+                height: 42,
+                decoration: BoxDecoration(
+                  gradient: FloTheme.gradBtn,
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: const [FloTheme.shBlue],
+                ),
+                child: Center(
+                  child: sending
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor:
+                                AlwaysStoppedAnimation<Color>(Colors.white),
+                          ),
+                        )
+                      : FloIcons.send(size: 18, color: Colors.white),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/flipper_ai_feature/lib/src/widgets/whatsapp_connection_dialog.dart
+++ b/packages/flipper_ai_feature/lib/src/widgets/whatsapp_connection_dialog.dart
@@ -3,9 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/whatsapp_connection_provider.dart';
 import '../services/whatsapp_connection_service.dart';
-import '../theme/ai_theme.dart';
+import '../theme/flo_theme.dart';
+import 'flo/flo_icons.dart';
 
-/// Dialog for connecting/disconnecting WhatsApp account
+/// Dialog for connecting/disconnecting WhatsApp account (Flo design language).
 class WhatsAppConnectionDialog extends ConsumerStatefulWidget {
   final VoidCallback? onConnectionChanged;
 
@@ -18,90 +19,66 @@ class WhatsAppConnectionDialog extends ConsumerStatefulWidget {
 }
 
 class _WhatsAppConnectionDialogState
-    extends ConsumerState<WhatsAppConnectionDialog>
-    with SingleTickerProviderStateMixin {
+    extends ConsumerState<WhatsAppConnectionDialog> {
   final TextEditingController _phoneNumberIdController =
       TextEditingController();
-  late AnimationController _pulseController;
-  late Animation<double> _pulseAnimation;
-
-  @override
-  void initState() {
-    super.initState();
-    _pulseController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 1500),
-    )..repeat(reverse: true);
-    _pulseAnimation = Tween<double>(begin: 0.4, end: 1.0).animate(
-      CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
-    );
-  }
 
   @override
   void dispose() {
     _phoneNumberIdController.dispose();
-    _pulseController.dispose();
     super.dispose();
   }
 
   Future<void> _handleConnect() async {
     final phoneNumberId = _phoneNumberIdController.text.trim();
 
-    // Validate phone number ID is non-empty and matches expected format
     if (phoneNumberId.isEmpty) {
       if (mounted) {
         showCustomSnackBarUtil(
           context,
           'Phone Number ID cannot be empty',
-          backgroundColor: Colors.red,
+          backgroundColor: FloTheme.loss,
         );
       }
       return;
     }
 
-    // Check that phone number ID contains only digits and has expected length
     if (!RegExp(r'^\d{5,15}$').hasMatch(phoneNumberId)) {
       if (mounted) {
         showCustomSnackBarUtil(
           context,
           'Phone Number ID must contain only digits and be 5-15 characters long',
-          backgroundColor: Colors.red,
+          backgroundColor: FloTheme.loss,
         );
       }
       return;
     }
 
     final notifier = ref.read(whatsAppConnectionStateProvider.notifier);
-
     final success = await notifier.connect(phoneNumberId);
 
     if (success && mounted) {
       widget.onConnectionChanged?.call();
-
       showCustomSnackBarUtil(
         context,
         'WhatsApp account connected successfully',
-        backgroundColor: AiTheme.whatsAppGreen,
+        backgroundColor: FloTheme.blue,
       );
-
       Navigator.of(context).pop();
     }
   }
 
   Future<void> _handleDisconnect() async {
     final notifier = ref.read(whatsAppConnectionStateProvider.notifier);
-
     final success = await notifier.disconnect();
 
     if (success && mounted) {
       widget.onConnectionChanged?.call();
-
       showCustomSnackBarUtil(
         context,
         'WhatsApp account disconnected successfully',
-        backgroundColor: AiTheme.whatsAppGreen,
+        backgroundColor: FloTheme.blue,
       );
-
       Navigator.of(context).pop();
     }
   }
@@ -110,7 +87,6 @@ class _WhatsAppConnectionDialogState
   Widget build(BuildContext context) {
     final connectionState = ref.watch(whatsAppConnectionStateProvider);
 
-    // Listen to provider changes to update controller text when needed
     ref.listen<AsyncValue<WhatsAppConnectionState>>(
       whatsAppConnectionStateProvider,
       (previous, next) {
@@ -131,19 +107,25 @@ class _WhatsAppConnectionDialogState
     );
 
     return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-      elevation: 8,
-      shadowColor: AiTheme.whatsAppGreen.withValues(alpha: 0.15),
+      backgroundColor: FloTheme.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(FloTheme.radiusLg),
+      ),
+      elevation: 0,
       child: Container(
         constraints: const BoxConstraints(maxWidth: 420),
+        decoration: BoxDecoration(
+          color: FloTheme.surface,
+          borderRadius: BorderRadius.circular(FloTheme.radiusLg),
+          border: Border.all(color: FloTheme.line),
+          boxShadow: const [FloTheme.sh3],
+        ),
         child: connectionState.when(
           loading: () => const Padding(
             padding: EdgeInsets.all(48),
             child: Center(
               child: CircularProgressIndicator(
-                valueColor: AlwaysStoppedAnimation<Color>(
-                  AiTheme.whatsAppGreen,
-                ),
+                valueColor: AlwaysStoppedAnimation<Color>(FloTheme.blue),
               ),
             ),
           ),
@@ -170,52 +152,23 @@ class _WhatsAppConnectionDialogState
 
   Widget _buildHeader(bool isConnected) {
     return Container(
-      padding: const EdgeInsets.fromLTRB(24, 20, 16, 16),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [
-            AiTheme.whatsAppGreen.withValues(alpha: 0.08),
-            AiTheme.whatsAppDarkGreen.withValues(alpha: 0.04),
-          ],
-        ),
-        borderRadius: const BorderRadius.only(
-          topLeft: Radius.circular(20),
-          topRight: Radius.circular(20),
-        ),
-        border: Border(
-          bottom: BorderSide(
-            color: AiTheme.whatsAppGreen.withValues(alpha: 0.15),
-          ),
-        ),
+      padding: const EdgeInsets.fromLTRB(24, 20, 12, 16),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: FloTheme.line)),
       ),
       child: Row(
         children: [
           Container(
-            padding: const EdgeInsets.all(10),
+            width: 40,
+            height: 40,
+            alignment: Alignment.center,
             decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [AiTheme.whatsAppGreen, AiTheme.whatsAppDarkGreen],
-              ),
-              borderRadius: BorderRadius.circular(12),
-              boxShadow: [
-                BoxShadow(
-                  color: AiTheme.whatsAppGreen.withValues(alpha: 0.3),
-                  blurRadius: 8,
-                  offset: const Offset(0, 2),
-                ),
-              ],
+              color: FloTheme.blueTint,
+              borderRadius: BorderRadius.circular(11),
             ),
-            child: const Icon(
-              Icons.chat_rounded,
-              color: Colors.white,
-              size: 22,
-            ),
+            child: FloIcons.whatsApp(size: 21, color: FloTheme.blueDeep),
           ),
-          const SizedBox(width: 14),
+          const SizedBox(width: 12),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -223,52 +176,20 @@ class _WhatsAppConnectionDialogState
                 const Text(
                   'WhatsApp Business',
                   style: TextStyle(
-                    fontSize: 18,
+                    fontSize: 17,
                     fontWeight: FontWeight.w700,
-                    color: AiTheme.textColor,
-                    letterSpacing: -0.3,
+                    letterSpacing: -0.02,
+                    color: FloTheme.ink1,
                   ),
                 ),
                 const SizedBox(height: 2),
-                Row(
-                  children: [
-                    if (isConnected) ...[
-                      AnimatedBuilder(
-                        animation: _pulseAnimation,
-                        builder: (context, child) {
-                          return Container(
-                            width: 7,
-                            height: 7,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: AiTheme.whatsAppGreen.withValues(
-                                alpha: _pulseAnimation.value,
-                              ),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: AiTheme.whatsAppGreen.withValues(
-                                    alpha: _pulseAnimation.value * 0.4,
-                                  ),
-                                  blurRadius: 4,
-                                ),
-                              ],
-                            ),
-                          );
-                        },
-                      ),
-                      const SizedBox(width: 6),
-                    ],
-                    Text(
-                      isConnected ? 'Connected' : 'Not connected',
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: isConnected
-                            ? AiTheme.whatsAppGreen
-                            : AiTheme.hintColor,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  ],
+                Text(
+                  isConnected ? 'Connected' : 'Not connected',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                    color: isConnected ? FloTheme.gainInk : FloTheme.ink3,
+                  ),
                 ),
               ],
             ),
@@ -276,7 +197,7 @@ class _WhatsAppConnectionDialogState
           IconButton(
             icon: const Icon(Icons.close_rounded, size: 20),
             onPressed: () => Navigator.of(context).pop(),
-            color: AiTheme.secondaryColor,
+            color: FloTheme.ink3,
             splashRadius: 18,
           ),
         ],
@@ -289,61 +210,42 @@ class _WhatsAppConnectionDialogState
       mainAxisSize: MainAxisSize.min,
       children: [
         Container(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(14),
           decoration: BoxDecoration(
-            color: AiTheme.whatsAppGreen.withValues(alpha: 0.06),
-            borderRadius: BorderRadius.circular(14),
-            border: Border.all(
-              color: AiTheme.whatsAppGreen.withValues(alpha: 0.2),
-            ),
+            color: FloTheme.gainTint,
+            borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+            border: Border.all(color: FloTheme.line),
           ),
           child: Row(
             children: [
               Container(
-                padding: const EdgeInsets.all(8),
+                width: 36,
+                height: 36,
+                alignment: Alignment.center,
                 decoration: BoxDecoration(
-                  color: AiTheme.whatsAppGreen.withValues(alpha: 0.12),
+                  color: FloTheme.surface,
                   borderRadius: BorderRadius.circular(10),
+                  border: Border.all(color: FloTheme.line),
                 ),
-                child: const Icon(
-                  Icons.verified_rounded,
-                  color: AiTheme.whatsAppGreen,
-                  size: 22,
-                ),
+                child: FloIcons.check(size: 16, color: FloTheme.gainInk),
               ),
-              const SizedBox(width: 14),
+              const SizedBox(width: 12),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     const Text(
-                      'Account Active',
+                      'Account active',
                       style: TextStyle(
                         fontWeight: FontWeight.w600,
-                        fontSize: 15,
-                        color: AiTheme.whatsAppDarkGreen,
+                        fontSize: 14,
+                        color: FloTheme.ink1,
                       ),
                     ),
-                    const SizedBox(height: 4),
-                    Row(
-                      children: [
-                        Icon(
-                          Icons.tag_rounded,
-                          size: 14,
-                          color: AiTheme.hintColor,
-                        ),
-                        const SizedBox(width: 4),
-                        Flexible(
-                          child: Text(
-                            state.phoneNumberId ?? '',
-                            style: TextStyle(
-                              fontSize: 13,
-                              color: AiTheme.secondaryColor,
-                              fontFamily: 'monospace',
-                            ),
-                          ),
-                        ),
-                      ],
+                    const SizedBox(height: 3),
+                    Text(
+                      state.phoneNumberId ?? '',
+                      style: FloTheme.mono(13).copyWith(color: FloTheme.ink2),
                     ),
                   ],
                 ),
@@ -352,27 +254,23 @@ class _WhatsAppConnectionDialogState
           ),
         ),
         const SizedBox(height: 12),
-        // Info text
         Container(
           padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
-            color: AiTheme.inputBackgroundColor,
-            borderRadius: BorderRadius.circular(10),
+            color: FloTheme.surface2,
+            borderRadius: BorderRadius.circular(FloTheme.radiusSm),
           ),
-          child: Row(
+          child: const Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Icon(
-                Icons.info_outline_rounded,
-                size: 16,
-                color: AiTheme.hintColor,
-              ),
-              const SizedBox(width: 10),
+              Icon(Icons.info_outline_rounded, size: 16, color: FloTheme.ink3),
+              SizedBox(width: 10),
               Expanded(
                 child: Text(
-                  'WhatsApp messages will appear in your conversations automatically.',
+                  'Saved to your business account — it stays connected on other devices when you sign in.',
                   style: TextStyle(
                     fontSize: 12,
-                    color: AiTheme.secondaryColor,
+                    color: FloTheme.ink2,
                     height: 1.4,
                   ),
                 ),
@@ -389,16 +287,19 @@ class _WhatsAppConnectionDialogState
                 ? const SizedBox(
                     height: 16,
                     width: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation(FloTheme.loss),
+                    ),
                   )
                 : const Icon(Icons.link_off_rounded, size: 18),
             label: Text(state.isLoading ? 'Disconnecting...' : 'Disconnect'),
             style: OutlinedButton.styleFrom(
-              foregroundColor: Colors.red.shade400,
-              side: BorderSide(color: Colors.red.shade300),
+              foregroundColor: FloTheme.lossInk,
+              side: const BorderSide(color: FloTheme.loss),
               padding: const EdgeInsets.symmetric(vertical: 14),
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(FloTheme.radiusMd),
               ),
             ),
           ),
@@ -412,16 +313,15 @@ class _WhatsAppConnectionDialogState
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
+        const Text(
           'Connect your WhatsApp Business account to receive and reply to customer messages.',
           style: TextStyle(
-            color: AiTheme.secondaryColor,
+            color: FloTheme.ink2,
             fontSize: 14,
             height: 1.5,
           ),
         ),
-        const SizedBox(height: 20),
-        // Setup steps
+        const SizedBox(height: 18),
         _buildSetupStep(
           number: '1',
           text: 'Go to your Meta Business Suite',
@@ -439,78 +339,99 @@ class _WhatsAppConnectionDialogState
           text: 'Paste it below and connect',
           icon: Icons.content_paste_rounded,
         ),
-        const SizedBox(height: 20),
+        const SizedBox(height: 18),
         TextField(
           controller: _phoneNumberIdController,
           decoration: InputDecoration(
             labelText: 'Phone Number ID',
-            labelStyle: const TextStyle(color: AiTheme.hintColor),
+            labelStyle: const TextStyle(color: FloTheme.ink3),
             hintText: 'e.g., 101514826127381',
             hintStyle: TextStyle(
-              color: AiTheme.hintColor.withValues(alpha: 0.6),
+              color: FloTheme.ink4.withValues(alpha: 0.9),
             ),
             errorText: state.error,
-            prefixIcon: Icon(
-              Icons.phone_rounded,
-              color: AiTheme.whatsAppGreen.withValues(alpha: 0.7),
+            errorStyle: const TextStyle(color: FloTheme.lossInk, fontSize: 12),
+            prefixIcon: const Icon(
+              Icons.tag_rounded,
+              color: FloTheme.ink3,
             ),
             border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(14),
-              borderSide: const BorderSide(color: AiTheme.borderColor),
+              borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+              borderSide: const BorderSide(color: FloTheme.line),
             ),
             enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(14),
-              borderSide: const BorderSide(color: AiTheme.borderColor),
+              borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+              borderSide: const BorderSide(color: FloTheme.line),
             ),
             focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(14),
-              borderSide: const BorderSide(
-                color: AiTheme.whatsAppGreen,
-                width: 2,
-              ),
+              borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+              borderSide: const BorderSide(color: FloTheme.blue, width: 1.5),
+            ),
+            errorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+              borderSide: const BorderSide(color: FloTheme.loss),
+            ),
+            focusedErrorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+              borderSide: const BorderSide(color: FloTheme.loss, width: 1.5),
             ),
             filled: true,
-            fillColor: AiTheme.inputBackgroundColor,
+            fillColor: FloTheme.surface2,
             contentPadding: const EdgeInsets.symmetric(
               horizontal: 16,
               vertical: 14,
             ),
           ),
           enabled: !state.isLoading,
-          style: const TextStyle(fontSize: 15, fontFamily: 'monospace'),
+          style: FloTheme.mono(14).copyWith(color: FloTheme.ink1),
         ),
-        const SizedBox(height: 24),
+        const SizedBox(height: 22),
         SizedBox(
           width: double.infinity,
-          child: ElevatedButton.icon(
-            onPressed: state.isLoading ? null : _handleConnect,
-            icon: state.isLoading
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                    ),
-                  )
-                : const Icon(Icons.link_rounded, size: 20),
-            label: Text(
-              state.isLoading ? 'Connecting...' : 'Connect WhatsApp',
-              style: const TextStyle(
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 0.2,
+          height: 48,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: state.isLoading ? null : _handleConnect,
+              borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+              child: Ink(
+                decoration: BoxDecoration(
+                  gradient: state.isLoading ? null : FloTheme.gradBtn,
+                  color: state.isLoading ? FloTheme.lineStrong : null,
+                  borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+                  boxShadow: state.isLoading
+                      ? null
+                      : const [FloTheme.shBlue],
+                ),
+                child: Center(
+                  child: state.isLoading
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor:
+                                AlwaysStoppedAnimation<Color>(Colors.white),
+                          ),
+                        )
+                      : Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            FloIcons.link(size: 18, color: Colors.white),
+                            const SizedBox(width: 8),
+                            const Text(
+                              'Connect WhatsApp',
+                              style: TextStyle(
+                                fontSize: 15,
+                                fontWeight: FontWeight.w700,
+                                color: Colors.white,
+                                letterSpacing: -0.01,
+                              ),
+                            ),
+                          ],
+                        ),
+                ),
               ),
-            ),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: AiTheme.whatsAppGreen,
-              foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(vertical: 16),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(14),
-              ),
-              elevation: 2,
-              shadowColor: AiTheme.whatsAppGreen.withValues(alpha: 0.3),
             ),
           ),
         ),
@@ -529,16 +450,17 @@ class _WhatsAppConnectionDialogState
           width: 24,
           height: 24,
           decoration: BoxDecoration(
-            color: AiTheme.whatsAppGreen.withValues(alpha: 0.1),
+            color: FloTheme.blueTint,
             shape: BoxShape.circle,
+            border: Border.all(color: FloTheme.blueTint2),
           ),
           child: Center(
             child: Text(
               number,
-              style: TextStyle(
+              style: const TextStyle(
                 fontSize: 12,
                 fontWeight: FontWeight.w700,
-                color: AiTheme.whatsAppDarkGreen,
+                color: FloTheme.blueDeep,
               ),
             ),
           ),
@@ -547,14 +469,14 @@ class _WhatsAppConnectionDialogState
         Expanded(
           child: Text(
             text,
-            style: TextStyle(
+            style: const TextStyle(
               fontSize: 13,
-              color: AiTheme.secondaryColor,
+              color: FloTheme.ink2,
               height: 1.3,
             ),
           ),
         ),
-        Icon(icon, size: 16, color: AiTheme.hintColor.withValues(alpha: 0.5)),
+        Icon(icon, size: 16, color: FloTheme.ink4),
       ],
     );
   }
@@ -568,82 +490,82 @@ class _WhatsAppConnectionDialogState
           Row(
             children: [
               Container(
-                padding: const EdgeInsets.all(10),
+                width: 40,
+                height: 40,
+                alignment: Alignment.center,
                 decoration: BoxDecoration(
-                  color: Colors.red.shade50,
-                  borderRadius: BorderRadius.circular(12),
+                  color: FloTheme.lossTint,
+                  borderRadius: BorderRadius.circular(11),
                 ),
-                child: Icon(
+                child: const Icon(
                   Icons.error_outline_rounded,
-                  color: Colors.red.shade400,
+                  color: FloTheme.lossInk,
                   size: 22,
                 ),
               ),
-              const SizedBox(width: 14),
+              const SizedBox(width: 12),
               const Expanded(
                 child: Text(
                   'Connection Error',
                   style: TextStyle(
-                    fontSize: 18,
+                    fontSize: 17,
                     fontWeight: FontWeight.w700,
-                    color: AiTheme.textColor,
+                    color: FloTheme.ink1,
                   ),
                 ),
               ),
               IconButton(
                 icon: const Icon(Icons.close_rounded, size: 20),
                 onPressed: () => Navigator.of(context).pop(),
-                color: AiTheme.secondaryColor,
+                color: FloTheme.ink3,
                 splashRadius: 18,
               ),
             ],
           ),
-          const SizedBox(height: 20),
+          const SizedBox(height: 18),
           Container(
             width: double.infinity,
             padding: const EdgeInsets.all(14),
             decoration: BoxDecoration(
-              color: Colors.red.shade50,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: Colors.red.withValues(alpha: 0.2)),
+              color: FloTheme.lossTint,
+              borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+              border: Border.all(color: FloTheme.loss.withValues(alpha: 0.35)),
             ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Icon(
-                  Icons.warning_amber_rounded,
-                  color: Colors.red.shade400,
-                  size: 18,
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    error,
-                    style: TextStyle(
-                      color: Colors.red.shade700,
-                      fontSize: 13,
-                      height: 1.4,
-                    ),
-                  ),
-                ),
-              ],
+            child: Text(
+              error,
+              style: const TextStyle(
+                color: FloTheme.lossInk,
+                fontSize: 13,
+                height: 1.4,
+              ),
             ),
           ),
           const SizedBox(height: 20),
           SizedBox(
             width: double.infinity,
-            child: ElevatedButton.icon(
-              onPressed: () {
-                ref.read(whatsAppConnectionStateProvider.notifier).refresh();
-              },
-              icon: const Icon(Icons.refresh_rounded, size: 18),
-              label: const Text('Try Again'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AiTheme.whatsAppGreen,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(vertical: 14),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
+            height: 44,
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: () {
+                  ref.read(whatsAppConnectionStateProvider.notifier).refresh();
+                },
+                borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+                child: Ink(
+                  decoration: BoxDecoration(
+                    gradient: FloTheme.gradBtn,
+                    borderRadius: BorderRadius.circular(FloTheme.radiusMd),
+                  ),
+                  child: const Center(
+                    child: Text(
+                      'Try Again',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/packages/flipper_dashboard/lib/AdminControl.dart
+++ b/packages/flipper_dashboard/lib/AdminControl.dart
@@ -24,6 +24,7 @@ import 'package:flutter/material.dart';
 import 'package:stacked_services/stacked_services.dart';
 import 'package:flutter/foundation.dart' hide Category;
 import 'package:supabase_flutter/supabase_flutter.dart' hide User;
+import 'package:supabase_models/brick/models/branch_sms_config.model.dart';
 import 'package:supabase_models/brick/models/user.model.dart';
 import 'package:supabase_models/sync/ditto_sync_coordinator.dart';
 import 'modals/_isBranchEnableForPayment.dart';
@@ -153,6 +154,7 @@ class _AdminControlState extends ConsumerState<AdminControl> {
   String? smsPhoneNumber;
   bool enableSmsNotification = false;
   bool enableWhatsappNotification = false;
+  int whatsappProvider = WhatsAppChannel.openwa;
   bool enableAutoAddSearch = false;
   late final TextEditingController phoneController;
   late final FocusNode _smsPhoneFocusNode;
@@ -217,6 +219,7 @@ class _AdminControlState extends ConsumerState<AdminControl> {
     String? phone,
     bool? enableSms,
     bool? enableWhatsapp,
+    int? whatsappProvider,
   }) async {
     if (phone != null && phone.isNotEmpty) {
       if (!_isValidPhoneNumber(phone)) {
@@ -235,6 +238,7 @@ class _AdminControlState extends ConsumerState<AdminControl> {
         smsPhoneNumber: phone,
         enableSms: enableSms,
         enableWhatsapp: enableWhatsapp,
+        whatsappProvider: whatsappProvider,
       );
 
       if (!mounted) return;
@@ -250,6 +254,9 @@ class _AdminControlState extends ConsumerState<AdminControl> {
         if (enableWhatsapp != null) {
           enableWhatsappNotification = enableWhatsapp;
         }
+        if (whatsappProvider != null) {
+          this.whatsappProvider = whatsappProvider;
+        }
         phoneError = null;
       });
     } catch (e) {
@@ -258,6 +265,101 @@ class _AdminControlState extends ConsumerState<AdminControl> {
         phoneError = 'Failed to update SMS configuration';
       });
     }
+  }
+
+  /// When enabling WhatsApp, prompt for OpenWA (1) vs Meta (2).
+  Future<void> _onWhatsappEnabledChanged(bool enabled) async {
+    if (!enabled) {
+      await _updateSmsConfig(enableWhatsapp: false);
+      return;
+    }
+    final channel = await _promptWhatsAppChannel(initial: whatsappProvider);
+    if (!mounted || channel == null) return;
+    await _updateSmsConfig(
+      enableWhatsapp: true,
+      whatsappProvider: channel,
+    );
+  }
+
+  Future<int?> _promptWhatsAppChannel({required int initial}) {
+    var selected = initial == WhatsAppChannel.meta
+        ? WhatsAppChannel.meta
+        : WhatsAppChannel.openwa;
+    return showDialog<int>(
+      context: context,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) {
+            return AlertDialog(
+              title: Text(
+                'WhatsApp channel',
+                style: GoogleFonts.outfit(fontWeight: FontWeight.w700),
+              ),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Choose how digital receipts and order notifications are sent.',
+                    style: GoogleFonts.outfit(
+                      fontSize: 14,
+                      color: const Color(0xFF6B7280),
+                      height: 1.35,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  RadioListTile<int>(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(
+                      'OpenWA',
+                      style: GoogleFonts.outfit(fontWeight: FontWeight.w600),
+                    ),
+                    subtitle: Text(
+                      'Local / self-hosted WhatsApp session (channel 1)',
+                      style: GoogleFonts.outfit(fontSize: 12),
+                    ),
+                    value: WhatsAppChannel.openwa,
+                    groupValue: selected,
+                    onChanged: (v) {
+                      if (v == null) return;
+                      setDialogState(() => selected = v);
+                    },
+                  ),
+                  RadioListTile<int>(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(
+                      'Meta Cloud API',
+                      style: GoogleFonts.outfit(fontWeight: FontWeight.w600),
+                    ),
+                    subtitle: Text(
+                      'Official Meta WhatsApp (channel 2). Customers may need '
+                      'to scan a QR to opt in before receipts can send.',
+                      style: GoogleFonts.outfit(fontSize: 12),
+                    ),
+                    value: WhatsAppChannel.meta,
+                    groupValue: selected,
+                    onChanged: (v) {
+                      if (v == null) return;
+                      setDialogState(() => selected = v);
+                    },
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  child: const Text('Cancel'),
+                ),
+                FilledButton(
+                  onPressed: () => Navigator.of(ctx).pop(selected),
+                  child: const Text('Save'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
   }
 
   String? _normalizedSmsPhoneFromController() {
@@ -885,6 +987,7 @@ class _AdminControlState extends ConsumerState<AdminControl> {
           smsPhoneNumber = config.smsPhoneNumber;
           enableSmsNotification = config.enableSms;
           enableWhatsappNotification = config.enableWhatsapp;
+          whatsappProvider = config.whatsappProvider;
           phoneController.text = config.smsPhoneNumber ?? '';
         });
       }
@@ -2071,10 +2174,60 @@ class _AdminControlState extends ConsumerState<AdminControl> {
                     const Color(0xFF25D366).withValues(alpha: 0.12),
                   ),
                   value: enableWhatsappNotification,
-                  onChanged: (value) =>
-                      _updateSmsConfig(enableWhatsapp: value),
+                  onChanged: _onWhatsappEnabledChanged,
                 ),
               ),
+              if (enableWhatsappNotification) ...[
+                Divider(height: 1, thickness: 1, color: _kAdminCardBorder),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Default WhatsApp channel',
+                        style: GoogleFonts.outfit(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 15,
+                          color: _kAdminTitleText,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        '1 = OpenWA · 2 = Meta Cloud API',
+                        style: GoogleFonts.outfit(
+                          fontSize: 12,
+                          color: _kAdminSubtitleText,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      SegmentedButton<int>(
+                        segments: const [
+                          ButtonSegment<int>(
+                            value: WhatsAppChannel.openwa,
+                            label: Text('OpenWA'),
+                            icon: Icon(Icons.smartphone_outlined, size: 16),
+                          ),
+                          ButtonSegment<int>(
+                            value: WhatsAppChannel.meta,
+                            label: Text('Meta'),
+                            icon: Icon(Icons.cloud_outlined, size: 16),
+                          ),
+                        ],
+                        selected: {
+                          whatsappProvider == WhatsAppChannel.meta
+                              ? WhatsAppChannel.meta
+                              : WhatsAppChannel.openwa,
+                        },
+                        onSelectionChanged: (set) {
+                          final v = set.first;
+                          _updateSmsConfig(whatsappProvider: v);
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ],
           ),
         ),

--- a/packages/flipper_dashboard/lib/AdminControl.dart
+++ b/packages/flipper_dashboard/lib/AdminControl.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flipper_dashboard/features/admin/widgets/language_settings_card.dart';
+import 'package:flipper_dashboard/providers/digital_receipt_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flipper_dashboard/features/bar_mode/widgets/bar_mode_admin_section.dart';
 import 'package:flipper_dashboard/ReinitializeEbm.dart';
 import 'package:flipper_localize/flipper_localize.dart';
@@ -132,14 +134,14 @@ Widget _adminLeadingSvg(String svg, Color backgroundTint) {
   );
 }
 
-class AdminControl extends StatefulWidget {
+class AdminControl extends ConsumerStatefulWidget {
   const AdminControl({super.key});
 
   @override
-  State<AdminControl> createState() => _AdminControlState();
+  ConsumerState<AdminControl> createState() => _AdminControlState();
 }
 
-class _AdminControlState extends State<AdminControl> {
+class _AdminControlState extends ConsumerState<AdminControl> {
   final navigator = locator<RouterService>();
   bool isPosDefault = false;
   bool isOrdersDefault = true;
@@ -150,6 +152,7 @@ class _AdminControlState extends State<AdminControl> {
   bool switchToCloudSync = false;
   String? smsPhoneNumber;
   bool enableSmsNotification = false;
+  bool enableWhatsappNotification = false;
   bool enableAutoAddSearch = false;
   late final TextEditingController phoneController;
   late final FocusNode _smsPhoneFocusNode;
@@ -210,7 +213,11 @@ class _AdminControlState extends State<AdminControl> {
     return cleanPhone;
   }
 
-  Future<void> _updateSmsConfig({String? phone, bool? enable}) async {
+  Future<void> _updateSmsConfig({
+    String? phone,
+    bool? enableSms,
+    bool? enableWhatsapp,
+  }) async {
     if (phone != null && phone.isNotEmpty) {
       if (!_isValidPhoneNumber(phone)) {
         setState(() {
@@ -226,12 +233,23 @@ class _AdminControlState extends State<AdminControl> {
       await SmsNotificationService.updateBranchSmsConfig(
         branchId: ProxyService.box.getBranchId()!,
         smsPhoneNumber: phone,
-        enableNotification: enable,
+        enableSms: enableSms,
+        enableWhatsapp: enableWhatsapp,
       );
+
+      if (!mounted) return;
+
+      // branchSmsNotificationsEnabledProvider caches for the life of the app,
+      // and it gates the POS digital-receipt toggle. Without this the checkout
+      // screen keeps the stale value until a full restart.
+      ref.invalidate(branchSmsNotificationsEnabledProvider);
 
       setState(() {
         if (phone != null) smsPhoneNumber = phone;
-        if (enable != null) enableSmsNotification = enable;
+        if (enableSms != null) enableSmsNotification = enableSms;
+        if (enableWhatsapp != null) {
+          enableWhatsappNotification = enableWhatsapp;
+        }
         phoneError = null;
       });
     } catch (e) {
@@ -865,7 +883,8 @@ class _AdminControlState extends State<AdminControl> {
       if (config != null) {
         setState(() {
           smsPhoneNumber = config.smsPhoneNumber;
-          enableSmsNotification = config.enableOrderNotification;
+          enableSmsNotification = config.enableSms;
+          enableWhatsappNotification = config.enableWhatsapp;
           phoneController.text = config.smsPhoneNumber ?? '';
         });
       }
@@ -2030,14 +2049,30 @@ class _AdminControlState extends State<AdminControl> {
               Padding(
                 padding: const EdgeInsets.all(16),
                 child: _AdminSwitchRow(
-                  title: context.flipperL10n.enableOrderNotifications,
+                  title: context.flipperL10n.enableSmsNotifications,
                   subtitle: context.flipperL10n.receiveSmsNotificationsForOrders,
                   leading: _adminLeadingSvg(
                     AdminDashboardSvgs.enableNotifications,
                     const Color(0xFF16A34A).withValues(alpha: 0.1),
                   ),
                   value: enableSmsNotification,
-                  onChanged: (value) => _updateSmsConfig(enable: value),
+                  onChanged: (value) => _updateSmsConfig(enableSms: value),
+                ),
+              ),
+              Divider(height: 1, thickness: 1, color: _kAdminCardBorder),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: _AdminSwitchRow(
+                  title: context.flipperL10n.enableWhatsappNotifications,
+                  subtitle:
+                      context.flipperL10n.receiveWhatsappNotificationsForOrders,
+                  leading: _adminLeadingSvg(
+                    AdminDashboardSvgs.enableNotifications,
+                    const Color(0xFF25D366).withValues(alpha: 0.12),
+                  ),
+                  value: enableWhatsappNotification,
+                  onChanged: (value) =>
+                      _updateSmsConfig(enableWhatsapp: value),
                 ),
               ),
             ],

--- a/packages/flipper_dashboard/lib/QuickSellingView.dart
+++ b/packages/flipper_dashboard/lib/QuickSellingView.dart
@@ -51,10 +51,12 @@ import 'package:flipper_dashboard/widgets/pos_cart_table_host.dart';
 import 'package:flipper_dashboard/widgets/checkout_mode_bar.dart';
 import 'package:flipper_dashboard/widgets/checkout_transfer_branch_row.dart';
 import 'package:flipper_dashboard/widgets/checkout_transfer_footer.dart';
+import 'package:flipper_dashboard/widgets/whatsapp_meta_opt_in_dialog.dart';
 import 'package:flipper_dashboard/providers/checkout_cart_mode_provider.dart';
 import 'package:flipper_dashboard/services/branch_transfer_service.dart';
 import 'package:flipper_dashboard/mixins/transaction_computation_mixin.dart';
 import 'package:flipper_models/helperModels/talker.dart' as tv_talk;
+import 'package:flipper_services/digital_receipt_service.dart';
 
 /// Compact label for correlating QuickSellingView with [pendingTransactionStream] logs.
 String _qsvPendingLabel(AsyncValue<ITransaction> v) {
@@ -733,6 +735,15 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
 
     // Store initial branch ID to detect changes
     _currentBranchId = ProxyService.box.getBranchId();
+
+    // Meta WhatsApp: when receipt is queued outside 24h window, show opt-in QR.
+    _whatsAppOptInSub = DigitalReceiptService.optInPromptStream.listen((prompt) {
+      if (!mounted || _whatsAppOptInDialogShowing) return;
+      _whatsAppOptInDialogShowing = true;
+      showWhatsAppMetaOptInDialog(context, prompt).whenComplete(() {
+        _whatsAppOptInDialogShowing = false;
+      });
+    });
   }
 
   void _onDiscountChanged() {
@@ -895,6 +906,8 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
 
   // Track current branch ID to detect branch changes
   String? _currentBranchId;
+  StreamSubscription<WhatsAppOptInPrompt>? _whatsAppOptInSub;
+  bool _whatsAppOptInDialogShowing = false;
 
   /// Collapsed = Search Customer; expanded = Name + Phone (swap, not stack).
   bool _customerFieldsExpanded = false;
@@ -992,6 +1005,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
   @override
   void dispose() {
     widget.discountController.removeListener(_onDiscountChanged);
+    _whatsAppOptInSub?.cancel();
     _customerNamePersistTimer?.cancel();
     _customerPhonePersistTimer?.cancel();
     _receivedAmountSyncTimer?.cancel();
@@ -1075,6 +1089,13 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     // header falls back to the stale stream row (old Txn ID).
     ref.read(suppressedCartTransactionIdProvider.notifier).state =
         transaction.id;
+    // Resuming a parked ticket pins the cart to it (primePosCartForTransaction),
+    // and that pin outranks the pending-cart cache. Left set, the cart resolves
+    // straight back to this now-completed sale's still-active lines as soon as
+    // suppression is released below — and stays that way until the app restarts,
+    // since the pin provider is never disposed. The settling branch above clears
+    // its own pin; this covers a plain resume (no till-settling session).
+    clearPinnedPosCartTransactionIfWidget(ref, transactionId: transaction.id);
     clearCartLinesOptimistically();
 
     ref
@@ -1141,7 +1162,13 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
       ref
           .read(optimisticCartProvider.notifier)
           .bindPendingTransaction(nextPending.id);
-      if (ref.read(suppressedCartTransactionIdProvider) == transaction.id) {
+      // Only release suppression once nothing still resolves the cart to the
+      // completed sale. A pin surviving here would outrank [nextPending] in the
+      // cache, so the sold lines would come straight back.
+      final stillPinnedToSold =
+          ref.read(pinnedPosCartTransactionIdProvider) == transaction.id;
+      if (!stillPinnedToSold &&
+          ref.read(suppressedCartTransactionIdProvider) == transaction.id) {
         ref.read(suppressedCartTransactionIdProvider.notifier).state = null;
       }
     } else {
@@ -3570,6 +3597,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     final txn =
         ref.read(pendingTransactionStreamProvider(isExpense: false)).value ??
         transaction;
+    var parked = false;
     // transaction.subTotal is a persisted/streamed snapshot that can lag
     // behind optimistic cart edits and discounts — pass the live sale total
     // (same source the checkout screen renders) so the dialog never shows a
@@ -3578,7 +3606,76 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
       context: context,
       transaction: txn,
       displayAmount: totalAfterDiscountAndShipping,
+      onParked: () => parked = true,
     );
+    if (!parked || !mounted) return;
+
+    // Unlike mobile checkout — which navigates away to the tickets list right
+    // after parking — this view stays put, so the handed-off lines must be
+    // cleared locally. parkSaleTicketFast mints the replacement pending cart
+    // unawaited, so waiting on the pending stream leaves the parked ticket
+    // rendered as the cart for as long as Ditto takes to reconcile.
+    final settling = ref.read(settlingTillTicketProvider);
+    if (settling != null) {
+      // A settling session scopes posCartDisplayItemsProvider straight to the
+      // ticket's item stream, which outranks every clear below.
+      ref.read(settlingTillTicketProvider.notifier).state = null;
+      clearPinnedPosCartTransactionIfWidget(
+        ref,
+        transactionId: settling.transactionId,
+      );
+    }
+    _clearCartAfterTicketHandoff(txn);
+    if (ref.read(previewingCart)) {
+      ref.read(previewingCart.notifier).state = false;
+    }
+    setState(() {});
+  }
+
+  /// Same-frame local reset for a cart that just left this device — parked as a
+  /// ticket or sent to the till. The pending-cart cache, the resume pin and the
+  /// optimistic ghosts all still point at [transaction] after the park lands in
+  /// Ditto, so without this the cart keeps rendering the handed-off lines (and
+  /// the next sale inherits its customer and tender fields).
+  void _clearCartAfterTicketHandoff(ITransaction transaction) {
+    ref.read(suppressedCartTransactionIdProvider.notifier).state =
+        transaction.id;
+    // A resumed ticket handed off again leaves its pin behind. Since the pin
+    // wins over the (just-cleared) cache, the suppression above would then
+    // blank *every* later cart too — new taps write to the next pending id
+    // while the display still resolves the suppressed, pinned one.
+    clearPinnedPosCartTransactionIfWidget(ref, transactionId: transaction.id);
+    clearCartLinesOptimistically();
+    ref
+        .read(optimisticCartProvider.notifier)
+        .clearForTransaction(transaction.id);
+    clearCachedPendingCartTransactionWidget(
+      ref,
+      isExpense: false,
+    );
+    ref.invalidate(
+      transactionItemsStreamProvider(
+        transactionId: transaction.id,
+        branchId: ProxyService.box.getBranchId() ?? '0',
+      ),
+    );
+    _lastAutoSetAmount = 0.0;
+    _lastPaymentInitTransactionId = null;
+    _cachedNonCreditPaid = null;
+    ref.invalidate(paymentMethodsProvider);
+    widget.receivedAmountController.clear();
+    widget.discountController.clear();
+    // Clear customer details too, so the next sale does not inherit the
+    // handed-off ticket's customer. Name/phone live in controllers + persisted
+    // box keys (mirrors _collapseCustomerFields).
+    ref.read(customerNameControllerProvider).clear();
+    widget.customerPhoneNumberController.clear();
+    ProxyService.box.writeString(key: 'customerName', value: '');
+    ProxyService.box.writeString(
+      key: 'currentSaleCustomerPhoneNumber',
+      value: '',
+    );
+    ref.invalidate(pendingTransactionStreamProvider(isExpense: false));
   }
 
   Future<void> _sendCartToTill(ITransaction transaction) async {
@@ -3604,39 +3701,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
             customerId: transaction.customerId,
           );
 
-      ref.read(suppressedCartTransactionIdProvider.notifier).state =
-          transaction.id;
-      clearCartLinesOptimistically();
-      ref
-          .read(optimisticCartProvider.notifier)
-          .clearForTransaction(transaction.id);
-      clearCachedPendingCartTransactionWidget(
-        ref,
-        isExpense: false,
-      );
-      ref.invalidate(
-        transactionItemsStreamProvider(
-          transactionId: transaction.id,
-          branchId: ProxyService.box.getBranchId() ?? '0',
-        ),
-      );
-      _lastAutoSetAmount = 0.0;
-      _lastPaymentInitTransactionId = null;
-      _cachedNonCreditPaid = null;
-      ref.invalidate(paymentMethodsProvider);
-      widget.receivedAmountController.clear();
-      widget.discountController.clear();
-      // Clear customer details too, so the next sale does not inherit the sent
-      // ticket's customer. Name/phone live in controllers + persisted box keys
-      // (mirrors _collapseCustomerFields).
-      ref.read(customerNameControllerProvider).clear();
-      widget.customerPhoneNumberController.clear();
-      ProxyService.box.writeString(key: 'customerName', value: '');
-      ProxyService.box.writeString(
-        key: 'currentSaleCustomerPhoneNumber',
-        value: '',
-      );
-      ref.invalidate(pendingTransactionStreamProvider(isExpense: false));
+      _clearCartAfterTicketHandoff(transaction);
 
       if (mounted) {
         showSuccessNotification(

--- a/packages/flipper_dashboard/lib/TransactionItemTable.dart
+++ b/packages/flipper_dashboard/lib/TransactionItemTable.dart
@@ -487,9 +487,24 @@ mixin TransactionItemTable<T extends ConsumerStatefulWidget>
     );
   }
 
-  List<TransactionItem> get _visibleTransactionItems => _linesForTable
-      .where((item) => !_optimisticallyDeletedItemIds.contains(item.id))
-      .toList();
+  List<TransactionItem> get _visibleTransactionItems {
+    final lines = _linesForTable;
+    // A ghost id only means "hidden until the provider catches up", so it must
+    // not outlive the line leaving the cart. [_removeUnusedControllers] cannot be
+    // trusted for this: it sweeps [_quantityControllers], which rows create
+    // lazily, and it only runs from the table builder — totals and completion
+    // hints read this getter too. It matters most on resume, where a parked
+    // ticket's lines come back with the *same* ids that
+    // [clearCartLinesOptimistically] hid when it was parked (the next sale gets
+    // fresh ids, which is why completion never showed this).
+    if (_optimisticallyDeletedItemIds.isNotEmpty) {
+      final ids = lines.map((line) => line.id).toSet();
+      _optimisticallyDeletedItemIds.removeWhere((id) => !ids.contains(id));
+    }
+    return lines
+        .where((item) => !_optimisticallyDeletedItemIds.contains(item.id))
+        .toList();
+  }
 
   /// Instantly empties the visible cart when a sale completes, before the async
   /// provider invalidations in completion reconcile [posCartDisplayItemsProvider]

--- a/packages/flipper_dashboard/lib/checkout.dart
+++ b/packages/flipper_dashboard/lib/checkout.dart
@@ -376,6 +376,12 @@ class CheckOutState extends ConsumerState<CheckOut>
       );
     }
 
+    // Same pin problem outside a settling session: a plain resumed ticket is
+    // pinned by _resumeOrder, nothing here unwinds it, and the pin outranks the
+    // fresh pending cart newTransaction() mints below — so the completed sale's
+    // lines keep resolving as the cart until the app restarts.
+    clearPinnedPosCartTransactionIfWidget(ref, transactionId: transaction.id);
+
     ref.invalidate(
       transactionItemsStreamProvider(
         transactionId: transaction.id,

--- a/packages/flipper_dashboard/lib/features/admin/controllers/admin_controller.dart
+++ b/packages/flipper_dashboard/lib/features/admin/controllers/admin_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flipper_services/proxy.dart';
+import 'package:supabase_models/brick/models/branch_sms_config.model.dart';
 import '../services/admin_settings_service.dart';
 
 class AdminController extends ChangeNotifier {
@@ -13,6 +14,7 @@ class AdminController extends ChangeNotifier {
   String? _smsPhoneNumber;
   bool _enableSmsNotification = false;
   bool _enableWhatsappNotification = false;
+  int _whatsappProvider = WhatsAppChannel.openwa;
   String? _phoneError;
 
   // Getters
@@ -26,6 +28,7 @@ class AdminController extends ChangeNotifier {
   String? get smsPhoneNumber => _smsPhoneNumber;
   bool get enableSmsNotification => _enableSmsNotification;
   bool get enableWhatsappNotification => _enableWhatsappNotification;
+  int get whatsappProvider => _whatsappProvider;
   String? get phoneError => _phoneError;
 
   AdminController() {
@@ -52,6 +55,10 @@ class AdminController extends ChangeNotifier {
       _smsPhoneNumber = config['smsPhoneNumber'];
       _enableSmsNotification = config['enableSms'] == true;
       _enableWhatsappNotification = config['enableWhatsapp'] == true;
+      final provider = config['whatsappProvider'];
+      _whatsappProvider = provider is int
+          ? provider
+          : (provider as num?)?.toInt() ?? WhatsAppChannel.openwa;
       notifyListeners();
     }
   }
@@ -102,6 +109,7 @@ class AdminController extends ChangeNotifier {
     String? phone,
     bool? enableSms,
     bool? enableWhatsapp,
+    int? whatsappProvider,
   }) async {
     if (phone != null && phone.isNotEmpty) {
       if (!AdminSettingsService.isValidPhoneNumber(phone)) {
@@ -118,11 +126,13 @@ class AdminController extends ChangeNotifier {
         phone: phone ?? _smsPhoneNumber ?? '',
         enableSms: enableSms ?? _enableSmsNotification,
         enableWhatsapp: enableWhatsapp ?? _enableWhatsappNotification,
+        whatsappProvider: whatsappProvider ?? _whatsappProvider,
       );
 
       if (phone != null) _smsPhoneNumber = phone;
       if (enableSms != null) _enableSmsNotification = enableSms;
       if (enableWhatsapp != null) _enableWhatsappNotification = enableWhatsapp;
+      if (whatsappProvider != null) _whatsappProvider = whatsappProvider;
       _phoneError = null;
       notifyListeners();
     } catch (e) {

--- a/packages/flipper_dashboard/lib/features/admin/controllers/admin_controller.dart
+++ b/packages/flipper_dashboard/lib/features/admin/controllers/admin_controller.dart
@@ -12,6 +12,7 @@ class AdminController extends ChangeNotifier {
   bool _switchToCloudSync = false;
   String? _smsPhoneNumber;
   bool _enableSmsNotification = false;
+  bool _enableWhatsappNotification = false;
   String? _phoneError;
 
   // Getters
@@ -24,6 +25,7 @@ class AdminController extends ChangeNotifier {
   bool get switchToCloudSync => _switchToCloudSync;
   String? get smsPhoneNumber => _smsPhoneNumber;
   bool get enableSmsNotification => _enableSmsNotification;
+  bool get enableWhatsappNotification => _enableWhatsappNotification;
   String? get phoneError => _phoneError;
 
   AdminController() {
@@ -48,7 +50,8 @@ class AdminController extends ChangeNotifier {
     final config = await AdminSettingsService.loadSmsConfig();
     if (config != null) {
       _smsPhoneNumber = config['smsPhoneNumber'];
-      _enableSmsNotification = config['enableOrderNotification'];
+      _enableSmsNotification = config['enableSms'] == true;
+      _enableWhatsappNotification = config['enableWhatsapp'] == true;
       notifyListeners();
     }
   }
@@ -95,7 +98,11 @@ class AdminController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> updateSmsConfig({String? phone, bool? enable}) async {
+  Future<void> updateSmsConfig({
+    String? phone,
+    bool? enableSms,
+    bool? enableWhatsapp,
+  }) async {
     if (phone != null && phone.isNotEmpty) {
       if (!AdminSettingsService.isValidPhoneNumber(phone)) {
         _phoneError =
@@ -109,11 +116,13 @@ class AdminController extends ChangeNotifier {
     try {
       await AdminSettingsService.updateSmsConfig(
         phone: phone ?? _smsPhoneNumber ?? '',
-        enable: enable ?? _enableSmsNotification,
+        enableSms: enableSms ?? _enableSmsNotification,
+        enableWhatsapp: enableWhatsapp ?? _enableWhatsappNotification,
       );
 
       if (phone != null) _smsPhoneNumber = phone;
-      if (enable != null) _enableSmsNotification = enable;
+      if (enableSms != null) _enableSmsNotification = enableSms;
+      if (enableWhatsapp != null) _enableWhatsappNotification = enableWhatsapp;
       _phoneError = null;
       notifyListeners();
     } catch (e) {

--- a/packages/flipper_dashboard/lib/features/admin/screens/admin_screen.dart
+++ b/packages/flipper_dashboard/lib/features/admin/screens/admin_screen.dart
@@ -8,6 +8,7 @@ import 'package:flipper_services/proxy.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:stacked_services/stacked_services.dart';
+import 'package:supabase_models/brick/models/branch_sms_config.model.dart';
 
 import '../controllers/admin_controller.dart';
 import '../widgets/settings_card.dart';
@@ -250,9 +251,94 @@ class _AdminScreenContent extends StatelessWidget {
                     context.flipperL10n.receiveWhatsappNotificationsForOrders,
                   ),
                   value: controller.enableWhatsappNotification,
-                  onChanged: (value) =>
-                      controller.updateSmsConfig(enableWhatsapp: value),
+                  onChanged: (value) async {
+                    if (!value) {
+                      await controller.updateSmsConfig(enableWhatsapp: false);
+                      return;
+                    }
+                    final channel = await showDialog<int>(
+                      context: context,
+                      builder: (ctx) {
+                        var selected = controller.whatsappProvider ==
+                                WhatsAppChannel.meta
+                            ? WhatsAppChannel.meta
+                            : WhatsAppChannel.openwa;
+                        return StatefulBuilder(
+                          builder: (ctx, setDialogState) {
+                            return AlertDialog(
+                              title: const Text('WhatsApp channel'),
+                              content: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  RadioListTile<int>(
+                                    title: const Text('OpenWA'),
+                                    subtitle: const Text('Channel 1'),
+                                    value: WhatsAppChannel.openwa,
+                                    groupValue: selected,
+                                    onChanged: (v) {
+                                      if (v == null) return;
+                                      setDialogState(() => selected = v);
+                                    },
+                                  ),
+                                  RadioListTile<int>(
+                                    title: const Text('Meta Cloud API'),
+                                    subtitle: const Text('Channel 2'),
+                                    value: WhatsAppChannel.meta,
+                                    groupValue: selected,
+                                    onChanged: (v) {
+                                      if (v == null) return;
+                                      setDialogState(() => selected = v);
+                                    },
+                                  ),
+                                ],
+                              ),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.of(ctx).pop(),
+                                  child: const Text('Cancel'),
+                                ),
+                                FilledButton(
+                                  onPressed: () =>
+                                      Navigator.of(ctx).pop(selected),
+                                  child: const Text('Save'),
+                                ),
+                              ],
+                            );
+                          },
+                        );
+                      },
+                    );
+                    if (channel == null) return;
+                    await controller.updateSmsConfig(
+                      enableWhatsapp: true,
+                      whatsappProvider: channel,
+                    );
+                  },
                 ),
+                if (controller.enableWhatsappNotification)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                    child: SegmentedButton<int>(
+                      segments: const [
+                        ButtonSegment<int>(
+                          value: WhatsAppChannel.openwa,
+                          label: Text('OpenWA'),
+                        ),
+                        ButtonSegment<int>(
+                          value: WhatsAppChannel.meta,
+                          label: Text('Meta'),
+                        ),
+                      ],
+                      selected: {
+                        controller.whatsappProvider == WhatsAppChannel.meta
+                            ? WhatsAppChannel.meta
+                            : WhatsAppChannel.openwa,
+                      },
+                      onSelectionChanged: (set) {
+                        controller.updateSmsConfig(whatsappProvider: set.first);
+                      },
+                    ),
+                  ),
               ],
             ),
           ),

--- a/packages/flipper_dashboard/lib/features/admin/screens/admin_screen.dart
+++ b/packages/flipper_dashboard/lib/features/admin/screens/admin_screen.dart
@@ -237,9 +237,21 @@ class _AdminScreenContent extends StatelessWidget {
                 const SizedBox(height: 16),
                 SwitchListTile.adaptive(
                   title: Text(context.flipperL10n.enableSmsNotifications),
+                  subtitle: Text(
+                    context.flipperL10n.receiveSmsNotificationsForOrders,
+                  ),
                   value: controller.enableSmsNotification,
                   onChanged: (value) =>
-                      controller.updateSmsConfig(enable: value),
+                      controller.updateSmsConfig(enableSms: value),
+                ),
+                SwitchListTile.adaptive(
+                  title: Text(context.flipperL10n.enableWhatsappNotifications),
+                  subtitle: Text(
+                    context.flipperL10n.receiveWhatsappNotificationsForOrders,
+                  ),
+                  value: controller.enableWhatsappNotification,
+                  onChanged: (value) =>
+                      controller.updateSmsConfig(enableWhatsapp: value),
                 ),
               ],
             ),

--- a/packages/flipper_dashboard/lib/features/admin/services/admin_settings_service.dart
+++ b/packages/flipper_dashboard/lib/features/admin/services/admin_settings_service.dart
@@ -66,6 +66,7 @@ class AdminSettingsService {
           'smsPhoneNumber': config.smsPhoneNumber,
           'enableSms': config.enableSms,
           'enableWhatsapp': config.enableWhatsapp,
+          'whatsappProvider': config.whatsappProvider,
         };
       }
       return null;
@@ -79,12 +80,14 @@ class AdminSettingsService {
     required String phone,
     required bool enableSms,
     required bool enableWhatsapp,
+    int? whatsappProvider,
   }) async {
     await SmsNotificationService.updateBranchSmsConfig(
       branchId: ProxyService.box.getBranchId()!,
       smsPhoneNumber: phone,
       enableSms: enableSms,
       enableWhatsapp: enableWhatsapp,
+      whatsappProvider: whatsappProvider,
     );
   }
 

--- a/packages/flipper_dashboard/lib/features/admin/services/admin_settings_service.dart
+++ b/packages/flipper_dashboard/lib/features/admin/services/admin_settings_service.dart
@@ -64,7 +64,8 @@ class AdminSettingsService {
       if (config != null) {
         return {
           'smsPhoneNumber': config.smsPhoneNumber,
-          'enableOrderNotification': config.enableOrderNotification,
+          'enableSms': config.enableSms,
+          'enableWhatsapp': config.enableWhatsapp,
         };
       }
       return null;
@@ -76,12 +77,14 @@ class AdminSettingsService {
 
   static Future<void> updateSmsConfig({
     required String phone,
-    required bool enable,
+    required bool enableSms,
+    required bool enableWhatsapp,
   }) async {
     await SmsNotificationService.updateBranchSmsConfig(
       branchId: ProxyService.box.getBranchId()!,
       smsPhoneNumber: phone,
-      enableNotification: enable,
+      enableSms: enableSms,
+      enableWhatsapp: enableWhatsapp,
     );
   }
 

--- a/packages/flipper_dashboard/lib/features/tickets/providers/handover_staff_provider.dart
+++ b/packages/flipper_dashboard/lib/features/tickets/providers/handover_staff_provider.dart
@@ -2,6 +2,7 @@ import 'package:flipper_dashboard/transaction_report_cashier_profile.dart';
 import 'package:flipper_dashboard/transaction_report_cashier_utils.dart';
 import 'package:flipper_models/view_models/flipperBaseModel.dart';
 import 'package:flipper_services/constants.dart';
+import 'package:flipper_services/data_connector_url.dart';
 import 'package:flipper_services/proxy.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -130,14 +131,5 @@ String? _normalizeHandoverPhone(String? raw) {
 }
 
 /// Resolves data-connector URL from cached EBM/box settings.
-Future<String?> resolveOrderFormDataConnectorUrl() async {
-  try {
-    final branchId = ProxyService.box.getBranchId();
-    if (branchId != null && branchId.isNotEmpty) {
-      final ebm = await ProxyService.strategy.ebm(branchId: branchId);
-      final url = ebm?.dataConnectorUrl?.trim();
-      if (url != null && url.isNotEmpty) return url;
-    }
-  } catch (_) {}
-  return ProxyService.box.readString(key: 'dataConnectorUrl');
-}
+Future<String?> resolveOrderFormDataConnectorUrl() =>
+    resolveEbmDataConnectorUrl();

--- a/packages/flipper_dashboard/lib/features/tickets/widgets/tickets_list.dart
+++ b/packages/flipper_dashboard/lib/features/tickets/widgets/tickets_list.dart
@@ -1073,6 +1073,11 @@ mixin TicketsListMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> {
           'Order form · Ticket #$refLabel · ${customer.isEmpty ? 'Walk-in' : customer}';
 
       final dataConnectorUrl = await resolveOrderFormDataConnectorUrl();
+      if (dataConnectorUrl == null || dataConnectorUrl.trim().isEmpty) {
+        throw OrderFormWhatsAppException(
+          'Ebm.dataConnectorUrl is not configured (taxServerUrl is not used for WhatsApp)',
+        );
+      }
       final client = await createOrderFormWhatsAppClient(
         dataConnectorUrl: dataConnectorUrl,
       );

--- a/packages/flipper_dashboard/lib/flipper_app.dart
+++ b/packages/flipper_dashboard/lib/flipper_app.dart
@@ -250,10 +250,10 @@ class _AppLifecycleObserver extends WidgetsBindingObserver {
     if (state == AppLifecycleState.resumed) {
       onResumed();
     } else if (state == AppLifecycleState.detached) {
-      // Clean up global event bus on app shutdown
+      // Clean up while Dart FFI is still alive — native Ditto threads must not
+      // outlive closed callbacks after isolate teardown / hot restart.
       EventBus().dispose();
-      // Also dispose of Ditto singleton to ensure proper cleanup
-      _cleanupDitto();
+      unawaited(_cleanupDitto());
     }
   }
 
@@ -261,9 +261,9 @@ class _AppLifecycleObserver extends WidgetsBindingObserver {
   Future<void> _cleanupDitto() async {
     try {
       await DittoSingleton.instance.dispose();
-      print('✅ Ditto singleton disposed on app shutdown');
+      debugPrint('✅ Ditto singleton disposed on app shutdown');
     } catch (e) {
-      print('⚠️ Error disposing Ditto singleton on app shutdown: $e');
+      debugPrint('⚠️ Error disposing Ditto singleton on app shutdown: $e');
     }
   }
 }

--- a/packages/flipper_dashboard/lib/mixins/previewCart.dart
+++ b/packages/flipper_dashboard/lib/mixins/previewCart.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:flipper_dashboard/utils/ebm_receipt_gate.dart';
 import 'package:flipper_dashboard/utils/sale_completion_budget.dart';
 import 'package:flipper_models/helperModels/sale_cart_qty_rows.dart';
 import 'package:flipper_models/helperModels/sale_completion_helpers.dart';
@@ -1619,7 +1620,17 @@ mixin PreviewCartMixin<T extends ConsumerStatefulWidget>
         transaction.customerTin = effectiveTin.isEmpty ? null : effectiveTin;
       }
 
-      if (effectiveTin.isNotEmpty) {
+      // A purchase code only exists to attach a buyer's RRA order code to a
+      // signed EBM receipt. [finalizePayment] drops [purchaseCode] on the floor
+      // whenever EBM will not sign (non-VAT business, no tax server, tax
+      // service stopped) — see [addFieldIfCondition], which also needs a
+      // non-null purchaseCode before it writes custTin/prcOrdCd. So a non-VAT
+      // business must never see this dialog: it demands a code they do not have
+      // (the field is `required`) and Cancel aborts the whole sale.
+      final needsPurchaseCode =
+          effectiveTin.isNotEmpty && await ebmWillSignReceipt();
+
+      if (needsPurchaseCode) {
         // Show dialog and capture whether the dialog completed successfully
         final bool? dialogResult =
             await additionalInformationIsRequiredToCompleteTransaction(

--- a/packages/flipper_dashboard/lib/providers/digital_receipt_provider.dart
+++ b/packages/flipper_dashboard/lib/providers/digital_receipt_provider.dart
@@ -4,15 +4,18 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-/// Whether the active branch has SMS notifications enabled in admin settings.
+/// Whether the active branch has SMS and/or WhatsApp notifications enabled.
 final branchSmsNotificationsEnabledProvider = FutureProvider<bool>((ref) async {
   final branchId = ProxyService.box.getBranchId();
   if (branchId == null || branchId.isEmpty) return false;
-  final config = await SmsNotificationService.getBranchSmsConfig(branchId);
-  return config?.enableOrderNotification ?? false;
+  final config = await SmsNotificationService.getBranchSmsConfig(
+    branchId,
+    forceRemote: true,
+  );
+  return config?.hasAnyChannelEnabled ?? false;
 });
 
-/// Quick-selling checkout: when true, receipt is sent digitally (SMS) instead of opening a PDF.
+/// Quick-selling checkout: when true, receipt is sent digitally instead of opening a PDF.
 final digitalReceiptToggleProvider = StateProvider<bool>((ref) => false);
 
 /// Resets the digital receipt toggle for the next sale (default: off).

--- a/packages/flipper_dashboard/lib/utils/ebm_receipt_gate.dart
+++ b/packages/flipper_dashboard/lib/utils/ebm_receipt_gate.dart
@@ -1,0 +1,36 @@
+import 'package:flipper_models/SyncStrategy.dart';
+import 'package:flipper_models/helperModels/talker.dart';
+import 'package:flipper_services/proxy.dart';
+
+/// Whether EBM/RRA will actually sign a receipt for the current branch.
+///
+/// Mirrors the gate `finalizePayment` applies before calling
+/// `handleReceiptGeneration`: VAT must be enabled on the branch EBM record, a
+/// tax server must be configured, the device must have a `bhfId`, and the tax
+/// service must not be stopped.
+///
+/// Callers use this to avoid asking for EBM-only input (a purchase code) from a
+/// business whose sale will never reach RRA. On any failure this returns
+/// `false` — the sale still completes, it just is not blocked on that input.
+Future<bool> ebmWillSignReceipt() async {
+  try {
+    final businessId = ProxyService.box.getBusinessId();
+    final branchId = ProxyService.box.getBranchId();
+    if (businessId == null || branchId == null) return false;
+    if (ProxyService.box.stopTaxService() ?? false) return false;
+    if ((await ProxyService.box.bhfId()) == null) return false;
+
+    final capella = ProxyService.getStrategy(Strategy.capella);
+    final taxEnabled = await capella.isTaxEnabled(
+      businessId: businessId,
+      branchId: branchId,
+    );
+    if (!taxEnabled) return false;
+
+    final ebm = await capella.ebm(branchId: branchId);
+    return ebm?.taxServerUrl != null;
+  } catch (e, s) {
+    talker.error('Failed to resolve EBM receipt-signing state', e, s);
+    return false;
+  }
+}

--- a/packages/flipper_dashboard/lib/widgets/app_icons_grid.dart
+++ b/packages/flipper_dashboard/lib/widgets/app_icons_grid.dart
@@ -155,6 +155,9 @@ class AppIconsGrid extends ConsumerWidget {
       if (app['feature'] == 'Orders') return true;
       if (app['feature'] == 'ServicesGigs') return true;
       if (app['feature'] == 'Settings') return true;
+      // See dashboardAppTileVisible: 'Credits' is an account-level top-up with
+      // no Access grant behind it, so it must not go through featureAccess.
+      if (app['feature'] == 'Credits') return true;
       if (app['feature'] == 'AgentCommission') return showCommission;
       final feature = app['feature'] as String;
       // The Tickets screen also hosts the Review Queue and Record Handover

--- a/packages/flipper_dashboard/lib/widgets/dashboard_all_apps_catalog.dart
+++ b/packages/flipper_dashboard/lib/widgets/dashboard_all_apps_catalog.dart
@@ -40,6 +40,13 @@ List<DashboardAllAppSection> dashboardAllAppsCatalog(BuildContext context) => [
         icon: FluentIcons.book_24_regular,
         color: Color(0xFF2563EB),
       ),
+      DashboardAllAppTile(
+        page: 'Credits',
+        label: 'Credits',
+        icon: FluentIcons.wallet_credit_card_24_regular,
+        color: Color(0xFFF59E0B),
+        feature: 'Credits',
+      ),
     ],
   ),
   DashboardAllAppSection(

--- a/packages/flipper_dashboard/lib/widgets/dashboard_app_access.dart
+++ b/packages/flipper_dashboard/lib/widgets/dashboard_app_access.dart
@@ -18,6 +18,10 @@ bool dashboardAppTileVisible(WidgetRef ref, DashboardAllAppTile tile) {
   if (tile.feature == 'Orders') return true;
   if (tile.feature == 'ServicesGigs') return true;
   if (tile.feature == 'Settings') return true;
+  // Credits is an account-level MoMo top-up, not a staff permission. It is not
+  // in [AppFeature] and no code path grants an Access row for it, so gating it
+  // on featureAccessProvider hid the tile from everyone. Always visible.
+  if (tile.feature == 'Credits') return true;
   if (tile.feature == 'AgentCommission') {
     return ref.watch(showAgentCommissionNavProvider);
   }

--- a/packages/flipper_dashboard/lib/widgets/whatsapp_meta_opt_in_dialog.dart
+++ b/packages/flipper_dashboard/lib/widgets/whatsapp_meta_opt_in_dialog.dart
@@ -1,0 +1,291 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flipper_services/digital_receipt_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+/// Well-designed POS dialog: customer scans to open WhatsApp and message the
+/// business so Meta can deliver the queued digital receipt.
+Future<void> showWhatsAppMetaOptInDialog(
+  BuildContext context,
+  WhatsAppOptInPrompt prompt,
+) {
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => WhatsAppMetaOptInDialog(prompt: prompt),
+  );
+}
+
+class WhatsAppMetaOptInDialog extends StatelessWidget {
+  const WhatsAppMetaOptInDialog({super.key, required this.prompt});
+
+  final WhatsAppOptInPrompt prompt;
+
+  static const _waGreen = Color(0xFF128C7E);
+  static const _waGreenDark = Color(0xFF075E54);
+  static const _surface = Color(0xFFF7F8FA);
+
+  Uint8List? get _qrBytes {
+    final b64 = prompt.qrPngBase64?.trim();
+    if (b64 == null || b64.isEmpty) return null;
+    try {
+      return base64Decode(b64);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final chatUrl = prompt.chatUrl?.trim();
+    final qrBytes = _qrBytes;
+    final hasQrData =
+        (chatUrl != null && chatUrl.isNotEmpty) || qrBytes != null;
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: Material(
+          color: Colors.white,
+          elevation: 12,
+          shadowColor: Colors.black26,
+          borderRadius: BorderRadius.circular(20),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.fromLTRB(24, 28, 24, 22),
+                decoration: const BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [_waGreenDark, _waGreen],
+                  ),
+                ),
+                child: Column(
+                  children: [
+                    Container(
+                      width: 56,
+                      height: 56,
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.18),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.chat_bubble_outline_rounded,
+                        color: Colors.white,
+                        size: 28,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Scan to receive receipt',
+                      textAlign: TextAlign.center,
+                      style: GoogleFonts.outfit(
+                        color: Colors.white,
+                        fontSize: 22,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: -0.3,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Customer must message your WhatsApp business number '
+                      'once so we can send their digital receipt.',
+                      textAlign: TextAlign.center,
+                      style: GoogleFonts.outfit(
+                        color: Colors.white.withValues(alpha: 0.92),
+                        fontSize: 14,
+                        height: 1.4,
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 24, 24, 8),
+                child: Column(
+                  children: [
+                    if (hasQrData)
+                      Container(
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: _surface,
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(color: const Color(0xFFE5E7EB)),
+                        ),
+                        child: Column(
+                          children: [
+                            if (qrBytes != null)
+                              ClipRRect(
+                                borderRadius: BorderRadius.circular(8),
+                                child: Image.memory(
+                                  qrBytes,
+                                  width: 220,
+                                  height: 220,
+                                  fit: BoxFit.contain,
+                                  gaplessPlayback: true,
+                                ),
+                              )
+                            else if (chatUrl != null && chatUrl.isNotEmpty)
+                              QrImageView(
+                                data: chatUrl,
+                                version: QrVersions.auto,
+                                size: 220,
+                                backgroundColor: Colors.white,
+                                eyeStyle: const QrEyeStyle(
+                                  eyeShape: QrEyeShape.square,
+                                  color: _waGreenDark,
+                                ),
+                                dataModuleStyle: const QrDataModuleStyle(
+                                  dataModuleShape: QrDataModuleShape.square,
+                                  color: Color(0xFF111827),
+                                ),
+                              ),
+                            const SizedBox(height: 12),
+                            Text(
+                              'Open WhatsApp → scan with the camera',
+                              textAlign: TextAlign.center,
+                              style: GoogleFonts.outfit(
+                                fontSize: 13,
+                                color: const Color(0xFF6B7280),
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ],
+                        ),
+                      )
+                    else
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFFFFF7ED),
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(color: const Color(0xFFFED7AA)),
+                        ),
+                        child: Text(
+                          'Receipt is queued. Ask the customer to message your '
+                          'WhatsApp business number, then the PDF will send '
+                          'automatically.',
+                          style: GoogleFonts.outfit(
+                            fontSize: 14,
+                            height: 1.4,
+                            color: const Color(0xFF9A3412),
+                          ),
+                        ),
+                      ),
+                    if (chatUrl != null && chatUrl.isNotEmpty) ...[
+                      const SizedBox(height: 16),
+                      InkWell(
+                        onTap: () async {
+                          await Clipboard.setData(ClipboardData(text: chatUrl));
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                'WhatsApp link copied',
+                                style: GoogleFonts.outfit(),
+                              ),
+                              behavior: SnackBarBehavior.floating,
+                              duration: const Duration(seconds: 2),
+                            ),
+                          );
+                        },
+                        borderRadius: BorderRadius.circular(10),
+                        child: Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 10,
+                          ),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFF0FDF4),
+                            borderRadius: BorderRadius.circular(10),
+                            border: Border.all(color: const Color(0xFFBBF7D0)),
+                          ),
+                          child: Row(
+                            children: [
+                              const Icon(
+                                Icons.link_rounded,
+                                size: 18,
+                                color: _waGreen,
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  chatUrl,
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: GoogleFonts.outfit(
+                                    fontSize: 12,
+                                    color: _waGreenDark,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 6),
+                              Text(
+                                'Copy',
+                                style: GoogleFonts.outfit(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                  color: _waGreen,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 8),
+                    Text(
+                      'Receipt phone: ${prompt.phone}',
+                      style: GoogleFonts.outfit(
+                        fontSize: 12,
+                        color: const Color(0xFF9CA3AF),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 8, 24, 24),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: _waGreenDark,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                    child: Text(
+                      'Done',
+                      style: GoogleFonts.outfit(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flipper_dashboard/test/ebm_receipt_gate_test.dart
+++ b/packages/flipper_dashboard/test/ebm_receipt_gate_test.dart
@@ -1,0 +1,129 @@
+import 'package:flipper_dashboard/utils/ebm_receipt_gate.dart';
+import 'package:flipper_models/DatabaseSyncInterface.dart';
+import 'package:flipper_models/SyncStrategy.dart';
+import 'package:flipper_models/db_model_export.dart';
+import 'package:flipper_services/FirebaseCrashlyticService.dart';
+import 'package:flipper_services/locator.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_models/brick/repository/storage.dart';
+
+// Deliberately does not import `test_helpers/mocks.dart`: that pulls in
+// `flipper_services/local_notification_service.dart`, which currently fails to
+// compile against the resolved `flutter_local_notifications`.
+class _MockCapella extends Mock implements DatabaseSyncInterface {}
+
+class MockBox extends Mock implements LocalStorage {
+  @override
+  String defaultCurrency() => 'USD';
+}
+
+class MockSyncStrategy extends Mock implements SyncStrategy {}
+
+const _businessId = 'biz-1';
+const _branchId = 'branch-1';
+
+/// Guards the purchase-code prompt in [PreviewCartMixin]: a business whose sale
+/// never reaches RRA must not be asked for an EBM purchase code.
+void main() {
+  late _MockCapella capella;
+  late MockBox box;
+  late MockSyncStrategy strategy;
+
+  Ebm _ebm({String? taxServerUrl = 'https://ebm.example'}) => Ebm(
+    bhfId: '00',
+    tinNumber: 123456789,
+    dvcSrlNo: 'dvc',
+    businessId: _businessId,
+    branchId: _branchId,
+    mrc: 'mrc',
+    taxServerUrl: taxServerUrl,
+  );
+
+  setUp(() async {
+    await getIt.reset();
+
+    capella = _MockCapella();
+    box = MockBox();
+    strategy = MockSyncStrategy();
+
+    getIt.registerSingleton<LocalStorage>(box);
+    getIt.registerSingleton<Crash>(CrashlitycsTalkerObserverUnsupported());
+    getIt.registerSingleton<SyncStrategy>(strategy, instanceName: 'strategy');
+
+    when(() => strategy.getStrategy(Strategy.capella)).thenReturn(capella);
+
+    // Happy path: EBM-registered, VAT-enabled branch with a tax server.
+    when(() => box.getBusinessId()).thenReturn(_businessId);
+    when(() => box.getBranchId()).thenReturn(_branchId);
+    when(() => box.stopTaxService()).thenReturn(false);
+    when(() => box.bhfId()).thenAnswer((_) async => '00');
+    when(
+      () => capella.isTaxEnabled(
+        businessId: _businessId,
+        branchId: _branchId,
+      ),
+    ).thenAnswer((_) async => true);
+    when(
+      () => capella.ebm(branchId: _branchId),
+    ).thenAnswer((_) async => _ebm());
+  });
+
+  test('signs for a VAT-enabled branch with a tax server', () async {
+    expect(await ebmWillSignReceipt(), isTrue);
+  });
+
+  test('does not sign for a non-VAT business', () async {
+    when(
+      () => capella.isTaxEnabled(
+        businessId: _businessId,
+        branchId: _branchId,
+      ),
+    ).thenAnswer((_) async => false);
+
+    expect(await ebmWillSignReceipt(), isFalse);
+  });
+
+  test('does not sign when the branch has no tax server url', () async {
+    when(
+      () => capella.ebm(branchId: _branchId),
+    ).thenAnswer((_) async => _ebm(taxServerUrl: null));
+
+    expect(await ebmWillSignReceipt(), isFalse);
+  });
+
+  test('does not sign when there is no EBM record for the branch', () async {
+    when(() => capella.ebm(branchId: _branchId)).thenAnswer((_) async => null);
+
+    expect(await ebmWillSignReceipt(), isFalse);
+  });
+
+  test('does not sign while the tax service is stopped', () async {
+    when(() => box.stopTaxService()).thenReturn(true);
+
+    expect(await ebmWillSignReceipt(), isFalse);
+  });
+
+  test('does not sign when the device has no bhfId', () async {
+    when(() => box.bhfId()).thenAnswer((_) async => null);
+
+    expect(await ebmWillSignReceipt(), isFalse);
+  });
+
+  test('does not sign when branch id is missing', () async {
+    when(() => box.getBranchId()).thenReturn(null);
+
+    expect(await ebmWillSignReceipt(), isFalse);
+  });
+
+  test('does not sign when the tax-enabled lookup throws', () async {
+    when(
+      () => capella.isTaxEnabled(
+        businessId: _businessId,
+        branchId: _branchId,
+      ),
+    ).thenThrow(Exception('ditto unavailable'));
+
+    expect(await ebmWillSignReceipt(), isFalse);
+  });
+}

--- a/packages/flipper_dashboard/test/pos_cart_display_suppression_test.dart
+++ b/packages/flipper_dashboard/test/pos_cart_display_suppression_test.dart
@@ -84,6 +84,44 @@ class _ReconHarness extends ConsumerWidget {
   }
 }
 
+/// Primes the cart to [ticket] exactly once — the resume / till-collect entry
+/// point ([_resumeOrder] in tickets_list.dart) — then renders the cart count.
+class _PrimeOnceHarness extends ConsumerStatefulWidget {
+  const _PrimeOnceHarness({required this.ticket});
+
+  final ITransaction ticket;
+
+  @override
+  ConsumerState<_PrimeOnceHarness> createState() => _PrimeOnceHarnessState();
+}
+
+class _PrimeOnceHarnessState extends ConsumerState<_PrimeOnceHarness> {
+  bool _primed = false;
+
+  // Not initState: WidgetRef.container reads an inherited widget, which is only
+  // legal once dependencies are available.
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_primed) return;
+    _primed = true;
+    primePosCartForTransactionWidget(
+      ref,
+      isExpense: false,
+      transaction: widget.ticket,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lines = ref.watch(posCartDisplayItemsProvider);
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Text('count:${lines.length}'),
+    );
+  }
+}
+
 void main() {
   late TestEnvironment env;
 
@@ -175,6 +213,281 @@ void main() {
     await tester.pump();
 
     expect(find.text('count:1'), findsOneWidget);
+  });
+
+  // A resumed parked ticket pins the cart to it (primePosCartForTransaction).
+  // The pin outranks the pending-cart cache in
+  // posCartPendingTransactionIdProvider and — unlike that cache — is never
+  // re-validated against the transaction's status, so a pin left behind on a
+  // completed sale keeps resolving the cart to its (still active) lines. That is
+  // the "cart never cleared until I restarted the app" report: the pin provider
+  // is not autoDispose, so only a relaunch drops it.
+  group('stale cart pin on a completed sale', () {
+    const nextBranchId = _branchId;
+
+    ProviderContainer containerForSoldAndNext({
+      required ITransaction sold,
+      required List<TransactionItem> soldItems,
+      required ITransaction next,
+    }) {
+      return ProviderContainer(
+        overrides: [
+          // Completion primes the cache with the *next* pending cart.
+          cachedPendingCartTransactionProvider(false)
+              .overrideWith((ref) => next),
+          pendingTransactionStreamProvider(isExpense: false)
+              .overrideWith((ref) => Stream<ITransaction>.value(next)),
+          transactionItemsStreamProvider(
+            transactionId: sold.id,
+            branchId: nextBranchId,
+          ).overrideWith((ref) => Stream<List<TransactionItem>>.value(soldItems)),
+          transactionItemsStreamProvider(
+            transactionId: next.id,
+            branchId: nextBranchId,
+          ).overrideWith(
+            (ref) => Stream<List<TransactionItem>>.value(const []),
+          ),
+        ],
+      );
+    }
+
+    testWidgets(
+        'clearing the pin keeps the sold lines away when suppression releases',
+        (tester) async {
+      final sold = _pendingTxn('txn-sold-1');
+      final next = _pendingTxn('txn-next-1');
+      final container = containerForSoldAndNext(
+        sold: sold,
+        soldItems: [_item('a', sold.id), _item('b', sold.id)],
+        next: next,
+      );
+      addTearDown(container.dispose);
+
+      // Resume pinned the cart to the ticket now being sold.
+      container.read(pinnedPosCartTransactionIdProvider.notifier).state =
+          sold.id;
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const _CartCountHarness(),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('count:2'), findsOneWidget);
+
+      // Sale completes: suppress the sold id and drop its now-stale pin.
+      container.read(suppressedCartTransactionIdProvider.notifier).state =
+          sold.id;
+      expect(
+        clearPinnedPosCartTransactionIfContainer(
+          container,
+          transactionId: sold.id,
+        ),
+        isTrue,
+        reason: 'the pin still pointed at the sold transaction',
+      );
+      await tester.pump();
+      expect(find.text('count:0'), findsOneWidget);
+
+      // Completion releases suppression once the next pending cart is bound.
+      container.read(suppressedCartTransactionIdProvider.notifier).state = null;
+      await tester.pump();
+
+      expect(
+        find.text('count:0'),
+        findsOneWidget,
+        reason: 'without the pin the cart resolves the empty next pending cart, '
+            'so the sold lines must not come back',
+      );
+    });
+
+    testWidgets('a pin left on the sold sale resurrects its lines',
+        (tester) async {
+      final sold = _pendingTxn('txn-sold-2');
+      final next = _pendingTxn('txn-next-2');
+      final container = containerForSoldAndNext(
+        sold: sold,
+        soldItems: [_item('a', sold.id)],
+        next: next,
+      );
+      addTearDown(container.dispose);
+
+      container.read(pinnedPosCartTransactionIdProvider.notifier).state =
+          sold.id;
+      container.read(suppressedCartTransactionIdProvider.notifier).state =
+          sold.id;
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const _CartCountHarness(),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('count:0'), findsOneWidget);
+
+      // Suppression alone is not enough — this is the regression being guarded.
+      container.read(suppressedCartTransactionIdProvider.notifier).state = null;
+      // Two pumps: suppression short-circuited the provider before it ever
+      // subscribed to the sold items stream, so releasing it starts that
+      // subscription (loading) and the value lands on the following frame.
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        find.text('count:1'),
+        findsOneWidget,
+        reason: 'documents why completion must unwind the pin, not just suppress',
+      );
+    });
+
+    test('the guarded clear leaves an unrelated pin alone', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(pinnedPosCartTransactionIdProvider.notifier).state =
+          'txn-other';
+
+      expect(
+        clearPinnedPosCartTransactionIfContainer(
+          container,
+          transactionId: 'txn-sold-3',
+        ),
+        isFalse,
+      );
+      expect(
+        container.read(pinnedPosCartTransactionIdProvider),
+        'txn-other',
+        reason: 'a pin for another transaction (e.g. mobile checkout) must stay',
+      );
+      expect(
+        clearPinnedPosCartTransactionIfContainer(
+          container,
+          transactionId: '',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  // Resuming a parked ticket makes that ticket both the pinned cart and the
+  // emitted pending row. `syncPendingTransaction` only releases suppression for a
+  // *different* pending id, so suppression left over from the park / send-to-till
+  // that hid the ticket earlier can never be released again — the resumed cart
+  // renders empty until the app restarts. Priming the cart must drop it.
+  group('resuming a suppressed ticket', () {
+    ProviderContainer containerForResumedTicket(
+      ITransaction ticket,
+      List<TransactionItem> items,
+    ) {
+      return ProviderContainer(
+        overrides: [
+          // Send-to-till cleared the pending-cart cache; after resume the ticket
+          // is the only PENDING row left for this device+agent.
+          cachedPendingCartTransactionProvider(false).overrideWith((ref) => null),
+          pendingTransactionStreamProvider(isExpense: false)
+              .overrideWith((ref) => Stream<ITransaction>.value(ticket)),
+          transactionItemsStreamProvider(
+            transactionId: ticket.id,
+            branchId: _branchId,
+          ).overrideWith((ref) => Stream<List<TransactionItem>>.value(items)),
+        ],
+      );
+    }
+
+    testWidgets('reconciliation cannot release suppression on the resumed id',
+        (tester) async {
+      final ticket = _pendingTxn('txn-ticket-1');
+      final container = containerForResumedTicket(ticket, [_item('a', ticket.id)]);
+      addTearDown(container.dispose);
+
+      // Left behind by the send-to-till that parked this ticket.
+      container.read(suppressedCartTransactionIdProvider.notifier).state =
+          ticket.id;
+      // Resume pinned the cart to the ticket.
+      container.read(pinnedPosCartTransactionIdProvider.notifier).state =
+          ticket.id;
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const _ReconHarness(),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        container.read(suppressedCartTransactionIdProvider),
+        ticket.id,
+        reason: 'the guard needs a different pending id, so nothing clears it',
+      );
+      expect(
+        container.read(posCartDisplayItemsProvider),
+        isEmpty,
+        reason: 'this is the empty cart after resume that was reported',
+      );
+    });
+
+    testWidgets('priming the cart releases suppression so the lines render',
+        (tester) async {
+      final ticket = _pendingTxn('txn-ticket-2');
+      final container = containerForResumedTicket(ticket, [
+        _item('a', ticket.id),
+        _item('b', ticket.id),
+      ]);
+      addTearDown(container.dispose);
+
+      container.read(suppressedCartTransactionIdProvider.notifier).state =
+          ticket.id;
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: _PrimeOnceHarness(ticket: ticket),
+        ),
+      );
+      // Prime defers to a microtask; let it land and the cart rebuild.
+      await tester.pump();
+      await tester.pump();
+
+      expect(container.read(suppressedCartTransactionIdProvider), isNull);
+      expect(
+        container.read(pinnedPosCartTransactionIdProvider),
+        ticket.id,
+        reason: 'the resumed ticket is still the pinned cart',
+      );
+      expect(find.text('count:2'), findsOneWidget);
+    });
+
+    test('the guarded clear leaves suppression for another sale alone', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(suppressedCartTransactionIdProvider.notifier).state =
+          'txn-just-sold';
+
+      expect(
+        clearSuppressedCartTransactionIfContainer(
+          container,
+          transactionId: 'txn-ticket-3',
+        ),
+        isFalse,
+      );
+      expect(
+        container.read(suppressedCartTransactionIdProvider),
+        'txn-just-sold',
+        reason: 'a sale completed elsewhere must stay suppressed',
+      );
+      expect(
+        clearSuppressedCartTransactionIfContainer(
+          container,
+          transactionId: '',
+        ),
+        isFalse,
+      );
+    });
   });
 
   testWidgets(

--- a/packages/flipper_dashboard/test/transaction_item_table_clear_test.dart
+++ b/packages/flipper_dashboard/test/transaction_item_table_clear_test.dart
@@ -124,6 +124,63 @@ void main() {
     },
   );
 
+  // Park / send-to-till also runs [clearCartLinesOptimistically], and a resumed
+  // ticket comes back with the *same* line ids — unlike the next sale, which
+  // gets fresh ones. The ghost-delete ids must therefore be released when the
+  // cart drains, or resuming the ticket renders an empty cart in
+  // QuickSellingView while every provider correctly resolves to it.
+  testWidgets(
+    "a resumed ticket's lines reappear after park cleared them optimistically",
+    (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          posCartDisplayItemsProvider
+              .overrideWith((ref) => ref.watch(_cartSourceProvider)),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final harnessKey = GlobalKey<CartHarnessState>();
+
+      container.read(_cartSourceProvider.notifier).state = [
+        _line('a'),
+        _line('b'),
+      ];
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: _CartHarness(key: harnessKey),
+        ),
+      );
+      expect(find.text('count:2'), findsOneWidget);
+
+      // Operator sends the cart to the till: the lines are hidden at once.
+      harnessKey.currentState!.clearCartLinesOptimistically();
+      await tester.pump();
+      expect(find.text('count:0'), findsOneWidget);
+
+      // The parked ticket leaves the cart (suppression / next pending cart).
+      container.read(_cartSourceProvider.notifier).state = const [];
+      await tester.pump();
+      expect(find.text('count:0'), findsOneWidget);
+
+      // Resume: the very same lines resolve as the cart again.
+      container.read(_cartSourceProvider.notifier).state = [
+        _line('a'),
+        _line('b'),
+      ];
+      await tester.pump();
+
+      expect(
+        find.text('count:2'),
+        findsOneWidget,
+        reason: 'the resumed ticket must render its lines, not stay filtered by '
+            'the ghost ids from when it was parked',
+      );
+    },
+  );
+
   testWidgets('clearCartLinesOptimistically is a no-op on an empty cart',
       (tester) async {
     final container = ProviderContainer(

--- a/packages/flipper_localize/lib/l10n/app_en.arb
+++ b/packages/flipper_localize/lib/l10n/app_en.arb
@@ -1085,6 +1085,14 @@
     "@enableSmsNotifications": {
         "description": "SMS notification toggle title"
     },
+    "enableWhatsappNotifications": "Enable WhatsApp Notifications",
+    "@enableWhatsappNotifications": {
+        "description": "WhatsApp notification toggle title"
+    },
+    "receiveWhatsappNotificationsForOrders": "Receive WhatsApp notifications for orders and digital receipt PDFs",
+    "@receiveWhatsappNotificationsForOrders": {
+        "description": "WhatsApp notification toggle subtitle"
+    },
     "systemSettings": "System Settings",
     "@systemSettings": {
         "description": "System settings section title"

--- a/packages/flipper_localize/lib/l10n/app_fr.arb
+++ b/packages/flipper_localize/lib/l10n/app_fr.arb
@@ -248,6 +248,8 @@
     "electronicBillingMachineSettings": "Paramètres de la machine de facturation électronique",
     "smsConfiguration": "Configuration SMS",
     "enableSmsNotifications": "Activer les notifications SMS",
+    "enableWhatsappNotifications": "Activer les notifications WhatsApp",
+    "receiveWhatsappNotificationsForOrders": "Recevoir des notifications WhatsApp pour les commandes et les reçus PDF",
     "systemSettings": "Paramètres système",
     "debugMode": "Mode débogage",
     "enableDebugFeatures": "Activer les fonctions de débogage",

--- a/packages/flipper_localize/lib/l10n/app_rw.arb
+++ b/packages/flipper_localize/lib/l10n/app_rw.arb
@@ -248,6 +248,8 @@
     "electronicBillingMachineSettings": "Igenamiterere ry'imashini ya fagitire ya elegitoroniki",
     "smsConfiguration": "Igenamiterere rya SMS",
     "enableSmsNotifications": "Emeza ubutumwa bwa SMS",
+    "enableWhatsappNotifications": "Emeza ubutumwa bwa WhatsApp",
+    "receiveWhatsappNotificationsForOrders": "Kwakira ubutumwa bwa WhatsApp ku byatumijwe n'inyemezabwishyu PDF",
     "systemSettings": "Igenamiterere rya sisitemu",
     "debugMode": "Uburyo bwo kugenzura amakosa",
     "enableDebugFeatures": "Emeza ibikorwa byo kugenzura amakosa",

--- a/packages/flipper_localize/lib/l10n/app_sw.arb
+++ b/packages/flipper_localize/lib/l10n/app_sw.arb
@@ -248,6 +248,8 @@
     "electronicBillingMachineSettings": "Mipangilio ya mashine ya ankara ya kielektroniki",
     "smsConfiguration": "Usanidi wa SMS",
     "enableSmsNotifications": "Wezesha arifa za SMS",
+    "enableWhatsappNotifications": "Wezesha arifa za WhatsApp",
+    "receiveWhatsappNotificationsForOrders": "Pokea arifa za WhatsApp kwa oda na risiti za PDF",
     "systemSettings": "Mipangilio ya mfumo",
     "debugMode": "Hali ya utatuzi",
     "enableDebugFeatures": "Wezesha vipengele vya utatuzi",

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations.dart
@@ -1597,6 +1597,18 @@ abstract class FlipperAppLocalizations {
   /// **'Enable SMS Notifications'**
   String get enableSmsNotifications;
 
+  /// WhatsApp notification toggle title
+  ///
+  /// In en, this message translates to:
+  /// **'Enable WhatsApp Notifications'**
+  String get enableWhatsappNotifications;
+
+  /// WhatsApp notification toggle subtitle
+  ///
+  /// In en, this message translates to:
+  /// **'Receive WhatsApp notifications for orders and digital receipt PDFs'**
+  String get receiveWhatsappNotificationsForOrders;
+
   /// System settings section title
   ///
   /// In en, this message translates to:

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_en.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_en.dart
@@ -846,6 +846,13 @@ class FlipperAppLocalizationsEn extends FlipperAppLocalizations {
   String get enableSmsNotifications => 'Enable SMS Notifications';
 
   @override
+  String get enableWhatsappNotifications => 'Enable WhatsApp Notifications';
+
+  @override
+  String get receiveWhatsappNotificationsForOrders =>
+      'Receive WhatsApp notifications for orders and digital receipt PDFs';
+
+  @override
   String get systemSettings => 'System Settings';
 
   @override

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_fr.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_fr.dart
@@ -863,6 +863,13 @@ class FlipperAppLocalizationsFr extends FlipperAppLocalizations {
   String get enableSmsNotifications => 'Activer les notifications SMS';
 
   @override
+  String get enableWhatsappNotifications => 'Activer les notifications WhatsApp';
+
+  @override
+  String get receiveWhatsappNotificationsForOrders =>
+      'Recevoir des notifications WhatsApp pour les commandes et les reçus PDF';
+
+  @override
   String get systemSettings => 'Paramètres système';
 
   @override

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_rw.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_rw.dart
@@ -854,6 +854,13 @@ class FlipperAppLocalizationsRw extends FlipperAppLocalizations {
   String get enableSmsNotifications => 'Emeza ubutumwa bwa SMS';
 
   @override
+  String get enableWhatsappNotifications => 'Emeza ubutumwa bwa WhatsApp';
+
+  @override
+  String get receiveWhatsappNotificationsForOrders =>
+      'Kwakira ubutumwa bwa WhatsApp ku byatumijwe n\'inyemezabwishyu PDF';
+
+  @override
   String get systemSettings => 'Igenamiterere rya sisitemu';
 
   @override

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_sw.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_sw.dart
@@ -854,6 +854,13 @@ class FlipperAppLocalizationsSw extends FlipperAppLocalizations {
   String get enableSmsNotifications => 'Wezesha arifa za SMS';
 
   @override
+  String get enableWhatsappNotifications => 'Wezesha arifa za WhatsApp';
+
+  @override
+  String get receiveWhatsappNotificationsForOrders =>
+      'Pokea arifa za WhatsApp kwa oda na risiti za PDF';
+
+  @override
   String get systemSettings => 'Mipangilio ya mfumo';
 
   @override

--- a/packages/flipper_models/lib/CoreSync.dart
+++ b/packages/flipper_models/lib/CoreSync.dart
@@ -2182,12 +2182,11 @@ class CoreSync extends AiStrategyImpl
             id: transactionId,
             branchId: ProxyService.box.getBranchId()!,
           );
+      final fileNameWithExtension = '$fileName.pdf';
       if (iTransaction != null) {
         /// never update transaction status here or any other properties
         /// first get transaction as it might be updated by other means
         ///
-        final fileNameWithExtension = fileName + ".pdf";
-
         iTransaction.receiptFileName = fileNameWithExtension;
 
         await ProxyService.getStrategy(Strategy.capella).updateTransaction(
@@ -2208,6 +2207,20 @@ class CoreSync extends AiStrategyImpl
             customerPhone: iTransaction.customerPhone,
             alternatePhone: iTransaction.currentSaleCustomerPhoneNumber,
             alreadySent: iTransaction.isDigitalReceiptGenerated,
+            pdfData: pdfData,
+          ),
+        );
+      } else {
+        talker.warning(
+          'digital receipt: upload ok but Capella transaction $transactionId '
+          'not found — still attempting send with PDF only',
+        );
+        unawaited(
+          DigitalReceiptService.maybeSendAfterUpload(
+            transactionId: transactionId,
+            branchId: branchId,
+            receiptFileName: fileNameWithExtension,
+            pdfData: pdfData,
           ),
         );
       }

--- a/packages/flipper_models/lib/order_form_whatsapp_client.dart
+++ b/packages/flipper_models/lib/order_form_whatsapp_client.dart
@@ -4,13 +4,23 @@ import 'dart:typed_data';
 import 'package:flipper_models/data_connector_http_log.dart';
 import 'package:http/http.dart' as http;
 
-/// Sends an order-form PDF to a stock handover staff member via WhatsApp
-/// (data-connector → OpenWA at whatsapp.yegobox.com).
+/// WhatsApp delivery backends supported by data-connector.
+abstract final class WhatsAppProvider {
+  static const openwa = 'openwa';
+  static const meta = 'meta';
+}
+
+/// Sends text / PDF via data-connector WhatsApp routes.
+///
+/// Pass [provider] per call (or [defaultProvider]) to switch OpenWA vs Meta.
+/// Meta outside the 24h window returns [OrderFormWhatsAppSendResult.needsOptIn]
+/// with [chatUrl] / [qrPngBase64] while the message is queued server-side.
 class OrderFormWhatsAppClient {
   OrderFormWhatsAppClient({
     required this.baseUrl,
     http.Client? httpClient,
     this.logHttp = true,
+    this.defaultProvider,
   }) : _http = httpClient ?? http.Client(),
        _base = baseUrl.endsWith('/') ? baseUrl : '$baseUrl/';
 
@@ -18,19 +28,27 @@ class OrderFormWhatsAppClient {
   final http.Client _http;
   final String _base;
   final bool logHttp;
+  final String? defaultProvider;
 
   static const _jsonHeaders = {'Content-Type': 'application/json'};
 
   Future<OrderFormWhatsAppSendResult> sendText({
     required String phone,
     required String text,
+    String? provider,
   }) async {
     final uri = Uri.parse('${_base}api/whatsapp/send-text');
-    final body = <String, dynamic>{'phone': phone, 'text': text};
+    final body = <String, dynamic>{
+      'phone': phone,
+      'text': text,
+      if (_effectiveProvider(provider) != null)
+        'provider': _effectiveProvider(provider),
+    };
     return _post(
       uri: uri,
       body: body,
-      logBody: '{"phone":"$phone","text":"…"}',
+      logBody:
+          '{"phone":"$phone","text":"…","provider":"${_effectiveProvider(provider) ?? ""}"}',
       operation: 'WhatsApp send-text',
     );
   }
@@ -40,6 +58,7 @@ class OrderFormWhatsAppClient {
     required Uint8List pdfBytes,
     required String filename,
     String? caption,
+    String? provider,
   }) async {
     final uri = Uri.parse('${_base}api/whatsapp/send-document');
     final body = <String, dynamic>{
@@ -48,13 +67,22 @@ class OrderFormWhatsAppClient {
       'filename': filename,
       if (caption != null && caption.trim().isNotEmpty)
         'caption': caption.trim(),
+      if (_effectiveProvider(provider) != null)
+        'provider': _effectiveProvider(provider),
     };
     return _post(
       uri: uri,
       body: body,
-      logBody: '{"phone":"$phone","filename":"$filename","pdf_base64":"…"}',
+      logBody:
+          '{"phone":"$phone","filename":"$filename","provider":"${_effectiveProvider(provider) ?? ""}","pdf_base64":"…"}',
       operation: 'WhatsApp send-document',
     );
+  }
+
+  String? _effectiveProvider(String? perCall) {
+    final raw = (perCall ?? defaultProvider)?.trim();
+    if (raw == null || raw.isEmpty) return null;
+    return raw;
   }
 
   Future<OrderFormWhatsAppSendResult> _post({
@@ -93,35 +121,77 @@ class OrderFormWhatsAppClient {
       );
     }
 
-    if (response.statusCode >= 200 && response.statusCode < 300) {
+    Map<String, dynamic>? decodedMap;
+    try {
       final decoded = jsonDecode(response.body);
       if (decoded is Map) {
-        return OrderFormWhatsAppSendResult(
-          ok: decoded['ok'] == true,
-          messageId:
-              decoded['message_id']?.toString() ??
-              decoded['messageId']?.toString(),
-        );
+        decodedMap = Map<String, dynamic>.from(decoded);
+      }
+    } catch (_) {}
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      if (decodedMap != null) {
+        return OrderFormWhatsAppSendResult.fromJson(decodedMap);
       }
       return const OrderFormWhatsAppSendResult(ok: true);
     }
 
+    // Meta 24h window closed: message queued; show QR / wa.me to the customer.
+    if (response.statusCode == 409 &&
+        decodedMap != null &&
+        decodedMap['needs_opt_in'] == true) {
+      return OrderFormWhatsAppSendResult.fromJson(decodedMap);
+    }
+
     String message = 'WhatsApp send failed (${response.statusCode})';
-    try {
-      final decoded = jsonDecode(response.body);
-      if (decoded is Map && decoded['error'] != null) {
-        message = decoded['error'].toString();
-      }
-    } catch (_) {}
+    if (decodedMap != null && decodedMap['error'] != null) {
+      message = decodedMap['error'].toString();
+    }
     throw OrderFormWhatsAppException(message);
   }
 }
 
 class OrderFormWhatsAppSendResult {
-  const OrderFormWhatsAppSendResult({required this.ok, this.messageId});
+  const OrderFormWhatsAppSendResult({
+    required this.ok,
+    this.messageId,
+    this.provider,
+    this.mediaId,
+    this.needsOptIn = false,
+    this.queued = false,
+    this.queueId,
+    this.chatUrl,
+    this.qrPngBase64,
+    this.error,
+  });
+
+  factory OrderFormWhatsAppSendResult.fromJson(Map<String, dynamic> json) {
+    return OrderFormWhatsAppSendResult(
+      ok: json['ok'] == true,
+      messageId:
+          json['message_id']?.toString() ?? json['messageId']?.toString(),
+      provider: json['provider']?.toString(),
+      mediaId: json['media_id']?.toString() ?? json['mediaId']?.toString(),
+      needsOptIn: json['needs_opt_in'] == true || json['needsOptIn'] == true,
+      queued: json['queued'] == true,
+      queueId: json['queue_id']?.toString() ?? json['queueId']?.toString(),
+      chatUrl: json['chat_url']?.toString() ?? json['chatUrl']?.toString(),
+      qrPngBase64:
+          json['qr_png_base64']?.toString() ?? json['qrPngBase64']?.toString(),
+      error: json['error']?.toString(),
+    );
+  }
 
   final bool ok;
   final String? messageId;
+  final String? provider;
+  final String? mediaId;
+  final bool needsOptIn;
+  final bool queued;
+  final String? queueId;
+  final String? chatUrl;
+  final String? qrPngBase64;
+  final String? error;
 }
 
 class OrderFormWhatsAppException implements Exception {
@@ -131,11 +201,10 @@ class OrderFormWhatsAppException implements Exception {
   String toString() => message;
 }
 
-/// Creates a WhatsApp client aimed at data-connector OpenWA routes.
-///
-/// [dataConnectorUrl] must be [Ebm.dataConnectorUrl] (not [Ebm.taxServerUrl]).
+/// Creates a WhatsApp client aimed at data-connector routes.
 Future<OrderFormWhatsAppClient> createOrderFormWhatsAppClient({
   required String dataConnectorUrl,
+  String? defaultProvider,
 }) async {
   final trimmed = dataConnectorUrl.trim();
   if (trimmed.isEmpty) {
@@ -144,5 +213,8 @@ Future<OrderFormWhatsAppClient> createOrderFormWhatsAppClient({
     );
   }
   final base = trimmed.endsWith('/') ? trimmed : '$trimmed/';
-  return OrderFormWhatsAppClient(baseUrl: base);
+  return OrderFormWhatsAppClient(
+    baseUrl: base,
+    defaultProvider: defaultProvider,
+  );
 }

--- a/packages/flipper_models/lib/order_form_whatsapp_client.dart
+++ b/packages/flipper_models/lib/order_form_whatsapp_client.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:flipper_models/bulk_rra_client.dart';
 import 'package:flipper_models/data_connector_http_log.dart';
 import 'package:http/http.dart' as http;
 
@@ -12,8 +11,8 @@ class OrderFormWhatsAppClient {
     required this.baseUrl,
     http.Client? httpClient,
     this.logHttp = true,
-  })  : _http = httpClient ?? http.Client(),
-        _base = baseUrl.endsWith('/') ? baseUrl : '$baseUrl/';
+  }) : _http = httpClient ?? http.Client(),
+       _base = baseUrl.endsWith('/') ? baseUrl : '$baseUrl/';
 
   final String baseUrl;
   final http.Client _http;
@@ -21,6 +20,20 @@ class OrderFormWhatsAppClient {
   final bool logHttp;
 
   static const _jsonHeaders = {'Content-Type': 'application/json'};
+
+  Future<OrderFormWhatsAppSendResult> sendText({
+    required String phone,
+    required String text,
+  }) async {
+    final uri = Uri.parse('${_base}api/whatsapp/send-text');
+    final body = <String, dynamic>{'phone': phone, 'text': text};
+    return _post(
+      uri: uri,
+      body: body,
+      logBody: '{"phone":"$phone","text":"…"}',
+      operation: 'WhatsApp send-text',
+    );
+  }
 
   Future<OrderFormWhatsAppSendResult> sendDocument({
     required String phone,
@@ -33,16 +46,31 @@ class OrderFormWhatsAppClient {
       'phone': phone,
       'pdf_base64': base64Encode(pdfBytes),
       'filename': filename,
-      if (caption != null && caption.trim().isNotEmpty) 'caption': caption.trim(),
+      if (caption != null && caption.trim().isNotEmpty)
+        'caption': caption.trim(),
     };
+    return _post(
+      uri: uri,
+      body: body,
+      logBody: '{"phone":"$phone","filename":"$filename","pdf_base64":"…"}',
+      operation: 'WhatsApp send-document',
+    );
+  }
+
+  Future<OrderFormWhatsAppSendResult> _post({
+    required Uri uri,
+    required Map<String, dynamic> body,
+    required String logBody,
+    required String operation,
+  }) async {
     final encodedBody = jsonEncode(body);
 
     if (logHttp) {
       DataConnectorHttpLog.request(
         method: 'POST',
         uri: uri,
-        body: '{"phone":"$phone","filename":"$filename","pdf_base64":"…"}',
-        operation: 'order form WhatsApp',
+        body: logBody,
+        operation: operation,
       );
     }
 
@@ -61,7 +89,7 @@ class OrderFormWhatsAppClient {
         statusCode: response.statusCode,
         body: response.body,
         elapsed: started.elapsed,
-        operation: 'order form WhatsApp',
+        operation: operation,
       );
     }
 
@@ -70,7 +98,8 @@ class OrderFormWhatsAppClient {
       if (decoded is Map) {
         return OrderFormWhatsAppSendResult(
           ok: decoded['ok'] == true,
-          messageId: decoded['message_id']?.toString() ??
+          messageId:
+              decoded['message_id']?.toString() ??
               decoded['messageId']?.toString(),
         );
       }
@@ -102,11 +131,18 @@ class OrderFormWhatsAppException implements Exception {
   String toString() => message;
 }
 
+/// Creates a WhatsApp client aimed at data-connector OpenWA routes.
+///
+/// [dataConnectorUrl] must be [Ebm.dataConnectorUrl] (not [Ebm.taxServerUrl]).
 Future<OrderFormWhatsAppClient> createOrderFormWhatsAppClient({
-  String? dataConnectorUrl,
+  required String dataConnectorUrl,
 }) async {
-  final base = await resolveDataConnectorBaseUrl(
-    dataConnectorUrl: dataConnectorUrl,
-  );
+  final trimmed = dataConnectorUrl.trim();
+  if (trimmed.isEmpty) {
+    throw OrderFormWhatsAppException(
+      'Ebm.dataConnectorUrl is required for WhatsApp (do not use taxServerUrl)',
+    );
+  }
+  final base = trimmed.endsWith('/') ? trimmed : '$trimmed/';
   return OrderFormWhatsAppClient(baseUrl: base);
 }

--- a/packages/flipper_models/lib/providers/ditto_presence_provider.dart
+++ b/packages/flipper_models/lib/providers/ditto_presence_provider.dart
@@ -1,7 +1,18 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flipper_web/services/ditto_service.dart';
-import 'package:ditto_live/ditto_live.dart';
+import 'dart:async';
 
+import 'package:ditto_live/ditto_live.dart';
+import 'package:flipper_web/services/ditto_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Live mesh presence for Connected Peers / stock completeness heuristics.
+///
+/// Polls [Presence.graph] instead of [Presence.observe].
+///
+/// In ditto_live 5.x, [PresenceObserver.stop] closes the Dart [NativeCallable]
+/// without clearing the native presence callback first. Riverpod autoDispose
+/// (or hot restart) then races Ditto's tokio thread and aborts with:
+/// `Callback invoked after it has been deleted` (`presence_legacy` c_cb).
+/// Reading [Presence.graph] never registers that FFI callback.
 final dittoPresenceProvider = StreamProvider<PresenceGraph?>((ref) {
   final ditto = DittoService.instance.dittoInstance;
   if (ditto == null) {
@@ -9,14 +20,42 @@ final dittoPresenceProvider = StreamProvider<PresenceGraph?>((ref) {
   }
 
   return Stream.multi((controller) {
-    final observer = ditto.presence.observe((presenceGraph) {
-      if (!controller.isClosed) {
-        controller.add(presenceGraph);
-      }
-    });
+    PresenceGraph? lastEmitted;
+    var hadValue = false;
 
-    controller.onCancel = () {
-      observer.stop();
-    };
+    void emitCurrent() {
+      if (controller.isClosed) return;
+      try {
+        final live = DittoService.instance.dittoInstance;
+        if (live == null || !DittoService.instance.isReady()) {
+          if (hadValue) {
+            hadValue = false;
+            lastEmitted = null;
+            controller.add(null);
+          }
+          return;
+        }
+        final graph = live.presence.graph;
+        if (hadValue && lastEmitted == graph) return;
+        hadValue = true;
+        lastEmitted = graph;
+        controller.add(graph);
+      } catch (_) {
+        if (!controller.isClosed && hadValue) {
+          hadValue = false;
+          lastEmitted = null;
+          controller.add(null);
+        }
+      }
+    }
+
+    emitCurrent();
+    final timer = Timer.periodic(
+      const Duration(seconds: 2),
+      (_) => emitCurrent(),
+    );
+
+    controller.onCancel = timer.cancel;
+    ref.onDispose(timer.cancel);
   });
 });

--- a/packages/flipper_models/lib/providers/pos_cart_display_provider.dart
+++ b/packages/flipper_models/lib/providers/pos_cart_display_provider.dart
@@ -488,6 +488,11 @@ void _primePosCartForTransactionContainer(
   final id = transaction.id;
   final txn = transaction;
   Future.microtask(() {
+    // [transaction] is being revived as the active cart, so any suppression left
+    // on it — from the park / send-to-till / completion that hid it earlier —
+    // must go first, or the pinned cart renders empty and nothing can release
+    // the flag again. See [clearSuppressedCartTransactionIfContainer].
+    clearSuppressedCartTransactionIfContainer(container, transactionId: id);
     container.read(pinnedPosCartTransactionIdProvider.notifier).state = id;
     writeCachedPendingCartTransactionContainer(
       container,
@@ -534,6 +539,77 @@ void clearPinnedPosCartTransaction(Ref ref) {
 
 void clearPinnedPosCartTransactionWidget(WidgetRef ref) {
   clearPinnedPosCartTransactionContainer(ref.container);
+}
+
+/// Drops the cart pin only when it still points at [transactionId].
+///
+/// The pin outranks the pending-cart cache in
+/// [posCartPendingTransactionIdProvider], and — unlike that cache, which refuses
+/// any non-`PENDING` row — it holds a bare id that is never re-validated against
+/// the transaction's status. So a pin left behind on a sale that has since
+/// completed (or been parked) keeps resolving the cart to that transaction's
+/// line items, which stay `active: true` in Ditto forever.
+/// [suppressedCartTransactionIdProvider] hides them, but the moment suppression
+/// is released the finished sale's lines reappear and cannot be cleared without
+/// an app restart (this provider is not autoDispose).
+///
+/// Returns true when a stale pin was actually dropped.
+bool clearPinnedPosCartTransactionIfContainer(
+  ProviderContainer container, {
+  required String transactionId,
+}) {
+  if (transactionId.isEmpty) return false;
+  final pinned = container.read(pinnedPosCartTransactionIdProvider);
+  if (pinned == null || pinned.isEmpty || pinned != transactionId) return false;
+  container.read(pinnedPosCartTransactionIdProvider.notifier).state = null;
+  return true;
+}
+
+/// Drops cart suppression when it still points at [transactionId].
+///
+/// Mirror of [clearPinnedPosCartTransactionIfContainer] for the *other* flag
+/// that blanks the cart. [suppressedCartTransactionIdProvider] has exactly one
+/// release site — `syncPendingTransaction` in
+/// [posCartStreamReconciliationProvider] — and it only fires when a
+/// **different** pending row becomes active. Resuming a parked ticket makes
+/// that same id both the pinned cart and the emitted pending row, so the guard
+/// can never fire: the ticket's lines stay hidden (the provider short-circuits
+/// to `const []`) until the app restarts. Park / send-to-till / completion all
+/// suppress the id the operator may resume next, so reviving a transaction as
+/// the cart must always release it.
+///
+/// Returns true when stale suppression was actually dropped.
+bool clearSuppressedCartTransactionIfContainer(
+  ProviderContainer container, {
+  required String transactionId,
+}) {
+  if (transactionId.isEmpty) return false;
+  final suppressed = container.read(suppressedCartTransactionIdProvider);
+  if (suppressed == null ||
+      suppressed.isEmpty ||
+      suppressed != transactionId) {
+    return false;
+  }
+  container.read(suppressedCartTransactionIdProvider.notifier).state = null;
+  return true;
+}
+
+bool clearPinnedPosCartTransactionIf(Ref ref, {required String transactionId}) {
+  return clearPinnedPosCartTransactionIfContainer(
+    ref.container,
+    transactionId: transactionId,
+  );
+}
+
+/// [WidgetRef] variant — not assignable to [Ref] in this Riverpod version.
+bool clearPinnedPosCartTransactionIfWidget(
+  WidgetRef ref, {
+  required String transactionId,
+}) {
+  return clearPinnedPosCartTransactionIfContainer(
+    ref.container,
+    transactionId: transactionId,
+  );
 }
 
 /// Synchronous txn id for grid tap (no stream subscription).

--- a/packages/flipper_services/lib/data_connector_url.dart
+++ b/packages/flipper_services/lib/data_connector_url.dart
@@ -1,0 +1,37 @@
+import 'package:flipper_models/helperModels/talker.dart';
+import 'package:flipper_services/proxy.dart';
+
+/// Resolves the data-connector base URL for WhatsApp / OpenWA proxy calls.
+///
+/// **Only** [Ebm.dataConnectorUrl] (column `data_connector_url`) is used.
+/// Never [Ebm.taxServerUrl] / `getServerUrl` — those are the RRA tax host.
+Future<String?> resolveEbmDataConnectorUrl() async {
+  try {
+    final branchId = ProxyService.box.getBranchId();
+    if (branchId != null && branchId.isNotEmpty) {
+      final ebm = await ProxyService.strategy.ebm(branchId: branchId);
+      // Explicit: dataConnectorUrl only — do not use taxServerUrl / remoteServerUrl.
+      final url = ebm?.dataConnectorUrl?.trim();
+      if (url != null && url.isNotEmpty) {
+        talker.info(
+          'data-connector URL from Ebm.dataConnectorUrl: $url '
+          '(taxServerUrl ignored)',
+        );
+        return url;
+      }
+      talker.warning(
+        'EBM for branch $branchId has no dataConnectorUrl '
+        '(taxServerUrl=${ebm?.taxServerUrl ?? "null"} is not used for WhatsApp)',
+      );
+    }
+  } catch (e, s) {
+    talker.warning('resolveEbmDataConnectorUrl EBM lookup failed: $e', e, s);
+  }
+
+  final cached = ProxyService.box.readString(key: 'dataConnectorUrl')?.trim();
+  if (cached != null && cached.isNotEmpty) {
+    talker.info('data-connector URL from box dataConnectorUrl: $cached');
+    return cached;
+  }
+  return null;
+}

--- a/packages/flipper_services/lib/digital_receipt_service.dart
+++ b/packages/flipper_services/lib/digital_receipt_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -9,11 +10,27 @@ import 'package:flipper_services/proxy.dart';
 import 'package:flipper_services/sms/sms_notification_service.dart';
 import 'package:flipper_services/supabase_session_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_models/brick/models/branch_sms_config.model.dart';
+
+/// Meta 24h opt-in prompt for POS (QR / wa.me) when a receipt is queued.
+class WhatsAppOptInPrompt {
+  const WhatsAppOptInPrompt({
+    required this.phone,
+    this.chatUrl,
+    this.qrPngBase64,
+    this.queueId,
+  });
+
+  final String phone;
+  final String? chatUrl;
+  final String? qrPngBase64;
+  final String? queueId;
+}
 
 /// Queues and delivers digital receipts after a receipt PDF is in S3.
 ///
 /// SMS goes through [generateReceiptUrl] + [sendSms]. WhatsApp sends the PDF
-/// via data-connector OpenWA `send-document` and audits a `messages` row.
+/// via data-connector `send-document` (OpenWA or Meta) and audits a `messages` row.
 class DigitalReceiptService {
   DigitalReceiptService._();
 
@@ -24,6 +41,13 @@ class DigitalReceiptService {
   /// `pending_digital_receipt_*` box writes were silently dropped.
   static final Map<String, bool> _pendingSmsByTransactionId = {};
   static final Set<String> _whatsAppSentTransactionIds = {};
+
+  static final StreamController<WhatsAppOptInPrompt> _optInPromptController =
+      StreamController<WhatsAppOptInPrompt>.broadcast();
+
+  /// Fired when Meta queues a receipt outside the 24h window (show QR on POS).
+  static Stream<WhatsAppOptInPrompt> get optInPromptStream =>
+      _optInPromptController.stream;
 
   static Future<void> queueSmsAfterReceiptUpload(String transactionId) async {
     if (transactionId.isEmpty) return;
@@ -113,6 +137,7 @@ class DigitalReceiptService {
         phone: phone,
         receiptFileName: receiptFileName,
         pdfData: pdfData,
+        whatsappProvider: config?.whatsappProvider,
       );
       if (ok) {
         _whatsAppSentTransactionIds.add(transactionId);
@@ -249,6 +274,7 @@ class DigitalReceiptService {
           phone: phone,
           receiptFileName: receiptFileName,
           pdfData: pdfData,
+          whatsappProvider: config?.whatsappProvider,
         );
         if (waOk) {
           _whatsAppSentTransactionIds.add(transactionId);
@@ -300,6 +326,7 @@ class DigitalReceiptService {
     required String phone,
     required String receiptFileName,
     Uint8List? pdfData,
+    int? whatsappProvider,
   }) async {
     if (pdfData == null || pdfData.isEmpty) {
       talker.warning(
@@ -326,19 +353,52 @@ class DigitalReceiptService {
         );
         return false;
       }
+      final provider = WhatsAppChannel.toApiProvider(whatsappProvider);
       final client = await createOrderFormWhatsAppClient(
         dataConnectorUrl: dataConnectorUrl,
+        defaultProvider: provider,
       );
       talker.info(
         'digital receipt: POST ${client.baseUrl}api/whatsapp/send-document '
-        'phone=$phone file=$receiptFileName',
+        'provider=$provider phone=$phone file=$receiptFileName',
       );
       final result = await client.sendDocument(
         phone: phone,
         pdfBytes: pdfData,
         filename: receiptFileName,
         caption: 'Your digital receipt',
+        provider: provider,
       );
+
+      if (result.needsOptIn) {
+        talker.info(
+          'digital receipt: Meta opt-in required (queued=${result.queued} '
+          'queue_id=${result.queueId})',
+        );
+        if (!_optInPromptController.isClosed) {
+          _optInPromptController.add(
+            WhatsAppOptInPrompt(
+              phone: phone,
+              chatUrl: result.chatUrl,
+              qrPngBase64: result.qrPngBase64,
+              queueId: result.queueId,
+            ),
+          );
+        }
+        await SmsNotificationService.createMessage(
+          text:
+              'Digital receipt PDF queued (awaiting WhatsApp opt-in): $receiptFileName',
+          phoneNumber: phone,
+          branchId: branchId,
+          messageSource: 'whatsapp',
+          messageType: 'document',
+          delivered: false,
+          whatsappMessageId: result.queueId,
+        );
+        // Queued server-side — treat as handled so we do not re-send.
+        return true;
+      }
+
       await SmsNotificationService.createMessage(
         text: 'Digital receipt PDF: $receiptFileName',
         phoneNumber: phone,

--- a/packages/flipper_services/lib/digital_receipt_service.dart
+++ b/packages/flipper_services/lib/digital_receipt_service.dart
@@ -1,12 +1,19 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flipper_models/SyncStrategy.dart';
 import 'package:flipper_models/helperModels/talker.dart';
+import 'package:flipper_models/order_form_whatsapp_client.dart';
+import 'package:flipper_services/data_connector_url.dart';
 import 'package:flipper_services/proxy.dart';
+import 'package:flipper_services/sms/sms_notification_service.dart';
 import 'package:flipper_services/supabase_session_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-/// Queues and invokes [generateReceiptUrl] after a receipt PDF is in S3.
+/// Queues and delivers digital receipts after a receipt PDF is in S3.
+///
+/// SMS goes through [generateReceiptUrl] + [sendSms]. WhatsApp sends the PDF
+/// via data-connector OpenWA `send-document` and audits a `messages` row.
 class DigitalReceiptService {
   DigitalReceiptService._();
 
@@ -16,11 +23,12 @@ class DigitalReceiptService {
   /// In-memory queue — [LocalStorage] only allows fixed keys, so per-transaction
   /// `pending_digital_receipt_*` box writes were silently dropped.
   static final Map<String, bool> _pendingSmsByTransactionId = {};
+  static final Set<String> _whatsAppSentTransactionIds = {};
 
   static Future<void> queueSmsAfterReceiptUpload(String transactionId) async {
     if (transactionId.isEmpty) return;
     _pendingSmsByTransactionId[transactionId] = true;
-    talker.info('digital receipt: queued SMS for transaction $transactionId');
+    talker.info('digital receipt: queued for transaction $transactionId');
   }
 
   static bool isQueuedForSms(String transactionId) {
@@ -28,11 +36,97 @@ class DigitalReceiptService {
     return _pendingSmsByTransactionId[transactionId] == true;
   }
 
-  static bool _isQueuedForSms(String transactionId) => isQueuedForSms(transactionId);
+  static bool _isQueuedForSms(String transactionId) =>
+      isQueuedForSms(transactionId);
 
   static void _clearQueuedForSms(String transactionId) {
     if (transactionId.isEmpty) return;
     _pendingSmsByTransactionId.remove(transactionId);
+  }
+
+  /// Sends WhatsApp PDF immediately when bytes are ready (does **not** need S3).
+  ///
+  /// Amplify upload often fails locally (`IdentityPool not found`); WhatsApp
+  /// must not wait on that. SMS short-link still runs from [maybeSendAfterUpload]
+  /// after a successful upload.
+  static Future<void> sendWhatsAppWhenPdfReady({
+    required String transactionId,
+    required String branchId,
+    required String receiptFileName,
+    required Uint8List pdfData,
+    String? customerPhone,
+    String? alternatePhone,
+  }) async {
+    talker.info(
+      'digital receipt: sendWhatsAppWhenPdfReady tx=$transactionId '
+      'file=$receiptFileName bytes=${pdfData.length}',
+    );
+    if (!_isQueuedForSms(transactionId)) {
+      talker.debug(
+        'digital receipt: WhatsApp early-send skipped — not queued for $transactionId',
+      );
+      return;
+    }
+    if (_whatsAppSentTransactionIds.contains(transactionId)) {
+      talker.info('digital receipt: WhatsApp already sent for $transactionId');
+      return;
+    }
+
+    try {
+      final config = await SmsNotificationService.getBranchSmsConfig(
+        branchId,
+        forceRemote: true,
+      );
+      if (config?.enableWhatsapp != true) {
+        talker.info(
+          'digital receipt: WhatsApp early-send skipped — enableWhatsapp=false',
+        );
+        return;
+      }
+
+      final smsBranchId = await _resolveSmsBranchId(branchId);
+      if (smsBranchId == null) {
+        talker.warning(
+          'digital receipt: WhatsApp early-send skipped — no smsBranchId',
+        );
+        return;
+      }
+
+      final phoneSource = _firstNonEmpty(customerPhone, alternatePhone) ??
+          config?.smsPhoneNumber;
+      if (phoneSource == null || phoneSource.trim().isEmpty) {
+        talker.warning(
+          'digital receipt: WhatsApp early-send skipped — no phone',
+        );
+        return;
+      }
+      final phone = _normalizePhoneForSms(phoneSource);
+      if (phone == null) {
+        talker.warning(
+          'digital receipt: WhatsApp early-send skipped — invalid phone "$phoneSource"',
+        );
+        return;
+      }
+
+      final ok = await _sendWhatsAppReceiptPdf(
+        branchId: branchId,
+        phone: phone,
+        receiptFileName: receiptFileName,
+        pdfData: pdfData,
+      );
+      if (ok) {
+        _whatsAppSentTransactionIds.add(transactionId);
+        talker.info(
+          'digital receipt: WhatsApp early-send ok for $transactionId',
+        );
+      }
+    } catch (e, s) {
+      talker.error(
+        'digital receipt: sendWhatsAppWhenPdfReady failed: $e',
+        e,
+        s,
+      );
+    }
   }
 
   static Future<void> maybeSendAfterUpload({
@@ -42,6 +136,7 @@ class DigitalReceiptService {
     String? customerPhone,
     String? alternatePhone,
     bool? alreadySent,
+    Uint8List? pdfData,
   }) async {
     talker.info(
       'digital receipt: maybeSendAfterUpload tx=$transactionId file=$receiptFileName',
@@ -63,22 +158,35 @@ class DigitalReceiptService {
       }
 
       final rawPhone = _firstNonEmpty(customerPhone, alternatePhone);
-      if (rawPhone == null) {
+      final config = await SmsNotificationService.getBranchSmsConfig(
+        branchId,
+        forceRemote: true,
+      );
+      // Prefer customer phone; fall back to branch notification phone from settings.
+      final phoneSource = rawPhone ?? config?.smsPhoneNumber;
+      if (phoneSource == null || phoneSource.trim().isEmpty) {
         talker.warning(
-          'digital receipt: skipped — no customerPhone on transaction $transactionId',
+          'digital receipt: skipped — no customerPhone and no branch '
+          'smsPhoneNumber for transaction $transactionId',
         );
         return;
+      }
+      if (rawPhone == null) {
+        talker.info(
+          'digital receipt: using branch smsPhoneNumber $phoneSource '
+          '(no customer phone on transaction)',
+        );
       }
 
-      final phone = _normalizePhoneForSms(rawPhone);
+      final phone = _normalizePhoneForSms(phoneSource);
       if (phone == null) {
         talker.warning(
-          'digital receipt: skipped — invalid phone "$rawPhone" on $transactionId',
+          'digital receipt: skipped — invalid phone "$phoneSource" on $transactionId',
         );
         return;
       }
-      if (phone != rawPhone.replaceAll(RegExp(r'\D'), '')) {
-        talker.info('digital receipt: normalized phone $rawPhone → $phone');
+      if (phone != phoneSource.replaceAll(RegExp(r'\D'), '')) {
+        talker.info('digital receipt: normalized phone $phoneSource → $phone');
       }
 
       talker.info(
@@ -93,33 +201,72 @@ class DigitalReceiptService {
       }
       talker.info('digital receipt: smsBranchId=$smsBranchId');
 
+      final enableSms = config?.enableSms ?? false;
+      final enableWhatsapp = config?.enableWhatsapp ?? false;
       talker.info(
-        'digital receipt: invoking generateReceiptUrl for $transactionId '
-        'file=$receiptFileName phone=$phone',
+        'digital receipt: channels enableSms=$enableSms enableWhatsapp=$enableWhatsapp',
       );
-      final result = await requestReceiptLink(
-        branchId: branchId,
-        receiptFileName: receiptFileName,
-        phoneNumber: phone,
-        transactionId: transactionId,
-        smsBranchId: smsBranchId,
-      );
-
-      if (result == null) {
+      if (!enableSms && !enableWhatsapp) {
         talker.warning(
-          'digital receipt: generateReceiptUrl returned no link for $transactionId '
-          '(see warnings above for status/body)',
+          'digital receipt: skipped — no channel enabled for branch $branchId',
         );
         return;
       }
 
-      final shortUrlId = result.shortUrlId;
-      talker.info(
-        'digital receipt: short link $shortUrlId queued — '
-        'message_id=${result.messageId ?? "n/a"}',
-      );
+      var anySuccess = false;
 
-      await _invokeSendSms();
+      if (enableSms) {
+        talker.info(
+          'digital receipt: SMS path for $transactionId '
+          'file=$receiptFileName phone=$phone',
+        );
+        final result = await requestReceiptLink(
+          branchId: branchId,
+          receiptFileName: receiptFileName,
+          phoneNumber: phone,
+          transactionId: transactionId,
+          smsBranchId: smsBranchId,
+          sendSms: true,
+        );
+        if (result != null) {
+          talker.info(
+            'digital receipt: short link ${result.shortUrlId} queued — '
+            'message_id=${result.messageId ?? "n/a"}',
+          );
+          await _invokeSendSms();
+          anySuccess = true;
+        } else {
+          talker.warning(
+            'digital receipt: generateReceiptUrl returned no link for $transactionId',
+          );
+        }
+      }
+
+      if (enableWhatsapp &&
+          !_whatsAppSentTransactionIds.contains(transactionId)) {
+        final waOk = await _sendWhatsAppReceiptPdf(
+          branchId: branchId,
+          phone: phone,
+          receiptFileName: receiptFileName,
+          pdfData: pdfData,
+        );
+        if (waOk) {
+          _whatsAppSentTransactionIds.add(transactionId);
+          anySuccess = true;
+        }
+      } else if (enableWhatsapp) {
+        anySuccess = true;
+        talker.info(
+          'digital receipt: WhatsApp already sent earlier for $transactionId',
+        );
+      }
+
+      if (!anySuccess) {
+        talker.warning(
+          'digital receipt: no channel succeeded for $transactionId',
+        );
+        return;
+      }
 
       try {
         final strategy = ProxyService.getStrategy(Strategy.capella);
@@ -144,6 +291,78 @@ class DigitalReceiptService {
       );
     } finally {
       _clearQueuedForSms(transactionId);
+      _whatsAppSentTransactionIds.remove(transactionId);
+    }
+  }
+
+  static Future<bool> _sendWhatsAppReceiptPdf({
+    required String branchId,
+    required String phone,
+    required String receiptFileName,
+    Uint8List? pdfData,
+  }) async {
+    if (pdfData == null || pdfData.isEmpty) {
+      talker.warning(
+        'digital receipt: WhatsApp skipped — no PDF bytes for $receiptFileName',
+      );
+      return false;
+    }
+
+    final charged =
+        await SmsNotificationService.deductSmsCredits(branchId: branchId);
+    if (!charged) {
+      talker.warning(
+        'digital receipt: WhatsApp skipped — insufficient credits for $branchId',
+      );
+      return false;
+    }
+
+    try {
+      final dataConnectorUrl = await resolveEbmDataConnectorUrl();
+      if (dataConnectorUrl == null || dataConnectorUrl.isEmpty) {
+        talker.warning(
+          'digital receipt: WhatsApp skipped — Ebm.dataConnectorUrl is not set '
+          '(taxServerUrl is not used)',
+        );
+        return false;
+      }
+      final client = await createOrderFormWhatsAppClient(
+        dataConnectorUrl: dataConnectorUrl,
+      );
+      talker.info(
+        'digital receipt: POST ${client.baseUrl}api/whatsapp/send-document '
+        'phone=$phone file=$receiptFileName',
+      );
+      final result = await client.sendDocument(
+        phone: phone,
+        pdfBytes: pdfData,
+        filename: receiptFileName,
+        caption: 'Your digital receipt',
+      );
+      await SmsNotificationService.createMessage(
+        text: 'Digital receipt PDF: $receiptFileName',
+        phoneNumber: phone,
+        branchId: branchId,
+        messageSource: 'whatsapp',
+        messageType: 'document',
+        delivered: true,
+        whatsappMessageId: result.messageId,
+      );
+      talker.info(
+        'digital receipt: WhatsApp PDF sent message_id=${result.messageId}',
+      );
+      return result.ok;
+    } catch (e, s) {
+      talker.error('digital receipt: WhatsApp PDF send failed: $e', e, s);
+      await SmsNotificationService.createMessage(
+        text: 'Digital receipt PDF: $receiptFileName',
+        phoneNumber: phone,
+        branchId: branchId,
+        messageSource: 'whatsapp',
+        messageType: 'document',
+        delivered: false,
+      );
+      return false;
     }
   }
 

--- a/packages/flipper_services/lib/sms/sms_notification_service.dart
+++ b/packages/flipper_services/lib/sms/sms_notification_service.dart
@@ -75,15 +75,17 @@ class SmsNotificationService {
         text: text,
         phoneNumber: phone,
         branchId: branchId,
+        whatsappProvider: config.whatsappProvider,
       );
     }
   }
 
-  /// Deducts credits, sends OpenWA text, and audits a delivered WhatsApp row.
+  /// Deducts credits, sends WhatsApp text, and audits a delivered WhatsApp row.
   static Future<bool> sendWhatsAppTextNotification({
     required String text,
     required String phoneNumber,
     required String branchId,
+    int? whatsappProvider,
   }) async {
     final charged = await deductSmsCredits(branchId: branchId);
     if (!charged) {
@@ -102,10 +104,32 @@ class SmsNotificationService {
         );
         return false;
       }
+      final provider = WhatsAppChannel.toApiProvider(whatsappProvider);
       final client = await createOrderFormWhatsAppClient(
         dataConnectorUrl: dataConnectorUrl,
+        defaultProvider: provider,
       );
-      final result = await client.sendText(phone: phoneNumber, text: text);
+      final result = await client.sendText(
+        phone: phoneNumber,
+        text: text,
+        provider: provider,
+      );
+      if (result.needsOptIn) {
+        talker.info(
+          'WhatsApp order notification queued pending Meta opt-in '
+          '(queue_id=${result.queueId})',
+        );
+        await createMessage(
+          text: text,
+          phoneNumber: phoneNumber,
+          branchId: branchId,
+          messageSource: 'whatsapp',
+          messageType: 'text',
+          delivered: false,
+          whatsappMessageId: result.queueId,
+        );
+        return true;
+      }
       await createMessage(
         text: text,
         phoneNumber: phoneNumber,
@@ -191,42 +215,70 @@ class SmsNotificationService {
     String? smsPhoneNumber,
     bool? enableSms,
     bool? enableWhatsapp,
+    int? whatsappProvider,
     @Deprecated('Use enableSms') bool? enableNotification,
   }) async {
     try {
       final smsFlag = enableSms ?? enableNotification;
       var config = await getBranchSmsConfig(branchId);
 
+      // After local Brick repair, BranchSmsConfig may be empty while Supabase
+      // still has the row — reuse that id so we don't INSERT a second branch_id.
+      final remoteId = await _remoteBranchSmsConfigId(branchId);
+      final id = remoteId ?? config?.id;
+
       if (config == null) {
         config = BranchSmsConfig(
+          id: id,
           branchId: branchId,
           smsPhoneNumber: smsPhoneNumber,
           enableSms: smsFlag ?? false,
           enableWhatsapp: enableWhatsapp ?? false,
+          whatsappProvider: whatsappProvider ?? WhatsAppChannel.openwa,
         );
       } else {
         config = BranchSmsConfig(
-          id: config.id,
+          id: id ?? config.id,
           branchId: branchId,
           smsPhoneNumber: smsPhoneNumber ?? config.smsPhoneNumber,
           enableSms: smsFlag ?? config.enableSms,
           enableWhatsapp: enableWhatsapp ?? config.enableWhatsapp,
+          whatsappProvider: whatsappProvider ?? config.whatsappProvider,
         );
       }
 
       await _repository.upsert<BranchSmsConfig>(config);
 
-      // Guarantee Supabase has the channel flags (Brick local can lag / miss columns).
-      await Supabase.instance.client.from('branch_sms_configs').upsert({
-        'id': config.id,
-        'branch_id': config.branchId,
-        'sms_phone_number': config.smsPhoneNumber,
-        'enable_sms': config.enableSms,
-        'enable_whatsapp': config.enableWhatsapp,
-      });
+      // Conflict on branch_id (unique), not id — local may mint a new UUID.
+      await Supabase.instance.client.from('branch_sms_configs').upsert(
+        {
+          'id': config.id,
+          'branch_id': config.branchId,
+          'sms_phone_number': config.smsPhoneNumber,
+          'enable_sms': config.enableSms,
+          'enable_whatsapp': config.enableWhatsapp,
+          'whatsapp_provider': config.whatsappProvider,
+        },
+        onConflict: 'branch_id',
+      );
     } catch (e) {
       print('Error updating branch SMS config: $e');
       rethrow;
+    }
+  }
+
+  static Future<String?> _remoteBranchSmsConfigId(String branchId) async {
+    try {
+      final row = await Supabase.instance.client
+          .from('branch_sms_configs')
+          .select('id')
+          .eq('branch_id', branchId)
+          .maybeSingle();
+      final id = row?['id']?.toString();
+      return (id != null && id.isNotEmpty) ? id : null;
+    } catch (e) {
+      talker.debug('_remoteBranchSmsConfigId failed for $branchId: $e');
+      return null;
     }
   }
 

--- a/packages/flipper_services/lib/sms/sms_notification_service.dart
+++ b/packages/flipper_services/lib/sms/sms_notification_service.dart
@@ -1,3 +1,9 @@
+import 'package:flipper_models/SyncStrategy.dart';
+import 'package:flipper_models/helperModels/talker.dart';
+import 'package:flipper_models/order_form_whatsapp_client.dart';
+import 'package:flipper_services/data_connector_url.dart';
+import 'package:flipper_services/proxy.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:supabase_models/brick/models/branch_sms_config.model.dart';
 import 'package:supabase_models/brick/models/message.model.dart';
 import 'package:supabase_models/brick/repository.dart';
@@ -6,24 +12,25 @@ import 'package:brick_offline_first/brick_offline_first.dart';
 class SmsNotificationService {
   static final Repository _repository = Repository();
 
+  /// Same cost as [sendSms] edge function (`SMS_CREDIT_COST`).
+  static const int smsCreditCost = 30;
+
   static Future<void> sendOrderRequestNotification({
     required String receiverBranchId,
     required String orderDetails,
     required String requesterPhone,
   }) async {
     try {
-      // Send notification to receiver branch
       final receiverConfig = await getBranchSmsConfig(receiverBranchId);
-      if (receiverConfig?.smsPhoneNumber != null &&
-          receiverConfig!.enableOrderNotification) {
-        await createMessage(
-          text: 'New Order Request: $orderDetails from $requesterPhone',
-          phoneNumber: receiverConfig.smsPhoneNumber!,
-          branchId: receiverBranchId,
-        );
-      }
+      if (receiverConfig?.smsPhoneNumber == null) return;
+
+      final text = 'New Order Request: $orderDetails from $requesterPhone';
+      await _dispatchOrderNotification(
+        config: receiverConfig!,
+        text: text,
+        branchId: receiverBranchId,
+      );
     } catch (e) {
-      // Log error but don't throw to prevent disrupting main flow
       print('Error sending order request notification: $e');
     }
   }
@@ -35,27 +42,121 @@ class SmsNotificationService {
   }) async {
     try {
       final branchConfig = await getBranchSmsConfig(requesterBranchId);
-      if (branchConfig?.smsPhoneNumber != null &&
-          branchConfig!.enableOrderNotification) {
-        await createMessage(
-          text: 'Order Status Update: $orderDetails has been $status',
-          phoneNumber: branchConfig.smsPhoneNumber!,
-          branchId: requesterBranchId,
-        );
-      }
+      if (branchConfig?.smsPhoneNumber == null) return;
+
+      final text = 'Order Status Update: $orderDetails has been $status';
+      await _dispatchOrderNotification(
+        config: branchConfig!,
+        text: text,
+        branchId: requesterBranchId,
+      );
     } catch (e) {
-      // Log error but don't throw to prevent disrupting main flow
       print('Error sending order status notification: $e');
     }
   }
 
-  static Future<BranchSmsConfig?> getBranchSmsConfig(String branchId) async {
+  static Future<void> _dispatchOrderNotification({
+    required BranchSmsConfig config,
+    required String text,
+    required String branchId,
+  }) async {
+    final phone = config.smsPhoneNumber!;
+    if (config.enableSms) {
+      await createMessage(
+        text: text,
+        phoneNumber: phone,
+        branchId: branchId,
+        messageSource: 'sms',
+        delivered: false,
+      );
+    }
+    if (config.enableWhatsapp) {
+      await sendWhatsAppTextNotification(
+        text: text,
+        phoneNumber: phone,
+        branchId: branchId,
+      );
+    }
+  }
+
+  /// Deducts credits, sends OpenWA text, and audits a delivered WhatsApp row.
+  static Future<bool> sendWhatsAppTextNotification({
+    required String text,
+    required String phoneNumber,
+    required String branchId,
+  }) async {
+    final charged = await deductSmsCredits(branchId: branchId);
+    if (!charged) {
+      talker.warning(
+        'WhatsApp order notification skipped — insufficient credits for $branchId',
+      );
+      return false;
+    }
+
+    try {
+      final dataConnectorUrl = await resolveEbmDataConnectorUrl();
+      if (dataConnectorUrl == null || dataConnectorUrl.isEmpty) {
+        talker.warning(
+          'WhatsApp order notification skipped — Ebm.dataConnectorUrl is not set '
+          '(taxServerUrl is not used)',
+        );
+        return false;
+      }
+      final client = await createOrderFormWhatsAppClient(
+        dataConnectorUrl: dataConnectorUrl,
+      );
+      final result = await client.sendText(phone: phoneNumber, text: text);
+      await createMessage(
+        text: text,
+        phoneNumber: phoneNumber,
+        branchId: branchId,
+        messageSource: 'whatsapp',
+        messageType: 'text',
+        delivered: true,
+        whatsappMessageId: result.messageId,
+      );
+      return result.ok;
+    } catch (e, s) {
+      talker.error('WhatsApp order notification failed: $e', e, s);
+      await createMessage(
+        text: text,
+        phoneNumber: phoneNumber,
+        branchId: branchId,
+        messageSource: 'whatsapp',
+        messageType: 'text',
+        delivered: false,
+      );
+      return false;
+    }
+  }
+
+  /// Deducts [smsCreditCost] via `deduct_credits` for [branchId] (UUID).
+  static Future<bool> deductSmsCredits({required String branchId}) async {
+    try {
+      await Supabase.instance.client.rpc(
+        'deduct_credits',
+        params: <String, dynamic>{
+          'branch_id': branchId,
+          'amount': smsCreditCost,
+        },
+      );
+      return true;
+    } catch (e, s) {
+      talker.warning('deduct_credits failed for $branchId: $e\n$s');
+      return false;
+    }
+  }
+
+  static Future<BranchSmsConfig?> getBranchSmsConfig(
+    String branchId, {
+    bool forceRemote = false,
+  }) async {
     try {
       final configs = await _repository.get<BranchSmsConfig>(
-        query: Query(
-          where: [Where('branchId').isExactly(branchId)],
-        ),
-        policy: OfflineFirstGetPolicy.awaitRemoteWhenNoneExist,
+        query: Query(where: [Where('branchId').isExactly(branchId)]),
+        policy: forceRemote
+            ? OfflineFirstGetPolicy.alwaysHydrate
+            : OfflineFirstGetPolicy.awaitRemoteWhenNoneExist,
       );
       return configs.firstOrNull;
     } catch (e) {
@@ -68,12 +169,19 @@ class SmsNotificationService {
     required String text,
     required String phoneNumber,
     required String branchId,
+    String messageSource = 'sms',
+    String? messageType,
+    bool delivered = false,
+    String? whatsappMessageId,
   }) async {
     final message = Message(
       text: text,
       phoneNumber: phoneNumber,
-      delivered: false,
+      delivered: delivered,
       branchId: branchId,
+      messageSource: messageSource,
+      messageType: messageType,
+      whatsappMessageId: whatsappMessageId,
     );
     await _repository.upsert<Message>(message);
   }
@@ -81,31 +189,59 @@ class SmsNotificationService {
   static Future<void> updateBranchSmsConfig({
     required String branchId,
     String? smsPhoneNumber,
-    bool? enableNotification,
+    bool? enableSms,
+    bool? enableWhatsapp,
+    @Deprecated('Use enableSms') bool? enableNotification,
   }) async {
     try {
+      final smsFlag = enableSms ?? enableNotification;
       var config = await getBranchSmsConfig(branchId);
 
       if (config == null) {
         config = BranchSmsConfig(
           branchId: branchId,
           smsPhoneNumber: smsPhoneNumber,
-          enableOrderNotification: enableNotification ?? false,
+          enableSms: smsFlag ?? false,
+          enableWhatsapp: enableWhatsapp ?? false,
         );
       } else {
         config = BranchSmsConfig(
           id: config.id,
           branchId: branchId,
           smsPhoneNumber: smsPhoneNumber ?? config.smsPhoneNumber,
-          enableOrderNotification:
-              enableNotification ?? config.enableOrderNotification,
+          enableSms: smsFlag ?? config.enableSms,
+          enableWhatsapp: enableWhatsapp ?? config.enableWhatsapp,
         );
       }
 
       await _repository.upsert<BranchSmsConfig>(config);
+
+      // Guarantee Supabase has the channel flags (Brick local can lag / miss columns).
+      await Supabase.instance.client.from('branch_sms_configs').upsert({
+        'id': config.id,
+        'branch_id': config.branchId,
+        'sms_phone_number': config.smsPhoneNumber,
+        'enable_sms': config.enableSms,
+        'enable_whatsapp': config.enableWhatsapp,
+      });
     } catch (e) {
       print('Error updating branch SMS config: $e');
       rethrow;
     }
+  }
+
+  /// Resolves Capella branch [serverId] used as the SMS credits gate.
+  static Future<int?> resolveSmsBranchServerId(String branchId) async {
+    try {
+      final branch = await ProxyService.getStrategy(
+        Strategy.capella,
+      ).branch(serverId: branchId);
+      final serverId = branch?.serverId;
+      if (serverId != null && serverId > 0) return serverId;
+    } catch (e, s) {
+      talker.warning('resolveSmsBranchServerId failed for $branchId: $e\n$s');
+    }
+    final parsed = int.tryParse(branchId);
+    return parsed != null && parsed > 0 ? parsed : null;
   }
 }

--- a/packages/flipper_services/lib/whatsapp_ditto_inbox.dart
+++ b/packages/flipper_services/lib/whatsapp_ditto_inbox.dart
@@ -1,0 +1,433 @@
+import 'package:flipper_services/proxy.dart';
+import 'package:flipper_web/services/ditto_service.dart';
+
+/// One emoji reaction on a WhatsApp message (one per reactor).
+class WhatsAppReaction {
+  const WhatsAppReaction({
+    required this.emoji,
+    required this.from,
+  });
+
+  final String emoji;
+  final String from;
+}
+
+/// One row from Ditto `whatsapp_messages`.
+class WhatsAppDittoMessage {
+  const WhatsAppDittoMessage({
+    required this.id,
+    required this.phoneNumberId,
+    required this.waId,
+    required this.from,
+    required this.body,
+    required this.messageType,
+    required this.timestamp,
+    required this.outbound,
+    this.contactName,
+    this.reactions = const [],
+    this.filename,
+    this.mimeType,
+    this.mediaUrl,
+    this.mediaId,
+    this.mediaBase64,
+  });
+
+  final String id;
+  final String phoneNumberId;
+  final String waId;
+  final String from;
+  final String body;
+  final String messageType;
+  final DateTime timestamp;
+  final bool outbound;
+  final String? contactName;
+  final List<WhatsAppReaction> reactions;
+  final String? filename;
+  final String? mimeType;
+  final String? mediaUrl;
+  final String? mediaId;
+  final String? mediaBase64;
+
+  bool get isPdf {
+    final mime = (mimeType ?? '').toLowerCase();
+    if (mime.contains('pdf')) return true;
+    final name = (filename ?? '').toLowerCase();
+    if (name.endsWith('.pdf')) return true;
+    return messageType.toLowerCase() == 'document' &&
+        (mime.isEmpty || mime.contains('pdf') || name.isEmpty);
+  }
+
+  bool get isDocument =>
+      messageType.toLowerCase() == 'document' || isPdf;
+
+  bool get hasDownloadableMedia =>
+      (mediaUrl != null && mediaUrl!.trim().isNotEmpty) ||
+      (mediaId != null && mediaId!.trim().isNotEmpty) ||
+      (mediaBase64 != null && mediaBase64!.trim().isNotEmpty) ||
+      id.isNotEmpty;
+
+  String get displayFilename {
+    final name = filename?.trim();
+    if (name != null && name.isNotEmpty) return name;
+    if (isPdf) return 'document.pdf';
+    return 'attachment';
+  }
+
+  WhatsAppDittoMessage copyWith({
+    List<WhatsAppReaction>? reactions,
+  }) {
+    return WhatsAppDittoMessage(
+      id: id,
+      phoneNumberId: phoneNumberId,
+      waId: waId,
+      from: from,
+      body: body,
+      messageType: messageType,
+      timestamp: timestamp,
+      outbound: outbound,
+      contactName: contactName,
+      reactions: reactions ?? this.reactions,
+      filename: filename,
+      mimeType: mimeType,
+      mediaUrl: mediaUrl,
+      mediaId: mediaId,
+      mediaBase64: mediaBase64,
+    );
+  }
+
+  factory WhatsAppDittoMessage.fromDoc(Map<String, dynamic> doc) {
+    final id = (doc['_id'] ?? doc['id'] ?? doc['messageId'] ?? '').toString();
+    final from = (doc['from'] ?? '').toString();
+    final waId = (doc['waId'] ?? from).toString();
+    final direction = (doc['direction'] ?? '').toString().toLowerCase();
+    final body = (doc['messageBody'] ?? doc['caption'] ?? '').toString();
+    final type = (doc['messageType'] ?? 'text').toString();
+    final filename = doc['filename']?.toString();
+    final mimeType =
+        (doc['mimeType'] ?? doc['mime_type'])?.toString();
+    final display = body.isNotEmpty
+        ? body
+        : (filename != null && filename.isNotEmpty)
+            ? filename
+            : (type.isEmpty ? '[attachment]' : '[$type]');
+
+    final metaTs = (doc['timestamp'] ?? '').toString();
+    final createdAt = (doc['createdAt'] ?? '').toString();
+    final tsRaw = metaTs.isNotEmpty ? metaTs : createdAt;
+
+    return WhatsAppDittoMessage(
+      id: id,
+      phoneNumberId: (doc['phoneNumberId'] ?? doc['phone_number_id'] ?? '')
+          .toString(),
+      waId: waId,
+      from: from,
+      body: display,
+      messageType: type,
+      timestamp: _parseTs(tsRaw),
+      outbound: direction == 'outbound' || direction == 'out',
+      contactName: doc['contactName']?.toString(),
+      reactions: _reactionsFromDoc(doc),
+      filename: filename,
+      mimeType: mimeType,
+      mediaUrl: (doc['mediaUrl'] ?? doc['media_url'])?.toString(),
+      mediaId: (doc['mediaId'] ?? doc['media_id'])?.toString(),
+      mediaBase64: (doc['mediaBase64'] ?? doc['media_base64'])?.toString(),
+    );
+  }
+
+  static bool isDeletedDoc(Map<String, dynamic> doc) {
+    final deleted = doc['deleted'];
+    if (deleted == true) return true;
+    if (deleted?.toString().toLowerCase() == 'true') return true;
+    final status = (doc['status'] ?? '').toString().toLowerCase();
+    if (status == 'deleted' || status == 'revoked') return true;
+    final type = (doc['messageType'] ?? '').toString().toLowerCase();
+    return type == 'revoke';
+  }
+
+  static bool isReactionDoc(Map<String, dynamic> doc) {
+    return (doc['messageType'] ?? '').toString().toLowerCase() == 'reaction';
+  }
+}
+
+List<WhatsAppReaction> _reactionsFromDoc(Map<String, dynamic> doc) {
+  final raw = doc['reactions'];
+  if (raw is! List) return const [];
+  final byFrom = <String, WhatsAppReaction>{};
+  for (final item in raw) {
+    if (item is! Map) continue;
+    final map = Map<String, dynamic>.from(item);
+    final emoji = (map['emoji'] ?? '').toString().trim();
+    if (emoji.isEmpty) continue;
+    final from = (map['from'] ?? '').toString();
+    final key = from.isNotEmpty ? from : emoji;
+    byFrom[key] = WhatsAppReaction(emoji: emoji, from: from);
+  }
+  return byFrom.values.toList(growable: false);
+}
+
+/// Customer thread grouped from Ditto `whatsapp_messages`.
+class WhatsAppDittoThread {
+  const WhatsAppDittoThread({
+    required this.waId,
+    required this.displayName,
+    required this.messages,
+  });
+
+  final String waId;
+  final String displayName;
+  final List<WhatsAppDittoMessage> messages;
+
+  DateTime get lastMessageAt => messages.isEmpty
+      ? DateTime.fromMillisecondsSinceEpoch(0)
+      : messages.last.timestamp;
+
+  String? get lastPreview {
+    if (messages.isEmpty) return null;
+    final m = messages.last;
+    if (m.isDocument) return 'PDF · ${m.displayFilename}';
+    return m.body;
+  }
+}
+
+DateTime _parseTs(String raw) {
+  if (raw.isEmpty) return DateTime.now().toUtc();
+  final asInt = int.tryParse(raw);
+  if (asInt != null) {
+    if (asInt > 1000000000000) {
+      return DateTime.fromMillisecondsSinceEpoch(asInt, isUtc: true);
+    }
+    return DateTime.fromMillisecondsSinceEpoch(asInt * 1000, isUtc: true);
+  }
+  try {
+    return DateTime.parse(raw).toUtc();
+  } catch (_) {
+    return DateTime.now().toUtc();
+  }
+}
+
+/// Helpers for Flo WhatsApp inbox (HTTP poll is the live source).
+class WhatsAppDittoInbox {
+  WhatsAppDittoInbox({DittoService? dittoService})
+      : _dittoService = dittoService ?? DittoService.instance;
+
+  final DittoService _dittoService;
+
+  Future<void> appendOutbound({
+    required String phoneNumberId,
+    required String waId,
+    required String body,
+    String? contactName,
+    String? messageId,
+  }) async {
+    final store = _dittoService.store;
+    if (store == null) return;
+    final now = DateTime.now().toUtc();
+    // Prefer Meta Graph wamid so inbound reactions can attach to this row.
+    final id = (messageId != null && messageId.trim().isNotEmpty)
+        ? messageId.trim()
+        : 'wa-out-${now.millisecondsSinceEpoch}';
+    final doc = {
+      '_id': id,
+      'id': id,
+      'messageId': id,
+      'phoneNumberId': phoneNumberId,
+      'waId': waId,
+      'from': 'business',
+      'messageBody': body,
+      'messageType': 'text',
+      'direction': 'outbound',
+      'messagingProduct': 'whatsapp',
+      'contactName': contactName,
+      'timestamp': (now.millisecondsSinceEpoch ~/ 1000).toString(),
+      'createdAt': now.millisecondsSinceEpoch.toString(),
+    };
+    await store.execute(
+      'INSERT INTO whatsapp_messages DOCUMENTS (:doc) ON ID CONFLICT DO UPDATE',
+      arguments: {'doc': doc},
+    );
+  }
+
+  static List<WhatsAppDittoThread> groupThreadsFromDocs(
+    List<Map<String, dynamic>> docs,
+  ) =>
+      _groupThreads(docs);
+
+  static List<WhatsAppDittoThread> _groupThreads(
+    List<Map<String, dynamic>> docs,
+  ) {
+    // targetMessageId -> from -> emoji (latest wins; empty emoji removes).
+    final reactionByTarget = <String, Map<String, String>>{};
+    final orphanMeta = <String, ({String waId, String? contactName})>{};
+
+    void applyReaction({
+      required String targetId,
+      required String from,
+      required String emoji,
+      String? waId,
+      String? contactName,
+    }) {
+      if (targetId.isEmpty) return;
+      final bucket = reactionByTarget.putIfAbsent(targetId, () => {});
+      final key = from.isNotEmpty ? from : '_';
+      if (emoji.trim().isEmpty) {
+        bucket.remove(key);
+      } else {
+        bucket[key] = emoji.trim();
+        orphanMeta[targetId] = (
+          waId: (waId != null && waId.isNotEmpty) ? waId : from,
+          contactName: contactName,
+        );
+      }
+    }
+
+    String docId(Map<String, dynamic> doc) =>
+        (doc['_id'] ?? doc['id'] ?? doc['messageId'] ?? '').toString();
+
+    final parentIds = <String>{};
+    for (final doc in docs) {
+      if (WhatsAppDittoMessage.isDeletedDoc(doc)) continue;
+      if (WhatsAppDittoMessage.isReactionDoc(doc)) continue;
+      final id = docId(doc);
+      if (id.isNotEmpty) parentIds.add(id);
+      final mid = (doc['messageId'] ?? '').toString();
+      if (mid.isNotEmpty) parentIds.add(mid);
+    }
+
+    for (final doc in docs) {
+      if (WhatsAppDittoMessage.isDeletedDoc(doc)) continue;
+
+      final embedded = doc['reactions'];
+      if (embedded is List) {
+        final parentId = docId(doc);
+        for (final item in embedded) {
+          if (item is! Map) continue;
+          final map = Map<String, dynamic>.from(item);
+          applyReaction(
+            targetId: parentId,
+            from: (map['from'] ?? '').toString(),
+            emoji: (map['emoji'] ?? '').toString(),
+            waId: (doc['waId'] ?? doc['from'])?.toString(),
+            contactName: doc['contactName']?.toString(),
+          );
+        }
+      }
+
+      if (WhatsAppDittoMessage.isReactionDoc(doc)) {
+        applyReaction(
+          targetId: (doc['reactionMessageId'] ??
+                  doc['reaction_message_id'] ??
+                  '')
+              .toString(),
+          from: (doc['from'] ?? '').toString(),
+          emoji: (doc['reactionEmoji'] ??
+                  doc['reaction_emoji'] ??
+                  doc['messageBody'] ??
+                  '')
+              .toString(),
+          waId: (doc['waId'] ?? doc['from'])?.toString(),
+          contactName: doc['contactName']?.toString(),
+        );
+      }
+    }
+
+    final byWa = <String, List<WhatsAppDittoMessage>>{};
+    final names = <String, String>{};
+    final attachedTargets = <String>{};
+
+    for (final doc in docs) {
+      if (WhatsAppDittoMessage.isDeletedDoc(doc)) continue;
+      if (WhatsAppDittoMessage.isReactionDoc(doc)) continue;
+
+      var msg = WhatsAppDittoMessage.fromDoc(doc);
+      if (msg.waId.isEmpty && msg.from.isEmpty) continue;
+
+      final mid = (doc['messageId'] ?? '').toString();
+      final fromMap =
+          reactionByTarget[msg.id] ?? reactionByTarget[mid];
+      if (fromMap != null && fromMap.isNotEmpty) {
+        attachedTargets.add(msg.id);
+        if (mid.isNotEmpty) attachedTargets.add(mid);
+        msg = msg.copyWith(
+          reactions: fromMap.entries
+              .map((e) => WhatsAppReaction(emoji: e.value, from: e.key))
+              .toList(growable: false),
+        );
+      }
+
+      final key = msg.waId.isNotEmpty ? msg.waId : msg.from;
+      byWa.putIfAbsent(key, () => []).add(msg);
+      final name = msg.contactName?.trim();
+      if (name != null && name.isNotEmpty) {
+        names[key] = name;
+      }
+    }
+
+    // Reactions on outbound Graph wamids we never stored as chat rows.
+    for (final entry in reactionByTarget.entries) {
+      if (entry.value.isEmpty) continue;
+      if (attachedTargets.contains(entry.key) ||
+          parentIds.contains(entry.key)) {
+        continue;
+      }
+      final meta = orphanMeta[entry.key];
+      final wa = meta?.waId ?? '';
+      if (wa.isEmpty) continue;
+      final stub = WhatsAppDittoMessage(
+        id: entry.key,
+        phoneNumberId: '',
+        waId: wa,
+        from: 'business',
+        body: '(message)',
+        messageType: 'text',
+        timestamp: DateTime.now().toUtc(),
+        outbound: true,
+        contactName: meta?.contactName,
+        reactions: entry.value.entries
+            .map((e) => WhatsAppReaction(emoji: e.value, from: e.key))
+            .toList(growable: false),
+      );
+      byWa.putIfAbsent(wa, () => []).add(stub);
+      final name = meta?.contactName?.trim();
+      if (name != null && name.isNotEmpty) {
+        names[wa] = name;
+      }
+    }
+
+    final threads = <WhatsAppDittoThread>[];
+    for (final entry in byWa.entries) {
+      final msgs = entry.value
+        ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+      threads.add(
+        WhatsAppDittoThread(
+          waId: entry.key,
+          displayName: names[entry.key] ?? entry.key,
+          messages: List.unmodifiable(msgs),
+        ),
+      );
+    }
+
+    threads.sort((a, b) => b.lastMessageAt.compareTo(a.lastMessageAt));
+    return threads;
+  }
+
+  Future<void> dispose() async {
+    // No live observers — HTTP poll owns the stream.
+  }
+}
+
+/// Resolve the Phone Number ID for the active business (prefs fallback).
+Future<String?> resolveWhatsAppPhoneNumberId() async {
+  final businessId = ProxyService.box.getBusinessId();
+  if (businessId != null) {
+    try {
+      final business =
+          await ProxyService.strategy.getBusiness(businessId: businessId);
+      final id = business?.getWhatsAppPhoneNumberId();
+      if (id != null && id.isNotEmpty) return id;
+    } catch (_) {}
+  }
+  final prefs = ProxyService.box.whatsAppPhoneNumberId();
+  if (prefs != null && prefs.isNotEmpty) return prefs;
+  return null;
+}

--- a/packages/flipper_services/lib/whatsapp_message_sync_service.dart
+++ b/packages/flipper_services/lib/whatsapp_message_sync_service.dart
@@ -90,15 +90,17 @@ class WhatsAppMessageSyncService {
       _stateController ??= StreamController<WhatsAppSyncState>.broadcast();
       _stateController?.add(WhatsAppSyncState.syncing());
 
-      // Query for WhatsApp messages matching this business's phoneNumberId
+      // Query for WhatsApp messages — Capella sync is unfiltered; Brick mirror
+      // still scopes by phoneNumberId in the observer transform path.
+      const syncQuery = 'SELECT * FROM whatsapp_messages';
       final query =
           'SELECT * FROM whatsapp_messages WHERE phoneNumberId = :phoneNumberId';
       final arguments = {'phoneNumberId': phoneNumberId};
 
-      // Register subscription to ensure we receive updates from other devices/cloud
-      await _runner.registerSubscription(query, arguments: arguments);
+      // Broad Capella subscription so inbound from data-connector replicates.
+      await _runner.registerSubscription(syncQuery);
 
-      // Register observer to listen for changes
+      // Observer stays phone-scoped for Brick upserts.
       _observer = _runner.registerObserver(
         query,
         arguments: arguments,
@@ -150,62 +152,61 @@ class WhatsAppMessageSyncService {
     String branchId,
   ) async {
     try {
-      // Extract fields from Ditto document
-      final messageId = doc['messageId']?.toString() ?? '';
+      final messageId = doc['messageId']?.toString() ??
+          doc['_id']?.toString() ??
+          doc['id']?.toString() ??
+          '';
       final messageBody =
           doc['messageBody']?.toString() ?? doc['caption']?.toString() ?? '';
       final from = doc['from']?.toString() ?? '';
-      final waId = doc['waId']?.toString() ?? '';
+      final waId = doc['waId']?.toString() ?? from;
       final contactName = doc['contactName']?.toString();
       final phoneNumberId = doc['phoneNumberId']?.toString() ?? '';
       final messageType = doc['messageType']?.toString() ?? 'text';
-      final timestampStr = doc['createdAt']?.toString() ?? '';
+      final timestampRaw = doc['createdAt']?.toString() ??
+          doc['timestamp']?.toString() ??
+          '';
 
-      // Only process text messages for now
-      if (messageType != 'text' || messageBody.isEmpty) {
+      // Skip empty non-media stubs; allow captioned media.
+      if (messageBody.isEmpty &&
+          messageType != 'image' &&
+          messageType != 'document' &&
+          messageType != 'audio' &&
+          messageType != 'video') {
         return;
       }
 
-      // Parse timestamp
-      DateTime? timestamp;
-      try {
-        timestamp = DateTime.parse(timestampStr);
-      } catch (e) {
-        timestamp = DateTime.now();
-      }
+      final displayText = messageBody.isNotEmpty
+          ? messageBody
+          : '[${messageType.isEmpty ? 'attachment' : messageType}]';
 
-      // Find or create conversation for this WhatsApp contact
+      final timestamp = _parseWhatsAppTimestamp(timestampRaw);
+
       final conversationId = await _getOrCreateConversation(
-        waId: waId,
-        contactName: contactName ?? from,
+        waId: waId.isNotEmpty ? waId : from,
+        contactName: contactName ?? (from.isNotEmpty ? from : 'Customer'),
         branchId: branchId,
       );
 
-      // Check if message already exists to avoid duplicates
-      // Only perform deduplication if messageId is available to avoid cross-branch conflicts'
       final repository = Repository();
       if (messageId.isNotEmpty) {
         final existingMessages = await repository.get<Message>(
           query: Query(
             where: [
               Where('whatsappMessageId').isExactly(messageId),
-              Where('branchId')
-                  .isExactly(branchId), // Scope deduplication per branch
+              Where('branchId').isExactly(branchId),
             ],
           ),
         );
 
         if (existingMessages.isNotEmpty) {
-          return; // Skip duplicate
+          return;
         }
-      } else {
-        // If messageId is missing, we skip the duplicate check to avoid dropping messages
-        // This prevents loss of messages that don't have a messageId
       }
 
-      // Create and save Message with WhatsApp-specific fields
+      // Inbound customer message → role `user` (shown on the left in the inbox).
       final message = Message(
-        text: messageBody,
+        text: displayText,
         phoneNumber: from,
         branchId: branchId,
         delivered: true,
@@ -221,9 +222,40 @@ class WhatsAppMessageSyncService {
       );
 
       await repository.upsert<Message>(message);
+
+      // Bump conversation ordering.
+      final conversations = await repository.get<Conversation>(
+        query: Query(where: [Where('id').isExactly(conversationId)]),
+      );
+      if (conversations.isNotEmpty) {
+        final c = conversations.first;
+        c.lastMessageAt = timestamp;
+        if (contactName != null &&
+            contactName.isNotEmpty &&
+            (c.title.isEmpty || c.title.startsWith('WhatsApp:'))) {
+          c.title = contactName;
+        }
+        await repository.upsert<Conversation>(c);
+      }
     } catch (e) {
-      // Log error but don't stop processing other messages
       print('Error transforming WhatsApp message: $e');
+    }
+  }
+
+  DateTime _parseWhatsAppTimestamp(String raw) {
+    if (raw.isEmpty) return DateTime.now().toUtc();
+    final asInt = int.tryParse(raw);
+    if (asInt != null) {
+      // Meta sends seconds; data-connector createdAt is millis.
+      if (asInt > 1000000000000) {
+        return DateTime.fromMillisecondsSinceEpoch(asInt, isUtc: true);
+      }
+      return DateTime.fromMillisecondsSinceEpoch(asInt * 1000, isUtc: true);
+    }
+    try {
+      return DateTime.parse(raw).toUtc();
+    } catch (_) {
+      return DateTime.now().toUtc();
     }
   }
 
@@ -235,7 +267,6 @@ class WhatsAppMessageSyncService {
   }) async {
     final repository = Repository();
 
-    // Try to find existing conversation for this WhatsApp contact using the dedicated whatsappWaId field
     final conversations = await repository.get<Conversation>(
       query: Query(
         where: [
@@ -249,11 +280,11 @@ class WhatsAppMessageSyncService {
       return conversations.first.id;
     }
 
-    // Create new conversation for this contact with the whatsappWaId field set
     final conversation = Conversation(
-      title: 'WhatsApp: $contactName',
+      title: contactName,
       branchId: branchId,
       whatsappWaId: waId,
+      useCase: 'whatsapp',
     );
 
     await repository.upsert<Conversation>(conversation);

--- a/packages/supabase_models/lib/brick/adapters/branch_sms_config_adapter.g.dart
+++ b/packages/supabase_models/lib/brick/adapters/branch_sms_config_adapter.g.dart
@@ -14,6 +14,7 @@ Future<BranchSmsConfig> _$BranchSmsConfigFromSupabase(
         : data['sms_phone_number'] as String?,
     enableSms: data['enable_sms'] as bool? ?? false,
     enableWhatsapp: data['enable_whatsapp'] as bool? ?? false,
+    whatsappProvider: (data['whatsapp_provider'] as num?)?.toInt() ?? 1,
   );
 }
 
@@ -28,6 +29,7 @@ Future<Map<String, dynamic>> _$BranchSmsConfigToSupabase(
     'sms_phone_number': instance.smsPhoneNumber,
     'enable_sms': instance.enableSms,
     'enable_whatsapp': instance.enableWhatsapp,
+    'whatsapp_provider': instance.whatsappProvider,
   };
 }
 
@@ -44,6 +46,7 @@ Future<BranchSmsConfig> _$BranchSmsConfigFromSqlite(
         : data['sms_phone_number'] as String?,
     enableSms: data['enable_sms'] == 1,
     enableWhatsapp: data['enable_whatsapp'] == 1,
+    whatsappProvider: data['whatsapp_provider'] as int? ?? 1,
   )..primaryKey = data['_brick_id'] as int;
 }
 
@@ -58,6 +61,7 @@ Future<Map<String, dynamic>> _$BranchSmsConfigToSqlite(
     'sms_phone_number': instance.smsPhoneNumber,
     'enable_sms': instance.enableSms ? 1 : 0,
     'enable_whatsapp': instance.enableWhatsapp ? 1 : 0,
+    'whatsapp_provider': instance.whatsappProvider,
   };
 }
 
@@ -91,6 +95,10 @@ class BranchSmsConfigAdapter
     'enableWhatsapp': const RuntimeSupabaseColumnDefinition(
       association: false,
       columnName: 'enable_whatsapp',
+    ),
+    'whatsappProvider': const RuntimeSupabaseColumnDefinition(
+      association: false,
+      columnName: 'whatsapp_provider',
     ),
   };
   @override
@@ -134,6 +142,12 @@ class BranchSmsConfigAdapter
       columnName: 'enable_whatsapp',
       iterable: false,
       type: bool,
+    ),
+    'whatsappProvider': const RuntimeSqliteColumnDefinition(
+      association: false,
+      columnName: 'whatsapp_provider',
+      iterable: false,
+      type: int,
     ),
   };
   @override

--- a/packages/supabase_models/lib/brick/adapters/branch_sms_config_adapter.g.dart
+++ b/packages/supabase_models/lib/brick/adapters/branch_sms_config_adapter.g.dart
@@ -12,7 +12,8 @@ Future<BranchSmsConfig> _$BranchSmsConfigFromSupabase(
     smsPhoneNumber: data['sms_phone_number'] == null
         ? null
         : data['sms_phone_number'] as String?,
-    enableOrderNotification: data['enable_order_notification'] as bool,
+    enableSms: data['enable_sms'] as bool? ?? false,
+    enableWhatsapp: data['enable_whatsapp'] as bool? ?? false,
   );
 }
 
@@ -25,7 +26,8 @@ Future<Map<String, dynamic>> _$BranchSmsConfigToSupabase(
     'id': instance.id,
     'branch_id': instance.branchId,
     'sms_phone_number': instance.smsPhoneNumber,
-    'enable_order_notification': instance.enableOrderNotification,
+    'enable_sms': instance.enableSms,
+    'enable_whatsapp': instance.enableWhatsapp,
   };
 }
 
@@ -40,7 +42,8 @@ Future<BranchSmsConfig> _$BranchSmsConfigFromSqlite(
     smsPhoneNumber: data['sms_phone_number'] == null
         ? null
         : data['sms_phone_number'] as String?,
-    enableOrderNotification: data['enable_order_notification'] == 1,
+    enableSms: data['enable_sms'] == 1,
+    enableWhatsapp: data['enable_whatsapp'] == 1,
   )..primaryKey = data['_brick_id'] as int;
 }
 
@@ -53,7 +56,8 @@ Future<Map<String, dynamic>> _$BranchSmsConfigToSqlite(
     'id': instance.id,
     'branch_id': instance.branchId,
     'sms_phone_number': instance.smsPhoneNumber,
-    'enable_order_notification': instance.enableOrderNotification ? 1 : 0,
+    'enable_sms': instance.enableSms ? 1 : 0,
+    'enable_whatsapp': instance.enableWhatsapp ? 1 : 0,
   };
 }
 
@@ -80,9 +84,13 @@ class BranchSmsConfigAdapter
       association: false,
       columnName: 'sms_phone_number',
     ),
-    'enableOrderNotification': const RuntimeSupabaseColumnDefinition(
+    'enableSms': const RuntimeSupabaseColumnDefinition(
       association: false,
-      columnName: 'enable_order_notification',
+      columnName: 'enable_sms',
+    ),
+    'enableWhatsapp': const RuntimeSupabaseColumnDefinition(
+      association: false,
+      columnName: 'enable_whatsapp',
     ),
   };
   @override
@@ -115,9 +123,15 @@ class BranchSmsConfigAdapter
       iterable: false,
       type: String,
     ),
-    'enableOrderNotification': const RuntimeSqliteColumnDefinition(
+    'enableSms': const RuntimeSqliteColumnDefinition(
       association: false,
-      columnName: 'enable_order_notification',
+      columnName: 'enable_sms',
+      iterable: false,
+      type: bool,
+    ),
+    'enableWhatsapp': const RuntimeSqliteColumnDefinition(
+      association: false,
+      columnName: 'enable_whatsapp',
       iterable: false,
       type: bool,
     ),

--- a/packages/supabase_models/lib/brick/db/20260728113000.migration.dart
+++ b/packages/supabase_models/lib/brick/db/20260728113000.migration.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE EDIT WITH CAUTION
+// THIS FILE **WILL NOT** BE REGENERATED
+// This file should be version controlled and can be manually edited.
+part of 'schema.g.dart';
+
+// While migrations are intelligently created, the difference between some commands, such as
+// DropTable vs. RenameTable, cannot be determined. For this reason, please review migrations after
+// they are created to ensure the correct inference was made.
+
+// The migration version must **always** mirror the file name
+
+const List<MigrationCommand> _migration_20260728113000_up = [
+  RenameColumn(
+    'enable_order_notification',
+    'enable_sms',
+    onTable: 'BranchSmsConfig',
+  ),
+  InsertColumn('enable_whatsapp', Column.boolean, onTable: 'BranchSmsConfig'),
+];
+
+const List<MigrationCommand> _migration_20260728113000_down = [
+  DropColumn('enable_whatsapp', onTable: 'BranchSmsConfig'),
+  RenameColumn(
+    'enable_sms',
+    'enable_order_notification',
+    onTable: 'BranchSmsConfig',
+  ),
+];
+
+//
+// DO NOT EDIT BELOW THIS LINE
+//
+
+@Migratable(
+  version: '20260728113000',
+  up: _migration_20260728113000_up,
+  down: _migration_20260728113000_down,
+)
+class Migration20260728113000 extends Migration {
+  const Migration20260728113000()
+    : super(
+        version: 20260728113000,
+        up: _migration_20260728113000_up,
+        down: _migration_20260728113000_down,
+      );
+}

--- a/packages/supabase_models/lib/brick/db/20260728163000.migration.dart
+++ b/packages/supabase_models/lib/brick/db/20260728163000.migration.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE EDIT WITH CAUTION
+// THIS FILE **WILL NOT** BE REGENERATED
+// This file should be version controlled and can be manually edited.
+part of 'schema.g.dart';
+
+const List<MigrationCommand> _migration_20260728163000_up = [
+  InsertColumn('whatsapp_provider', Column.integer, onTable: 'BranchSmsConfig'),
+];
+
+const List<MigrationCommand> _migration_20260728163000_down = [
+  DropColumn('whatsapp_provider', onTable: 'BranchSmsConfig'),
+];
+
+@Migratable(
+  version: '20260728163000',
+  up: _migration_20260728163000_up,
+  down: _migration_20260728163000_down,
+)
+class Migration20260728163000 extends Migration {
+  const Migration20260728163000()
+    : super(
+        version: 20260728163000,
+        up: _migration_20260728163000_up,
+        down: _migration_20260728163000_down,
+      );
+}

--- a/packages/supabase_models/lib/brick/db/schema.g.dart
+++ b/packages/supabase_models/lib/brick/db/schema.g.dart
@@ -11,6 +11,7 @@ part '20260630125158.migration.dart';
 part '20260702191831.migration.dart';
 part '20260705114226.migration.dart';
 part '20260723122459.migration.dart';
+part '20260728113000.migration.dart';
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{
@@ -24,11 +25,12 @@ final migrations = <Migration>{
   const Migration20260702191831(),
   const Migration20260705114226(),
   const Migration20260723122459(),
+  const Migration20260728113000(),
 };
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(
-  20260723122459,
+  20260728113000,
   generatorVersion: 1,
   tables: <SchemaTable>{
     SchemaTable(
@@ -191,7 +193,8 @@ final schema = Schema(
         SchemaColumn('id', Column.varchar, unique: true),
         SchemaColumn('branch_id', Column.varchar),
         SchemaColumn('sms_phone_number', Column.varchar),
-        SchemaColumn('enable_order_notification', Column.boolean),
+        SchemaColumn('enable_sms', Column.boolean),
+        SchemaColumn('enable_whatsapp', Column.boolean),
       },
       indices: <SchemaIndex>{
         SchemaIndex(columns: ['id'], unique: true),

--- a/packages/supabase_models/lib/brick/db/schema.g.dart
+++ b/packages/supabase_models/lib/brick/db/schema.g.dart
@@ -12,6 +12,7 @@ part '20260702191831.migration.dart';
 part '20260705114226.migration.dart';
 part '20260723122459.migration.dart';
 part '20260728113000.migration.dart';
+part '20260728163000.migration.dart';
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{
@@ -26,11 +27,12 @@ final migrations = <Migration>{
   const Migration20260705114226(),
   const Migration20260723122459(),
   const Migration20260728113000(),
+  const Migration20260728163000(),
 };
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(
-  20260728113000,
+  20260728163000,
   generatorVersion: 1,
   tables: <SchemaTable>{
     SchemaTable(
@@ -195,6 +197,7 @@ final schema = Schema(
         SchemaColumn('sms_phone_number', Column.varchar),
         SchemaColumn('enable_sms', Column.boolean),
         SchemaColumn('enable_whatsapp', Column.boolean),
+        SchemaColumn('whatsapp_provider', Column.integer),
       },
       indices: <SchemaIndex>{
         SchemaIndex(columns: ['id'], unique: true),

--- a/packages/supabase_models/lib/brick/models/branch_sms_config.model.dart
+++ b/packages/supabase_models/lib/brick/models/branch_sms_config.model.dart
@@ -13,12 +13,16 @@ class BranchSmsConfig extends OfflineFirstWithSupabaseModel {
 
   final String branchId;
   String? smsPhoneNumber;
-  bool enableOrderNotification;
+  bool enableSms;
+  bool enableWhatsapp;
 
   BranchSmsConfig({
     String? id,
     required this.branchId,
     this.smsPhoneNumber,
-    this.enableOrderNotification = false,
+    this.enableSms = false,
+    this.enableWhatsapp = false,
   }) : id = id ?? const Uuid().v4();
+
+  bool get hasAnyChannelEnabled => enableSms || enableWhatsapp;
 }

--- a/packages/supabase_models/lib/brick/models/branch_sms_config.model.dart
+++ b/packages/supabase_models/lib/brick/models/branch_sms_config.model.dart
@@ -3,6 +3,21 @@ import 'package:brick_sqlite/brick_sqlite.dart';
 import 'package:brick_supabase/brick_supabase.dart';
 import 'package:uuid/uuid.dart';
 
+/// WhatsApp delivery backend stored on [BranchSmsConfig.whatsappProvider].
+/// Matches data-connector `provider`: 1 = openwa, 2 = meta.
+abstract final class WhatsAppChannel {
+  static const int openwa = 1;
+  static const int meta = 2;
+
+  /// API string for data-connector (`openwa` | `meta`).
+  static String toApiProvider(int? code) {
+    if (code == meta) return 'meta';
+    return 'openwa';
+  }
+
+  static bool isMeta(int? code) => code == meta;
+}
+
 @ConnectOfflineFirstWithSupabase(
   supabaseConfig: SupabaseSerializable(tableName: 'branch_sms_configs'),
 )
@@ -16,12 +31,16 @@ class BranchSmsConfig extends OfflineFirstWithSupabaseModel {
   bool enableSms;
   bool enableWhatsapp;
 
+  /// `1` = OpenWA, `2` = Meta Cloud API (see [WhatsAppChannel]).
+  int whatsappProvider;
+
   BranchSmsConfig({
     String? id,
     required this.branchId,
     this.smsPhoneNumber,
     this.enableSms = false,
     this.enableWhatsapp = false,
+    this.whatsappProvider = WhatsAppChannel.openwa,
   }) : id = id ?? const Uuid().v4();
 
   bool get hasAnyChannelEnabled => enableSms || enableWhatsapp;

--- a/packages/supabase_models/lib/brick/models/business.model.dart
+++ b/packages/supabase_models/lib/brick/models/business.model.dart
@@ -353,22 +353,22 @@ class Business extends OfflineFirstWithSupabaseModel {
     }
   }
 
-  /// Set WhatsApp phone number ID in messaging channels
+  /// Set WhatsApp phone number ID in messaging channels.
+  ///
+  /// Mutates this instance in place — [copyWith] drops several Business fields
+  /// (email, tax flags, bhfId, …), so it must not be used for this update.
   Business setWhatsAppPhoneNumberId(String? phoneNumberId) {
     Map<String, dynamic> channels = {};
 
-    // Parse existing channels if any
     if (messagingChannels != null && messagingChannels!.isNotEmpty) {
       try {
         channels =
             Map<String, dynamic>.from(jsonDecode(messagingChannels!) as Map);
-      } catch (e) {
-        // If parsing fails, start with empty map
+      } catch (_) {
         channels = {};
       }
     }
 
-    // Update or remove WhatsApp config
     if (phoneNumberId == null || phoneNumberId.isEmpty) {
       channels.remove('whatsapp');
     } else {
@@ -379,9 +379,19 @@ class Business extends OfflineFirstWithSupabaseModel {
       };
     }
 
-    // Return updated business
-    return copyWith(
-      messagingChannels: channels.isEmpty ? '{}' : jsonEncode(channels),
-    );
+    messagingChannels = channels.isEmpty ? '{}' : jsonEncode(channels);
+    return this;
+  }
+
+  /// Parsed messaging channels map (empty if unset / invalid).
+  Map<String, dynamic> messagingChannelsMap() {
+    if (messagingChannels == null || messagingChannels!.isEmpty) {
+      return {};
+    }
+    try {
+      return Map<String, dynamic>.from(jsonDecode(messagingChannels!) as Map);
+    } catch (_) {
+      return {};
+    }
   }
 }

--- a/packages/supabase_models/lib/brick/repository.dart
+++ b/packages/supabase_models/lib/brick/repository.dart
@@ -579,29 +579,29 @@ class Repository extends OfflineFirstWithSupabaseRepository {
     }
     try {
       debugPrint('Upserting: ${instance.toString()}');
-      try {
-        if (instance is ITransaction) {
-          instance.items ??= [];
+      if (instance is ITransaction) {
+        instance.items ??= [];
+      }
+      if (instance is TransactionItem) {
+        debugPrint('We got item to save: ${instance.toString()}');
+      }
+      instance = await super.upsert(instance, policy: policy, query: query);
+      // Counters are Capella-only in Ditto; never push SQLite/Supabase rows.
+      if (!skipDittoSync && instance is! Counter) {
+        if (instance is Stock) {
+          debugPrint('New Current Stock: ${instance.currentStock}');
         }
         if (instance is TransactionItem) {
           debugPrint('We got item to save: ${instance.toString()}');
         }
-        instance = await super.upsert(instance, policy: policy, query: query);
-        // Counters are Capella-only in Ditto; never push SQLite/Supabase rows.
-        if (!skipDittoSync && instance is! Counter) {
-          if (instance is Stock) {
-            debugPrint('New Current Stock: ${instance.currentStock}');
-          }
-          if (instance is TransactionItem) {
-            debugPrint('We got item to save: ${instance.toString()}');
-          }
+        try {
           unawaited(
             DittoSyncCoordinator.instance.notifyLocalUpsert(instance),
           );
+        } catch (e, stackTrace) {
+          _logger.warning(
+              'Error notifying Ditto of local change: $e', stackTrace);
         }
-      } catch (e, stackTrace) {
-        _logger.warning(
-            'Error notifying Ditto of local change: $e', stackTrace);
       }
 
       return instance;

--- a/packages/supabase_models/lib/brick/repository/platform_helpers_io.dart
+++ b/packages/supabase_models/lib/brick/repository/platform_helpers_io.dart
@@ -7,6 +7,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:logging/logging.dart';
 import 'package:sqflite_common_ffi_web/sqflite_ffi_web.dart';
 import 'package:supabase_models/brick/databasePath.dart';
+import 'package:supabase_models/brick/repository/turso_preflight_repair.dart';
 // ignore: depend_on_referenced_packages
 export 'package:brick_core/query.dart'
     show And, Or, Query, QueryAction, Where, WherePhrase, Compare, OrderBy;
@@ -116,6 +117,8 @@ class PlatformHelpers {
     final DatabaseFactory factory;
     if (AppSecrets.tursoCloudSyncEnabled) {
       final localFile = File(localPath);
+      // Fix known BranchSmsConfig temp-rebuild corruption before Turso opens.
+      repairTursoMigrationCorruptionIfNeeded(localPath);
       if (TursoReplicaPaths.hasOrphanedSyncMetadata(localPath)) {
         _logger.warning(
           'Removing orphaned Turso sync metadata for $localPath '
@@ -147,6 +150,7 @@ class PlatformHelpers {
       );
     } else {
       _logger.info('Using local Turso for main Brick database');
+      repairTursoMigrationCorruptionIfNeeded(localPath);
       factory = tursoDatabaseFactory();
     }
 

--- a/packages/supabase_models/lib/brick/repository/turso_preflight_repair.dart
+++ b/packages/supabase_models/lib/brick/repository/turso_preflight_repair.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+final _logger = Logger('TursoPreflightRepair');
+
+/// Repairs known Turso migration corruption **before** Turso opens the replica.
+///
+/// Failed [AlterColumnHelper] rebuilds on `BranchSmsConfig` have left:
+/// - indexes pointing at dropped `temp_branchsmsconfig`
+/// - duplicate `sqlite_master` rows for `BranchSmsConfig` / `branchsmsconfig`
+///
+/// Those break Turso open with `table "branchsmsconfig" already exists` /
+/// `no such table: main.temp_branchsmsconfig`. Local SMS config is cheap to
+/// rebuild from Supabase; prefer an empty healthy table over a brick.
+void repairTursoMigrationCorruptionIfNeeded(String localDbPath) {
+  final file = File(localDbPath);
+  if (!file.existsSync() || file.lengthSync() == 0) {
+    return;
+  }
+
+  Database? db;
+  try {
+    db = sqlite3.open(localDbPath);
+    final needsRepair = _needsBranchSmsConfigRepair(db);
+    if (!needsRepair) {
+      return;
+    }
+
+    _logger.warning(
+      'Repairing BranchSmsConfig Turso migration corruption at $localDbPath',
+    );
+
+    db.execute('PRAGMA writable_schema=ON');
+    db.execute(
+      "DELETE FROM sqlite_master WHERE type='index' AND sql LIKE '%temp_%'",
+    );
+    // Keep one table entry; Turso case-folding can leave a ghost lowercase twin.
+    final tables = db.select(
+      "SELECT rowid, name FROM sqlite_master WHERE type='table' "
+      "AND lower(name)='branchsmsconfig' ORDER BY rowid",
+    );
+    if (tables.length > 1) {
+      for (var i = 1; i < tables.length; i++) {
+        final rowid = tables[i]['rowid'];
+        db.execute('DELETE FROM sqlite_master WHERE rowid=?', [rowid]);
+      }
+    }
+    db.execute('PRAGMA writable_schema=OFF');
+
+    // If schema is still unusable, recreate an empty BranchSmsConfig.
+    // Channel flags rehydrate from Supabase `branch_sms_configs`.
+    try {
+      db.select('PRAGMA table_info(BranchSmsConfig)');
+      db.select('SELECT COUNT(*) AS c FROM BranchSmsConfig');
+    } catch (e) {
+      _logger.warning(
+        'BranchSmsConfig still unreadable ($e); recreating empty table',
+      );
+      db.execute('DROP TABLE IF EXISTS BranchSmsConfig');
+      db.execute('DROP TABLE IF EXISTS branchsmsconfig');
+      db.execute('''
+        CREATE TABLE BranchSmsConfig (
+          _brick_id INTEGER PRIMARY KEY AUTOINCREMENT,
+          id VARCHAR UNIQUE,
+          branch_id VARCHAR,
+          sms_phone_number VARCHAR,
+          enable_sms INTEGER,
+          enable_whatsapp INTEGER
+        )
+      ''');
+      db.execute(
+        'CREATE UNIQUE INDEX IF NOT EXISTS index_BranchSmsConfig_on_id '
+        'ON BranchSmsConfig ("id")',
+      );
+    }
+
+    try {
+      db.execute('PRAGMA wal_checkpoint(TRUNCATE)');
+    } catch (_) {}
+  } catch (e, s) {
+    _logger.warning(
+      'Turso preflight repair failed for $localDbPath: $e',
+      e,
+      s,
+    );
+  } finally {
+    db?.dispose();
+  }
+}
+
+bool _needsBranchSmsConfigRepair(Database db) {
+  try {
+    final badIndexes = db.select(
+      "SELECT name, sql FROM sqlite_master WHERE type='index' "
+      "AND sql LIKE '%temp_%'",
+    );
+    for (final row in badIndexes) {
+      final sql = row['sql']?.toString() ?? '';
+      if (sql.toLowerCase().contains('temp_')) {
+        return true;
+      }
+    }
+
+    final tables = db.select(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND lower(name)='branchsmsconfig'",
+    );
+    if (tables.length > 1) {
+      return true;
+    }
+
+    // Probe readability — malformed schema often surfaces here.
+    db.select('SELECT 1 FROM BranchSmsConfig LIMIT 1');
+    return false;
+  } catch (e) {
+    final msg = e.toString().toLowerCase();
+    return msg.contains('temp_branch') ||
+        msg.contains('branchsmsconfig') ||
+        msg.contains('malformed') ||
+        msg.contains('already exists');
+  }
+}


### PR DESCRIPTION
The Credits feature (MoMo top-up) was unreachable on mobile from both
launchers, for two separate reasons:

- dashboardAllAppsCatalog never carried a Credits tile over when the
  grouped "All apps" sheet was built, so it was absent there entirely.
- The Quick Access tile in AppIconsGrid is tagged feature: 'Credits',
  which routes through featureAccessProvider. 'Credits' is not in
  AppFeature and no current code path seeds an Access row for it, so the
  check denied everyone and hid the tile.

Add the tile to the Finance section of the catalog and whitelist
'Credits' in both visibility filters, matching the existing
Orders/ServicesGigs/Settings pattern. Buying credits is an account-level
top-up where the purchaser enters their own phone number, so there is no
staff permission to gate on.

The rest of the feature was already intact and is unchanged: the
'Credits' -> CreditAppRoute case, the purchase widget's payNow /
checkPaymentStatus flow, and the Supabase realtime balance stream.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate SMS and WhatsApp notification controls for orders and digital receipts, including WhatsApp channel selection.
  * Added WhatsApp “Meta opt-in” prompting for queued message delivery.
  * Added WhatsApp inbox threads/messages experience backed by Ditto sync.
  * Added a Credits shortcut in the Finance section.
* **Bug Fixes**
  * Improved SMS/WhatsApp receipt delivery, including cases without existing transaction records.
  * Added validation for missing WhatsApp connector configuration.
  * Fixed stale cart hiding and pinned/suppression cleanup on resume/completed sales.
* **Localization**
  * Added WhatsApp notification labels and descriptions (all supported languages).
* **Chores**
  * Bumped app/package versions and updated an open-source dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->