### PR TITLE
fix(brick): stamp a live JWT on queued Supabase requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
       - dev
       - re-design
       - v5
-      - product-editor-category-variants-ux
+      - fix/*
 env:
   URL: ${{ secrets.DB_URL }}
   PASSWORD: ${{ secrets.DB_PASSWORD }}

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.299.0+1756529786
+version: 1.300.0+1756529787
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.303.0.0
+  msix_version: 1.304.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.296.0+1756529783
+version: 1.297.0+1756529784
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.300.0.0
+  msix_version: 1.301.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.298.0+1756529785
+version: 1.299.0+1756529786
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.302.0.0
+  msix_version: 1.303.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.297.0+1756529784
+version: 1.298.0+1756529785
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.301.0.0
+  msix_version: 1.302.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/packages/flipper_dashboard/lib/data_view_reports/DynamicDataSource.dart
+++ b/packages/flipper_dashboard/lib/data_view_reports/DynamicDataSource.dart
@@ -14,8 +14,8 @@ import 'package:talker_flutter/talker_flutter.dart';
 
 final talker = TalkerFlutter.init();
 
-/// Column count for transaction summary grid (non-PLU): receipt, cashier, …, actions.
-const int kTransactionSummaryColumnCount = 10;
+/// Column count for transaction summary grid (non-PLU): receipt, cashier, customer, …, actions.
+const int kTransactionSummaryColumnCount = 11;
 
 String transactionReportReceiptLabel(ITransaction t) {
   final inv = t.invoiceNumber;
@@ -26,6 +26,16 @@ String transactionReportReceiptLabel(ITransaction t) {
   if (id.isEmpty) return '—';
   final short = id.length > 5 ? id.substring(0, 5) : id;
   return '#${short.toUpperCase()}';
+}
+
+/// Summary grid / export Customer column: stored name, else the phone captured on
+/// the sale, else a dash so walk-in sales stay visually aligned with named ones.
+String transactionReportCustomerLabel(ITransaction t) {
+  final name = t.customerName?.trim();
+  if (name != null && name.isNotEmpty) return name;
+  final phone = (t.customerPhone ?? t.currentSaleCustomerPhoneNumber)?.trim();
+  if (phone != null && phone.isNotEmpty) return phone;
+  return '—';
 }
 
 String _transactionReportStatusLabel(ITransaction tx) {
@@ -72,6 +82,7 @@ Map<String, Object?> transactionSummaryExportRow(
       transaction,
       directory: cashierDirectory,
     ),
+    'Customer': transactionReportCustomerLabel(transaction),
     'Type': transactionReportGridTypeLabel(transaction),
     'Status': _transactionReportStatusLabel(transaction),
     'SaleTotal': _signedReportMoney(transaction.subTotal ?? 0.0, transaction),
@@ -356,6 +367,10 @@ abstract class DynamicDataSource<T> extends DataGridSource {
           ),
         ),
         DataGridCell<String>(
+          columnName: 'Customer',
+          value: transactionReportCustomerLabel(trans),
+        ),
+        DataGridCell<String>(
           columnName: 'Type',
           value: transactionReportGridTypeLabel(trans),
         ),
@@ -577,6 +592,29 @@ abstract class DynamicDataSource<T> extends DataGridSource {
                 ),
               ),
             ],
+          ),
+        );
+      }
+      if (name == 'Customer') {
+        final label = tx != null
+            ? transactionReportCustomerLabel(tx)
+            : (e.value?.toString() ?? '');
+        final unnamed = label == '—' || label.isEmpty;
+        return Container(
+          alignment: Alignment.centerLeft,
+          color: rowBg,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            unnamed ? '—' : label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: unnamed ? FontWeight.w500 : FontWeight.w600,
+              color: unnamed
+                  ? const Color(0xFF9CA3AF)
+                  : const Color(0xFF111827),
+            ),
           ),
         );
       }

--- a/packages/flipper_dashboard/lib/data_view_reports/HeaderTransactionItem.dart
+++ b/packages/flipper_dashboard/lib/data_view_reports/HeaderTransactionItem.dart
@@ -40,6 +40,10 @@ mixin Headers<T extends ConsumerStatefulWidget> on ConsumerState<T> {
         label: _zReportHeaderLabel(headerPadding, 'CASHIER', active: true),
       ),
       GridColumn(
+        columnName: 'Customer',
+        label: _zReportHeaderLabel(headerPadding, 'CUSTOMER'),
+      ),
+      GridColumn(
         columnName: 'Type',
         label: _zReportHeaderLabel(headerPadding, 'TYPE'),
       ),

--- a/packages/flipper_models/lib/helperModels/sale_completion_helpers.dart
+++ b/packages/flipper_models/lib/helperModels/sale_completion_helpers.dart
@@ -59,6 +59,31 @@ String applyTicketReviewWorkflowRedirect({
   return saleCompletionStatusPendingReview;
 }
 
+/// Aligned with [PENDING] in `flipper_services/constants.dart` (VM-safe).
+const String saleCompletionStatusPending = 'pending';
+
+/// The report date a POS row should carry once it settles, or `null` to leave
+/// `createdAt` untouched.
+///
+/// A POS cart row is minted the moment the *previous* sale finishes and is then
+/// reused with no age limit, so its `createdAt` is the previous sale's
+/// timestamp — not this sale's. It must therefore be re-stamped on the
+/// transition out of [saleCompletionStatusPending], and only then: every later
+/// write (refunds, receipt counters, RRA fields) has to preserve the sale date.
+///
+/// The returned value is always local time. Report windows are built from local
+/// wall clock with no `Z` suffix and Ditto compares them as strings, so a UTC
+/// stamp shifts sales out of their own day (−2h in Rwanda).
+DateTime? posSettlementCreatedAtStamp({
+  required String? priorStatus,
+  required String? newStatus,
+  required DateTime settledAt,
+}) {
+  if (newStatus == null || newStatus == saleCompletionStatusPending) return null;
+  if (priorStatus != saleCompletionStatusPending) return null;
+  return settledAt.isUtc ? settledAt.toLocal() : settledAt;
+}
+
 /// Statuses that mean "money already collected, tax already signed" for
 /// accounting/reporting purposes, even though the ticket is not yet in its
 /// final [saleCompletionStatusComplete] state.

--- a/packages/flipper_models/lib/sync/capella/mixins/transaction_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/transaction_mixin.dart
@@ -15,6 +15,7 @@ import 'package:supabase_models/brick/models/sars.model.dart';
 import 'package:supabase_models/brick/repository.dart';
 import 'package:synchronized/synchronized.dart';
 import 'package:talker/talker.dart';
+import 'package:flipper_models/helperModels/sale_completion_helpers.dart';
 import 'package:flipper_models/helperModels/sale_device_id.dart';
 import 'package:flipper_models/sync/utils/rra_sar_sequence.dart';
 import 'package:flipper_models/sync/utils/sale_line_pricing.dart';
@@ -2186,18 +2187,20 @@ mixin CapellaTransactionMixin implements TransactionInterface {
     if (updates.isEmpty) return;
 
     final newStatus = arguments['status'] as String?;
-    Map<String, dynamic>? priorRowForEnsure;
-    if (!skipDittoSync &&
-        !deferEnsureNextPendingCart &&
-        newStatus != null &&
-        newStatus != PENDING) {
+    final leavingPending = newStatus != null && newStatus != PENDING;
+
+    // The prior row answers two questions: whether to prime the next pending
+    // cart, and whether this write is the PENDING → settled transition that
+    // owns the report date (see the createdAt re-stamp below).
+    Map<String, dynamic>? priorRow;
+    if (!skipDittoSync && leavingPending) {
       try {
         final pre = await ditto.store.execute(
           'SELECT * FROM transactions WHERE _id = :id OR id = :id',
           arguments: {'id': targetId},
         );
         if (pre.items.isNotEmpty) {
-          priorRowForEnsure = Map<String, dynamic>.from(pre.items.first.value);
+          priorRow = Map<String, dynamic>.from(pre.items.first.value);
         }
       } catch (e, s) {
         talker.warning(
@@ -2205,6 +2208,22 @@ mixin CapellaTransactionMixin implements TransactionInterface {
           s,
         );
       }
+    }
+    // Unchanged gate: when the caller primes the next cart itself
+    // (markTransactionAsCompleted → manageTransaction) we must not race it.
+    final priorRowForEnsure = deferEnsureNextPendingCart ? null : priorRow;
+
+    // The cart row this write is settling was minted by
+    // [_ensureNextPendingCartIfNeeded] when the *previous* sale finished, so its
+    // createdAt is that sale's timestamp — re-stamp it here, and only here. See
+    // [posSettlementCreatedAtStamp] for the rule and why the stamp is local.
+    if (priorRow != null) {
+      final saleDate = posSettlementCreatedAtStamp(
+        priorStatus: priorRow['status'] as String?,
+        newStatus: newStatus,
+        settledAt: resolvedLastTouched,
+      );
+      if (saleDate != null) addFieldUpdate('createdAt', saleDate);
     }
 
     final statusGuardClause = requireCurrentStatus != null
@@ -2615,7 +2634,11 @@ mixin CapellaTransactionMixin implements TransactionInterface {
 
     final targetId = transaction.id;
     final branchId = transaction.branchId ?? ProxyService.box.getBranchId()!;
-    final nowIso = DateTime.now().toUtc().toIso8601String();
+    final now = DateTime.now();
+    final nowIso = now.toUtc().toIso8601String();
+    // Report windows compare local wall-clock strings — see the createdAt note
+    // on [setClauses] below.
+    final nowLocalIso = now.toIso8601String();
 
     // Ensure peers subscribed to this branch can pull the PARKED update.
     // Pending-cart sync alone is deviceId+PENDING and does not match parks.
@@ -2685,15 +2708,25 @@ mixin CapellaTransactionMixin implements TransactionInterface {
     // POS tickets list filters `isOriginalTransaction = true`; ensure park
     // always lands in that set (kitchen already skips this check).
     transaction.isOriginalTransaction = true;
+    transaction.createdAt = now;
 
-    // Preserve original sale createdAt. Till "sent N min ago" uses lastTouched
-    // captured into SettlingTillTicket at Collect (before resume bumps it).
+    // Park is this ticket's transition out of the shared pending cart, whose
+    // createdAt is the *previous* sale's timestamp (see the re-stamp in
+    // [updateTransaction]) — so stamp the ticket's real open time here, or a
+    // parked ticket files under the wrong day in Transaction Reports. Local,
+    // not UTC, to match the report window's wall-clock string bounds.
+    // [resumeSaleTicketFast] deliberately leaves createdAt alone; the later
+    // PENDING → COMPLETE write re-stamps it to the settlement date.
+    //
+    // Till "sent N min ago" uses lastTouched captured into SettlingTillTicket
+    // at Collect (before resume bumps it), so it is unaffected.
     final setClauses = <String>[
       'status = :status',
       'ticketName = :ticketName',
       'note = :note',
       'isLoan = :isLoan',
       'isOriginalTransaction = :isOriginal',
+      'createdAt = :createdAt',
       'updatedAt = :updatedAt',
       'lastTouched = :lastTouched',
       'subTotal = :subTotal',
@@ -2705,6 +2738,7 @@ mixin CapellaTransactionMixin implements TransactionInterface {
       'note': ticketNote,
       'isLoan': transaction.isLoan ?? false,
       'isOriginal': true,
+      'createdAt': nowLocalIso,
       'updatedAt': nowIso,
       'lastTouched': nowIso,
       'subTotal': subTotal,
@@ -2766,8 +2800,9 @@ mixin CapellaTransactionMixin implements TransactionInterface {
     }
 
     final nowIso = DateTime.now().toUtc().toIso8601String();
-    // Do NOT touch createdAt here: it holds the original sale time (park no
-    // longer overwrites it). Till "sent N min ago" is stamped onto
+    // Do NOT touch createdAt here: resume is not a settlement. The row keeps
+    // the park stamp until the PENDING → COMPLETE write re-stamps it to the
+    // settlement date. Till "sent N min ago" is stamped onto
     // SettlingTillTicket from lastTouched *before* this resume write.
     //
     // Resume the ticket *before* sibling-cart cleanup. Cleanup used to run

--- a/packages/flipper_models/test/sale_completion_helpers_test.dart
+++ b/packages/flipper_models/test/sale_completion_helpers_test.dart
@@ -264,4 +264,103 @@ void main() {
       expect(isFinanciallySettledSaleStatus(null), isFalse);
     });
   });
+
+  group('posSettlementCreatedAtStamp', () {
+    // The shared pending cart is minted when the previous sale finishes, so its
+    // createdAt is yesterday's last sale for the first sale of a new day.
+    final yesterdayCart = DateTime(2026, 8, 6, 18, 30);
+    final settledNow = DateTime(2026, 8, 7, 9, 15);
+
+    test('re-stamps the sale date when the cart leaves pending', () {
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusPending,
+          newStatus: saleCompletionStatusComplete,
+          settledAt: settledNow,
+        ),
+        settledNow,
+      );
+    });
+
+    test('re-stamps for parked, pendingReview and awaitingHandover too', () {
+      for (final status in [
+        saleCompletionStatusParked,
+        saleCompletionStatusPendingReview,
+        saleCompletionStatusAwaitingHandover,
+      ]) {
+        expect(
+          posSettlementCreatedAtStamp(
+            priorStatus: saleCompletionStatusPending,
+            newStatus: status,
+            settledAt: settledNow,
+          ),
+          settledNow,
+          reason: 'leaving the pending cart for $status owns the report date',
+        );
+      }
+    });
+
+    test('preserves the sale date on later writes (refund, counters, RRA)', () {
+      // Prior row is already settled — createdAt must not move.
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusComplete,
+          newStatus: saleCompletionStatusComplete,
+          settledAt: settledNow,
+        ),
+        isNull,
+      );
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusParked,
+          newStatus: saleCompletionStatusComplete,
+          settledAt: settledNow,
+        ),
+        isNull,
+      );
+    });
+
+    test('does not stamp when the row stays a pending cart', () {
+      // e.g. resumeSaleTicketFast (parked → pending) and cart edits.
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusPending,
+          newStatus: saleCompletionStatusPending,
+          settledAt: settledNow,
+        ),
+        isNull,
+      );
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusPending,
+          newStatus: null,
+          settledAt: settledNow,
+        ),
+        isNull,
+      );
+    });
+
+    test('normalizes a UTC settlement time to local', () {
+      // Report windows are local wall-clock strings with no `Z`, compared
+      // lexicographically — a UTC stamp would file the sale in the wrong day.
+      final stamp = posSettlementCreatedAtStamp(
+        priorStatus: saleCompletionStatusPending,
+        newStatus: saleCompletionStatusComplete,
+        settledAt: settledNow.toUtc(),
+      );
+      expect(stamp!.isUtc, isFalse);
+      expect(stamp, settledNow);
+      expect(stamp.toIso8601String(), isNot(endsWith('Z')));
+    });
+
+    test("the stale cart date is never what lands on the sale", () {
+      final stamp = posSettlementCreatedAtStamp(
+        priorStatus: saleCompletionStatusPending,
+        newStatus: saleCompletionStatusComplete,
+        settledAt: settledNow,
+      );
+      expect(stamp, isNot(yesterdayCart));
+      expect(stamp!.day, 7, reason: 'sold on the 7th, not the cart-mint day');
+    });
+  });
 }

--- a/packages/supabase_models/lib/brick/repository.dart
+++ b/packages/supabase_models/lib/brick/repository.dart
@@ -304,6 +304,12 @@ class Repository extends OfflineFirstWithSupabaseRepository {
       },
     );
 
+    // Tags each write with the signed-in uid. This has to wrap the queue
+    // rather than sit inside it: the queue serializes headers into SQLite
+    // before AuthRefreshingClient runs, so a stamp applied further down would
+    // never be persisted alongside the job.
+    final stampingClient = EnqueuedUserStampClient(client);
+
     final SupabaseClient supabaseClient;
     final mock = SupabaseMockServer(modelDictionary: supabaseModelDictionary);
 
@@ -311,15 +317,15 @@ class Repository extends OfflineFirstWithSupabaseRepository {
       debugPrint('Using mocked Supabase client in test environment');
       // Use the mocked client in a test environment
       await mock.setUp();
-      supabaseClient =
-          SupabaseClient(mock.serverUrl, mock.apiKey, httpClient: client);
+      supabaseClient = SupabaseClient(mock.serverUrl, mock.apiKey,
+          httpClient: stampingClient);
     } else {
       debugPrint('Using real Supabase client in non-test environment');
       // Initialize the real Supabase client in a non-test environment
       supabaseClient = (await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseAnonKey,
-        httpClient: client,
+        httpClient: stampingClient,
       ))
           .client;
     }

--- a/packages/supabase_models/lib/brick/repository.dart
+++ b/packages/supabase_models/lib/brick/repository.dart
@@ -11,7 +11,7 @@ import 'package:brick_supabase/brick_supabase.dart' hide Supabase;
 import 'package:flipper_services/constants.dart';
 import 'package:flipper_services/event_bus.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:http/http.dart' as http show Request;
+import 'package:http/http.dart' as http show Client, Request;
 import 'package:supabase_models/brick/brick.g.dart';
 import 'package:supabase_models/brick/databasePath.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, debugPrint;
@@ -25,6 +25,7 @@ import 'package:logging/logging.dart';
 export 'package:brick_core/query.dart'
     show And, Or, Query, QueryAction, Where, WherePhrase, Compare, OrderBy;
 
+import 'repository/auth_refreshing_client.dart';
 import 'repository/database_manager.dart';
 import 'repository/legacy_database_migration.dart';
 import 'repository/queue_manager.dart';
@@ -268,6 +269,29 @@ class Repository extends OfflineFirstWithSupabaseRepository {
     final (client, queue) = OfflineFirstWithSupabaseRepository.clientQueue(
       databaseFactory: PlatformHelpers.getQueueDatabaseFactory(),
       databasePath: queuePath, // This is the path for the queue database
+      // Stamps a live access token onto every request, including queue
+      // replays, which would otherwise carry the JWT frozen at enqueue time.
+      innerClient: AuthRefreshingClient(
+        http.Client(),
+        anonKey: supabaseAnonKey,
+      ),
+      // Brick's default list contains 401 and 403, which means an auth
+      // rejection is retried forever. Because the queue is serial and ordered
+      // by created_at, one such job sits at the head and blocks every other
+      // pending write. AuthRefreshingClient already holds requests back (503)
+      // while there is no session, so a 401/403 that still reaches us is a
+      // genuine rejection and the job should be dropped.
+      reattemptForStatusCodes: const [
+        400,
+        404,
+        405,
+        408,
+        429,
+        500,
+        502,
+        503,
+        504,
+      ],
       onReattempt: (http.Request request, dynamic object) async {
         _logger.info('Reattempting offline request: ${request.url}');
       },
@@ -322,6 +346,14 @@ class Repository extends OfflineFirstWithSupabaseRepository {
       dbPath: dbPath,
     );
     await _singleton!._ensurePendingAnalyticsEventTable();
+
+    // Clear jobs that have already exhausted their reattempts. Queues in the
+    // field can hold requests that looped on a 401 for as long as the app has
+    // been installed, blocking every write behind them.
+    final purged = await _singleton!.purgeExhaustedQueue();
+    if (purged > 0) {
+      _logger.warning('Purged $purged exhausted offline queue request(s)');
+    }
 
     _markReady();
     print('✅ [Repository] Repository marked as ready');
@@ -480,6 +512,25 @@ class Repository extends OfflineFirstWithSupabaseRepository {
     } catch (e) {
       _logger.warning('Error getting queue status: $e');
       return {'locked': 0, 'unlocked': 0, 'total': 0};
+    }
+  }
+
+  /// Drop queued requests that have exhausted their reattempts.
+  /// Returns the number of requests deleted.
+  Future<int> purgeExhaustedQueue() async {
+    if (kIsWeb) {
+      return 0;
+    }
+    if (_isDisposed) {
+      _logger.warning(
+          'Attempted to call purgeExhaustedQueue on a disposed Repository.');
+      return 0;
+    }
+    try {
+      return await _queueManager.purgeExhaustedRequests();
+    } catch (e) {
+      _logger.warning('Error purging exhausted queue: $e');
+      return 0;
     }
   }
 

--- a/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
+++ b/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+// ignore: depend_on_referenced_packages
+import 'package:logging/logging.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// An [http.Client] that stamps a *current* Supabase access token onto every
+/// outgoing PostgREST/Storage/Functions request.
+///
+/// This sits **below** Brick's offline queue. That matters: the queue
+/// serializes a request's entire header map into SQLite when the request is
+/// created (`RestRequestSqliteCache.toSqlite`) and replays it verbatim later,
+/// so a job that waits longer than the access-token lifetime (1h by default)
+/// would otherwise be sent with a dead JWT and rejected by PostgREST with a
+/// 401. Because this client runs on both the first attempt and every replay,
+/// the stored `Authorization` header is always overwritten with a live one.
+///
+/// When no usable token can be obtained, the request is **not** sent — the
+/// client synthesizes a retryable [_noSessionStatus] response so the job stays
+/// in the queue instead of burning an unauthenticated round trip.
+class AuthRefreshingClient extends http.BaseClient {
+  /// Retryable status used when there is no session to authenticate with.
+  /// Must be present in the queue's `reattemptForStatusCodes` so the job is
+  /// kept rather than discarded.
+  static const int _noSessionStatus = 503;
+
+  /// Refresh the token this long before it actually expires, so a request
+  /// that is in flight when the clock rolls over is not rejected.
+  static const Duration _expiryLeeway = Duration(minutes: 1);
+
+  /// After a failed refresh, don't try again for this long. The queue ticks
+  /// every 5 seconds; without a cooldown a broken session would hammer
+  /// `/auth/v1/token`.
+  static const Duration _refreshCooldown = Duration(seconds: 30);
+
+  /// Paths that carry their own credentials and must be forwarded untouched.
+  /// Rewriting the header on the token endpoint would break session refresh
+  /// (and recurse, since refreshes are issued through this same client).
+  static const _passthroughPaths = ['/auth/v1'];
+
+  /// Paths whose requests are authenticated with the user's access token.
+  static const _authenticatedPaths = ['/rest/v1', '/storage/v1', '/functions/v1'];
+
+  final http.Client _inner;
+  final String _anonKey;
+  final Logger _logger;
+
+  /// Deduplicates concurrent refreshes; the queue and the UI can both trip the
+  /// expiry check at the same moment.
+  Future<Session?>? _inFlightRefresh;
+  DateTime? _refreshFailedAt;
+
+  AuthRefreshingClient(
+    this._inner, {
+    required String anonKey,
+    Logger? logger,
+  })  : _anonKey = anonKey,
+        _logger = logger ?? Logger('AuthRefreshingClient');
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final path = request.url.path;
+
+    if (_passthroughPaths.any(path.startsWith) ||
+        !_authenticatedPaths.any(path.startsWith)) {
+      return _inner.send(request);
+    }
+
+    final token = await _currentAccessToken();
+
+    if (token == null) {
+      _logger.warning(
+        'No Supabase session; holding ${request.method} $path in the queue',
+      );
+      // Shaped like a PostgREST error so postgrest_dart raises a normal
+      // PostgrestException rather than choking on an unparseable body.
+      const body =
+          '{"code":"no_session","message":"No active Supabase session",'
+          '"details":null,"hint":null}';
+      return http.StreamedResponse(
+        Stream.value(utf8.encode(body)),
+        _noSessionStatus,
+        request: request,
+        contentLength: body.length,
+        headers: const {'content-type': 'application/json; charset=utf-8'},
+        reasonPhrase: 'No active Supabase session',
+      );
+    }
+
+    // Overwrite rather than add: a replayed request already carries a stale
+    // Authorization header from whenever it was first queued.
+    request.headers['Authorization'] = 'Bearer $token';
+    request.headers['apikey'] = _anonKey;
+
+    return _inner.send(request);
+  }
+
+  /// Returns a non-expired access token, refreshing if necessary, or `null`
+  /// when the user has no session (signed out, or never signed in).
+  Future<String?> _currentAccessToken() async {
+    final GoTrueClient auth;
+    try {
+      auth = Supabase.instance.client.auth;
+    } catch (_) {
+      // Supabase.initialize hasn't completed yet.
+      return null;
+    }
+
+    final session = auth.currentSession;
+    if (session == null) return null;
+    if (!_isExpiring(session)) return session.accessToken;
+
+    final failedAt = _refreshFailedAt;
+    if (failedAt != null &&
+        DateTime.now().difference(failedAt) < _refreshCooldown) {
+      return null;
+    }
+
+    final refreshed = await (_inFlightRefresh ??= _refresh(auth));
+    return refreshed?.accessToken;
+  }
+
+  Future<Session?> _refresh(GoTrueClient auth) async {
+    try {
+      final response = await auth.refreshSession();
+      _refreshFailedAt = null;
+      return response.session;
+    } catch (e) {
+      _refreshFailedAt = DateTime.now();
+      _logger.warning('Failed to refresh Supabase session: $e');
+      return null;
+    } finally {
+      _inFlightRefresh = null;
+    }
+  }
+
+  bool _isExpiring(Session session) {
+    final expiresAt = session.expiresAt;
+    if (expiresAt == null) return session.isExpired;
+
+    final expiry = DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000);
+    return DateTime.now().add(_expiryLeeway).isAfter(expiry);
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}

--- a/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
+++ b/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
@@ -6,28 +6,35 @@ import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-/// An [http.Client] that stamps a *current* Supabase access token onto every
-/// outgoing PostgREST/Storage/Functions request.
+/// Header carrying the `auth.uid()` that was signed in when a request was
+/// first enqueued.
 ///
-/// This sits **below** Brick's offline queue. That matters: the queue
-/// serializes a request's entire header map into SQLite when the request is
-/// created (`RestRequestSqliteCache.toSqlite`) and replays it verbatim later,
-/// so a job that waits longer than the access-token lifetime (1h by default)
-/// would otherwise be sent with a dead JWT and rejected by PostgREST with a
-/// 401. Because this client runs on both the first attempt and every replay,
-/// the stored `Authorization` header is always overwritten with a live one.
-///
-/// When no usable token can be obtained, the request is **not** sent — the
-/// client synthesizes a retryable [_noSessionStatus] response so the job stays
-/// in the queue instead of burning an unauthenticated round trip.
-class AuthRefreshingClient extends http.BaseClient {
-  /// Retryable status used when there is no session to authenticate with.
-  /// Must be present in the queue's `reattemptForStatusCodes` so the job is
-  /// kept rather than discarded.
-  static const int _noSessionStatus = 503;
+/// Brick's offline queue serializes a request's headers into SQLite, so this
+/// rides along with the job and survives an app restart. It is stripped by
+/// [AuthRefreshingClient] before the request leaves the device — Supabase
+/// never sees it. This mirrors Brick's own `X-Brick-OfflineFirstPolicy`.
+const String enqueuedUserHeader = 'X-Flipper-Enqueued-Uid';
 
-  /// Refresh the token this long before it actually expires, so a request
-  /// that is in flight when the clock rolls over is not rejected.
+/// A live access token together with the user it belongs to.
+typedef QueuedAuth = ({String accessToken, String userId});
+
+/// Supplies a non-expired access token for outgoing requests.
+///
+/// Exists as a seam so the queue clients can be tested without a live
+/// Supabase session.
+abstract class AccessTokenSource {
+  /// Returns a usable token, refreshing if necessary, or `null` when there is
+  /// no session to authenticate with.
+  Future<QueuedAuth?> current();
+
+  /// The signed-in user, without triggering a refresh. `null` when signed out.
+  String? get currentUserId;
+}
+
+/// [AccessTokenSource] backed by the ambient `Supabase.instance` session.
+class SupabaseAccessTokenSource implements AccessTokenSource {
+  /// Refresh this long before the token actually expires, so a request that is
+  /// in flight when the clock rolls over is not rejected.
   static const Duration _expiryLeeway = Duration(minutes: 1);
 
   /// After a failed refresh, don't try again for this long. The queue ticks
@@ -35,16 +42,6 @@ class AuthRefreshingClient extends http.BaseClient {
   /// `/auth/v1/token`.
   static const Duration _refreshCooldown = Duration(seconds: 30);
 
-  /// Paths that carry their own credentials and must be forwarded untouched.
-  /// Rewriting the header on the token endpoint would break session refresh
-  /// (and recurse, since refreshes are issued through this same client).
-  static const _passthroughPaths = ['/auth/v1'];
-
-  /// Paths whose requests are authenticated with the user's access token.
-  static const _authenticatedPaths = ['/rest/v1', '/storage/v1', '/functions/v1'];
-
-  final http.Client _inner;
-  final String _anonKey;
   final Logger _logger;
 
   /// Deduplicates concurrent refreshes; the queue and the UI can both trip the
@@ -52,65 +49,20 @@ class AuthRefreshingClient extends http.BaseClient {
   Future<Session?>? _inFlightRefresh;
   DateTime? _refreshFailedAt;
 
-  AuthRefreshingClient(
-    this._inner, {
-    required String anonKey,
-    Logger? logger,
-  })  : _anonKey = anonKey,
-        _logger = logger ?? Logger('AuthRefreshingClient');
+  SupabaseAccessTokenSource({Logger? logger})
+      : _logger = logger ?? Logger('SupabaseAccessTokenSource');
 
   @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) async {
-    final path = request.url.path;
+  String? get currentUserId => _auth?.currentSession?.user.id;
 
-    if (_passthroughPaths.any(path.startsWith) ||
-        !_authenticatedPaths.any(path.startsWith)) {
-      return _inner.send(request);
-    }
-
-    final token = await _currentAccessToken();
-
-    if (token == null) {
-      _logger.warning(
-        'No Supabase session; holding ${request.method} $path in the queue',
-      );
-      // Shaped like a PostgREST error so postgrest_dart raises a normal
-      // PostgrestException rather than choking on an unparseable body.
-      const body =
-          '{"code":"no_session","message":"No active Supabase session",'
-          '"details":null,"hint":null}';
-      return http.StreamedResponse(
-        Stream.value(utf8.encode(body)),
-        _noSessionStatus,
-        request: request,
-        contentLength: body.length,
-        headers: const {'content-type': 'application/json; charset=utf-8'},
-        reasonPhrase: 'No active Supabase session',
-      );
-    }
-
-    // Overwrite rather than add: a replayed request already carries a stale
-    // Authorization header from whenever it was first queued.
-    request.headers['Authorization'] = 'Bearer $token';
-    request.headers['apikey'] = _anonKey;
-
-    return _inner.send(request);
-  }
-
-  /// Returns a non-expired access token, refreshing if necessary, or `null`
-  /// when the user has no session (signed out, or never signed in).
-  Future<String?> _currentAccessToken() async {
-    final GoTrueClient auth;
-    try {
-      auth = Supabase.instance.client.auth;
-    } catch (_) {
-      // Supabase.initialize hasn't completed yet.
-      return null;
-    }
+  @override
+  Future<QueuedAuth?> current() async {
+    final auth = _auth;
+    if (auth == null) return null;
 
     final session = auth.currentSession;
     if (session == null) return null;
-    if (!_isExpiring(session)) return session.accessToken;
+    if (!_isExpiring(session)) return _asAuth(session);
 
     final failedAt = _refreshFailedAt;
     if (failedAt != null &&
@@ -119,8 +71,20 @@ class AuthRefreshingClient extends http.BaseClient {
     }
 
     final refreshed = await (_inFlightRefresh ??= _refresh(auth));
-    return refreshed?.accessToken;
+    return refreshed == null ? null : _asAuth(refreshed);
   }
+
+  /// `null` until `Supabase.initialize` has completed.
+  GoTrueClient? get _auth {
+    try {
+      return Supabase.instance.client.auth;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  QueuedAuth _asAuth(Session session) =>
+      (accessToken: session.accessToken, userId: session.user.id);
 
   Future<Session?> _refresh(GoTrueClient auth) async {
     try {
@@ -142,6 +106,167 @@ class AuthRefreshingClient extends http.BaseClient {
 
     final expiry = DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000);
     return DateTime.now().add(_expiryLeeway).isAfter(expiry);
+  }
+}
+
+/// Paths whose requests are authenticated with the user's access token.
+const _authenticatedPaths = ['/rest/v1', '/storage/v1', '/functions/v1'];
+
+/// Paths that carry their own credentials and must be forwarded untouched.
+/// Rewriting the header on the token endpoint would break session refresh
+/// (and recurse, since refreshes are issued through the same client).
+const _passthroughPaths = ['/auth/v1'];
+
+bool _isAuthenticatedPath(String path) =>
+    !_passthroughPaths.any(path.startsWith) &&
+    _authenticatedPaths.any(path.startsWith);
+
+/// Tags outgoing writes with the `auth.uid()` that owns them.
+///
+/// This must sit **above** Brick's offline queue: the queue serializes headers
+/// when the job is written to SQLite, before [AuthRefreshingClient] ever runs,
+/// so a stamp applied lower down would not be persisted with the job.
+class EnqueuedUserStampClient extends http.BaseClient {
+  static const _pushMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+  final http.Client _inner;
+  final AccessTokenSource _tokenSource;
+
+  EnqueuedUserStampClient(
+    this._inner, {
+    AccessTokenSource? tokenSource,
+  }) : _tokenSource = tokenSource ?? SupabaseAccessTokenSource();
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (_pushMethods.contains(request.method) &&
+        _isAuthenticatedPath(request.url.path)) {
+      final uid = _tokenSource.currentUserId;
+      if (uid != null) request.headers[enqueuedUserHeader] = uid;
+    }
+
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}
+
+/// An [http.Client] that stamps a *current* Supabase access token onto every
+/// outgoing PostgREST/Storage/Functions request.
+///
+/// This sits **below** Brick's offline queue. That matters: the queue
+/// serializes a request's entire header map into SQLite when the request is
+/// created (`RestRequestSqliteCache.toSqlite`) and replays it verbatim later,
+/// so a job that waits longer than the access-token lifetime (1h by default)
+/// would otherwise be sent with a dead JWT and rejected by PostgREST with a
+/// 401. Because this client runs on both the first attempt and every replay,
+/// the stored `Authorization` header is always overwritten with a live one.
+///
+/// Two cases are not sent at all:
+///
+/// * No session — synthesizes a retryable [_noSessionStatus] so the job stays
+///   queued rather than burning an unauthenticated round trip.
+/// * The job was enqueued by a *different* user (see [enqueuedUserHeader]) —
+///   synthesizes [_wrongUserStatus], which is outside the queue's reattempt
+///   list, so the job is dropped. Without this, a write parked by user A would
+///   be committed under user B's identity after a handover on a shared device,
+///   which no RLS policy can catch because the credentials really are B's.
+class AuthRefreshingClient extends http.BaseClient {
+  /// Retryable status used when there is no session to authenticate with.
+  /// Must be present in the queue's `reattemptForStatusCodes`.
+  static const int _noSessionStatus = 503;
+
+  /// Terminal status used when a job belongs to a different user. Must be
+  /// absent from `reattemptForStatusCodes` so the job is discarded.
+  static const int _wrongUserStatus = 403;
+
+  final http.Client _inner;
+  final String _anonKey;
+  final AccessTokenSource _tokenSource;
+  final Logger _logger;
+
+  AuthRefreshingClient(
+    this._inner, {
+    required String anonKey,
+    AccessTokenSource? tokenSource,
+    Logger? logger,
+  })  : _anonKey = anonKey,
+        _logger = logger ?? Logger('AuthRefreshingClient'),
+        _tokenSource = tokenSource ?? SupabaseAccessTokenSource();
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final path = request.url.path;
+    if (!_isAuthenticatedPath(path)) return _inner.send(request);
+
+    final auth = await _tokenSource.current();
+
+    if (auth == null) {
+      _logger.warning(
+        'No Supabase session; holding ${request.method} $path in the queue',
+      );
+      return _refuse(
+        request,
+        status: _noSessionStatus,
+        code: 'no_session',
+        message: 'No active Supabase session',
+      );
+    }
+
+    // Strip before forwarding — this header is for us, not for Supabase.
+    final enqueuedBy = request.headers.remove(enqueuedUserHeader);
+
+    // Absent on jobs queued before uid tagging existed; those are sent as-is
+    // rather than discarded.
+    if (enqueuedBy != null && enqueuedBy != auth.userId) {
+      _logger.warning(
+        'Dropping ${request.method} $path: queued by $enqueuedBy but the '
+        'active session is ${auth.userId}',
+      );
+      return _refuse(
+        request,
+        status: _wrongUserStatus,
+        code: 'enqueued_by_other_user',
+        message: 'Queued request belongs to a different user',
+      );
+    }
+
+    // Overwrite rather than add: a replayed request already carries a stale
+    // Authorization header from whenever it was first queued.
+    request.headers['Authorization'] = 'Bearer ${auth.accessToken}';
+    request.headers['apikey'] = _anonKey;
+
+    return _inner.send(request);
+  }
+
+  /// Builds a locally-synthesized response shaped like a PostgREST error, so
+  /// postgrest_dart raises a normal PostgrestException rather than choking on
+  /// an unparseable body.
+  http.StreamedResponse _refuse(
+    http.BaseRequest request, {
+    required int status,
+    required String code,
+    required String message,
+  }) {
+    final body = jsonEncode({
+      'code': code,
+      'message': message,
+      'details': null,
+      'hint': null,
+    });
+
+    return http.StreamedResponse(
+      Stream.value(utf8.encode(body)),
+      status,
+      request: request,
+      contentLength: body.length,
+      headers: const {'content-type': 'application/json; charset=utf-8'},
+      reasonPhrase: message,
+    );
   }
 
   @override

--- a/packages/supabase_models/lib/brick/repository/queue_manager.dart
+++ b/packages/supabase_models/lib/brick/repository/queue_manager.dart
@@ -1,6 +1,13 @@
 // ignore: depend_on_referenced_packages
 import 'package:logging/logging.dart';
 import 'package:brick_offline_first/offline_queue.dart';
+// ignore: depend_on_referenced_packages
+import 'package:brick_offline_first_with_rest/offline_queue.dart'
+    show
+        HTTP_JOBS_ATTEMPTS_COLUMN,
+        HTTP_JOBS_REQUEST_METHOD_COLUMN,
+        HTTP_JOBS_TABLE_NAME,
+        HTTP_JOBS_URL_COLUMN;
 
 /// Manages offline request queue operations
 class QueueManager {
@@ -11,6 +18,11 @@ class QueueManager {
   static const int _batchSize = 10;
   // Delay between batches to prevent lock contention
   static const Duration _batchDelay = Duration(milliseconds: 50);
+
+  /// Attempts after which a job is considered unrecoverable and dropped.
+  /// The queue is serial and ordered by `created_at`, so a job that can never
+  /// succeed stays at the head and starves every write behind it.
+  static const int _maxAttempts = 25;
 
   QueueManager(this.offlineRequestQueue);
 
@@ -97,6 +109,46 @@ class QueueManager {
       return requests.length;
     } catch (e) {
       _logger.warning("An error occurred while deleting failed requests: $e");
+      return 0;
+    }
+  }
+
+  /// Drop jobs that have been reattempted more than [maxAttempts] times.
+  ///
+  /// Brick has no built-in attempt ceiling: [RestOfflineQueueClient] only
+  /// removes a job when the response status is outside its reattempt list, so
+  /// a request the server will never accept is replayed every processing
+  /// interval indefinitely. Because processing is serial and ordered by
+  /// `created_at`, that job also blocks everything queued after it.
+  ///
+  /// Returns the number of requests deleted.
+  Future<int> purgeExhaustedRequests({int maxAttempts = _maxAttempts}) async {
+    try {
+      final db = await offlineRequestQueue.requestManager.getDb();
+      final exhausted = await db.query(
+        HTTP_JOBS_TABLE_NAME,
+        where: '$HTTP_JOBS_ATTEMPTS_COLUMN > ?',
+        whereArgs: [maxAttempts],
+      );
+
+      if (exhausted.isEmpty) return 0;
+
+      for (final request in exhausted) {
+        _logger.warning(
+          'Dropping queue job after ${request[HTTP_JOBS_ATTEMPTS_COLUMN]} '
+          'attempts: ${request[HTTP_JOBS_REQUEST_METHOD_COLUMN]} '
+          '${request[HTTP_JOBS_URL_COLUMN]}',
+        );
+      }
+
+      await _processBatches(
+        exhausted,
+        offlineRequestQueue.requestManager.primaryKeyColumn,
+      );
+
+      return exhausted.length;
+    } catch (e) {
+      _logger.warning('Error purging exhausted requests: $e');
       return 0;
     }
   }

--- a/packages/supabase_models/test/auth_refreshing_client_test.dart
+++ b/packages/supabase_models/test/auth_refreshing_client_test.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:supabase_models/brick/repository/auth_refreshing_client.dart';
+
+/// Records what actually reached the wire.
+class _RecordingClient extends http.BaseClient {
+  final List<http.BaseRequest> sent = [];
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    sent.add(request);
+    return http.StreamedResponse(const Stream.empty(), 200, request: request);
+  }
+}
+
+void main() {
+  const anonKey = 'anon-key';
+  late _RecordingClient inner;
+  late AuthRefreshingClient client;
+
+  setUp(() {
+    inner = _RecordingClient();
+    client = AuthRefreshingClient(inner, anonKey: anonKey);
+  });
+
+  http.Request request(String url) => http.Request('POST', Uri.parse(url))
+    ..headers['Authorization'] = 'Bearer stale-token';
+
+  group('with no Supabase session', () {
+    test('holds PostgREST writes instead of sending them unauthenticated',
+        () async {
+      final response = await client.send(
+        request('https://project.supabase.co/rest/v1/logs?id=eq.abc'),
+      );
+
+      expect(response.statusCode, 503,
+          reason: 'must be retryable so the queue keeps the job');
+      expect(inner.sent, isEmpty,
+          reason: 'no request should reach Supabase without a live token');
+    });
+
+    test('synthesized body parses as a PostgREST error', () async {
+      final response = await client.send(
+        request('https://project.supabase.co/rest/v1/logs'),
+      );
+      final body = await response.stream.bytesToString();
+
+      expect(
+        jsonDecode(body),
+        containsPair('message', 'No active Supabase session'),
+      );
+    });
+
+    test('holds storage and functions writes too', () async {
+      for (final path in ['/storage/v1/object/x', '/functions/v1/x']) {
+        final response =
+            await client.send(request('https://project.supabase.co$path'));
+        expect(response.statusCode, 503, reason: path);
+      }
+      expect(inner.sent, isEmpty);
+    });
+  });
+
+  group('passthrough', () {
+    test('forwards auth requests untouched', () async {
+      final auth =
+          request('https://project.supabase.co/auth/v1/token?grant_type=x');
+
+      final response = await client.send(auth);
+
+      expect(response.statusCode, 200);
+      expect(inner.sent, hasLength(1));
+      expect(
+        inner.sent.single.headers['Authorization'],
+        'Bearer stale-token',
+        reason: 'rewriting the token endpoint would break session refresh',
+      );
+    });
+
+    test('forwards non-Supabase requests untouched', () async {
+      await client.send(request('https://example.com/api/thing'));
+
+      expect(inner.sent, hasLength(1));
+      expect(inner.sent.single.headers['Authorization'], 'Bearer stale-token');
+      expect(inner.sent.single.headers.containsKey('apikey'), isFalse);
+    });
+  });
+}

--- a/packages/supabase_models/test/auth_refreshing_client_test.dart
+++ b/packages/supabase_models/test/auth_refreshing_client_test.dart
@@ -16,36 +16,130 @@ class _RecordingClient extends http.BaseClient {
   }
 }
 
+class _FakeTokenSource implements AccessTokenSource {
+  QueuedAuth? auth;
+  int refreshCount = 0;
+
+  _FakeTokenSource({this.auth});
+
+  factory _FakeTokenSource.signedInAs(String userId) => _FakeTokenSource(
+        auth: (accessToken: 'fresh-$userId', userId: userId),
+      );
+
+  @override
+  String? get currentUserId => auth?.userId;
+
+  @override
+  Future<QueuedAuth?> current() async {
+    refreshCount++;
+    return auth;
+  }
+}
+
 void main() {
   const anonKey = 'anon-key';
-  late _RecordingClient inner;
-  late AuthRefreshingClient client;
+  const restUrl = 'https://project.supabase.co/rest/v1/logs?id=eq.abc';
 
-  setUp(() {
-    inner = _RecordingClient();
-    client = AuthRefreshingClient(inner, anonKey: anonKey);
+  late _RecordingClient inner;
+
+  setUp(() => inner = _RecordingClient());
+
+  http.Request request(String url, {String method = 'POST', String? queuedBy}) {
+    final req = http.Request(method, Uri.parse(url))
+      ..headers['Authorization'] = 'Bearer stale-token';
+    if (queuedBy != null) req.headers[enqueuedUserHeader] = queuedBy;
+    return req;
+  }
+
+  group('token refresh', () {
+    test('replaces the stale token captured when the job was queued', () async {
+      final client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+
+      await client.send(request(restUrl));
+
+      expect(inner.sent.single.headers['Authorization'], 'Bearer fresh-user-a');
+      expect(inner.sent.single.headers['apikey'], anonKey);
+    });
   });
 
-  http.Request request(String url) => http.Request('POST', Uri.parse(url))
-    ..headers['Authorization'] = 'Bearer stale-token';
+  group('cross-user replay', () {
+    test('drops a job queued by a different user', () async {
+      final client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-b'),
+      );
 
-  group('with no Supabase session', () {
+      final response = await client.send(request(restUrl, queuedBy: 'user-a'));
+
+      expect(response.statusCode, 403,
+          reason: 'must be outside reattemptForStatusCodes so it is discarded');
+      expect(inner.sent, isEmpty,
+          reason: "user A's write must not be committed as user B");
+    });
+
+    test('sends a job queued by the same user, without leaking the stamp',
+        () async {
+      final client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+
+      await client.send(request(restUrl, queuedBy: 'user-a'));
+
+      expect(inner.sent, hasLength(1));
+      expect(inner.sent.single.headers.containsKey(enqueuedUserHeader), isFalse,
+          reason: 'the stamp is internal and must not reach Supabase');
+    });
+
+    test('sends untagged jobs queued before uid tagging existed', () async {
+      final client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-b'),
+      );
+
+      await client.send(request(restUrl));
+
+      expect(inner.sent, hasLength(1),
+          reason: 'pre-existing queue rows must not be discarded wholesale');
+    });
+  });
+
+  group('with no session', () {
+    late AuthRefreshingClient client;
+
+    setUp(() {
+      client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource(),
+      );
+    });
+
     test('holds PostgREST writes instead of sending them unauthenticated',
         () async {
-      final response = await client.send(
-        request('https://project.supabase.co/rest/v1/logs?id=eq.abc'),
-      );
+      final response = await client.send(request(restUrl));
 
       expect(response.statusCode, 503,
           reason: 'must be retryable so the queue keeps the job');
-      expect(inner.sent, isEmpty,
-          reason: 'no request should reach Supabase without a live token');
+      expect(inner.sent, isEmpty);
+    });
+
+    test('holds rather than drops a tagged job', () async {
+      final response = await client.send(request(restUrl, queuedBy: 'user-a'));
+
+      expect(response.statusCode, 503,
+          reason: 'user A may sign back in; the write should survive');
     });
 
     test('synthesized body parses as a PostgREST error', () async {
-      final response = await client.send(
-        request('https://project.supabase.co/rest/v1/logs'),
-      );
+      final response = await client.send(request(restUrl));
       final body = await response.stream.bytesToString();
 
       expect(
@@ -65,14 +159,20 @@ void main() {
   });
 
   group('passthrough', () {
+    late AuthRefreshingClient client;
+
+    setUp(() {
+      client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+    });
+
     test('forwards auth requests untouched', () async {
-      final auth =
-          request('https://project.supabase.co/auth/v1/token?grant_type=x');
+      await client
+          .send(request('https://project.supabase.co/auth/v1/token?g=x'));
 
-      final response = await client.send(auth);
-
-      expect(response.statusCode, 200);
-      expect(inner.sent, hasLength(1));
       expect(
         inner.sent.single.headers['Authorization'],
         'Bearer stale-token',
@@ -83,9 +183,67 @@ void main() {
     test('forwards non-Supabase requests untouched', () async {
       await client.send(request('https://example.com/api/thing'));
 
-      expect(inner.sent, hasLength(1));
       expect(inner.sent.single.headers['Authorization'], 'Bearer stale-token');
       expect(inner.sent.single.headers.containsKey('apikey'), isFalse);
+    });
+  });
+
+  group('EnqueuedUserStampClient', () {
+    test('tags writes with the signed-in uid', () async {
+      final client = EnqueuedUserStampClient(
+        inner,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+
+      await client.send(request(restUrl));
+
+      expect(inner.sent.single.headers[enqueuedUserHeader], 'user-a');
+    });
+
+    test('does not tag reads, auth calls, or signed-out writes', () async {
+      final signedIn = EnqueuedUserStampClient(
+        inner,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+      final signedOut = EnqueuedUserStampClient(
+        inner,
+        tokenSource: _FakeTokenSource(),
+      );
+
+      await signedIn.send(request(restUrl, method: 'GET'));
+      await signedIn
+          .send(request('https://project.supabase.co/auth/v1/token?g=x'));
+      await signedOut.send(request(restUrl));
+
+      expect(
+        inner.sent.where((r) => r.headers.containsKey(enqueuedUserHeader)),
+        isEmpty,
+      );
+    });
+
+    test('round-trips through the queue into AuthRefreshingClient', () async {
+      // The stamp is applied above the queue and read below it, so the two
+      // halves must agree on the header.
+      final stamped = EnqueuedUserStampClient(
+        _RecordingClient(),
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+      final outbound = request(restUrl);
+      await stamped.send(outbound);
+
+      // Simulate the queue serializing and replaying the headers verbatim.
+      final replayed = http.Request('POST', outbound.url)
+        ..headers.addAll(jsonDecode(jsonEncode(outbound.headers))
+            .cast<String, String>());
+
+      final response = await AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-b'),
+      ).send(replayed);
+
+      expect(response.statusCode, 403);
+      expect(inner.sent, isEmpty);
     });
   });
 }


### PR DESCRIPTION
Brick's offline queue serializes a request's entire header map into
SQLite when the request is created and replays it verbatim later, so any
job that outlived the access-token lifetime (1h by default) was resent
with a dead JWT and rejected by PostgREST with a 401.

Worse, 401 and 403 are in the queue's default reattemptForStatusCodes, so
the job was never removed. Processing is serial and ordered by
created_at, which meant one permanently-401 request sat at the head of
the queue and starved every write behind it while re-hitting Supabase
every 5 seconds.

- Add AuthRefreshingClient as the queue's innerClient. It sits below the
  queue, so it overwrites Authorization/apikey with a live token on first
  attempts and replays alike, refreshing within 60s of expiry (deduped,
  with a 30s cooldown after a failed refresh). Auth and non-Supabase
  paths pass through untouched. With no session it holds the request
  back with a retryable 503 rather than sending it unauthenticated.
- Drop 401/403 from reattemptForStatusCodes; with the above, a 401 that
  still lands is a genuine rejection and the job should not be retried.
- Add QueueManager.purgeExhaustedRequests to drop jobs past 25 attempts,
  run at startup to clear queues already stalled in the field.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Customer column to transaction and Z-report views, including exports.
  * Improved transaction settlement and parked-sale date tracking.
* **Bug Fixes**
  * Improved offline request handling by keeping authentication tokens current during retries.
  * Prevented permanently rejected requests from blocking later offline changes.
  * Automatically removes exhausted queued requests and provides clearer retry behavior when authentication is unavailable.
* **Release**
  * Updated the application and Windows package versions.
* **Tests**
  * Added coverage for authentication, offline requests, and transaction settlement dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->