### PR TITLE
fix(brick): stamp a live JWT on queued Supabase requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
       - dev
       - re-design
       - v5
-      - product-editor-category-variants-ux
+      - fix/*
 env:
   URL: ${{ secrets.DB_URL }}
   PASSWORD: ${{ secrets.DB_PASSWORD }}

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.299.0+1756529786
+version: 1.300.0+1756529787
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.303.0.0
+  msix_version: 1.304.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.301.0+1756529788
+version: 1.302.0+1756529789
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.305.0.0
+  msix_version: 1.306.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.303.0+1756529790
+version: 1.304.0+1756529791
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.307.0.0
+  msix_version: 1.308.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.300.0+1756529787
+version: 1.301.0+1756529788
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.304.0.0
+  msix_version: 1.305.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.296.0+1756529783
+version: 1.297.0+1756529784
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.300.0.0
+  msix_version: 1.301.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.298.0+1756529785
+version: 1.299.0+1756529786
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.302.0.0
+  msix_version: 1.303.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.302.0+1756529789
+version: 1.303.0+1756529790
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.306.0.0
+  msix_version: 1.307.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.297.0+1756529784
+version: 1.298.0+1756529785
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.301.0.0
+  msix_version: 1.302.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/packages/flipper_dashboard/lib/Refund.dart
+++ b/packages/flipper_dashboard/lib/Refund.dart
@@ -5,6 +5,7 @@ import 'package:flipper_dashboard/data_view_reports/DynamicDataSource.dart';
 import 'package:flipper_dashboard/services/transaction_refund_helpers.dart';
 import 'package:flipper_dashboard/services/transaction_refund_service.dart';
 import 'package:flipper_design_system/flipper_design_system.dart';
+import 'package:flipper_models/SyncStrategy.dart';
 import 'package:flipper_models/db_model_export.dart';
 import 'package:flipper_services/constants.dart';
 import 'package:flipper_services/proxy.dart';
@@ -135,6 +136,16 @@ class _RefundState extends ConsumerState<Refund> {
               _TransactionIdPill(
                 shortId: shortId,
                 transactionId: widget.transactionId,
+              ),
+              const SizedBox(height: 20),
+              _PaymentBreakdown(
+                transactionId: widget.transactionId,
+                currency: _currency,
+                customerLabel: tx == null
+                    ? null
+                    : transactionReportCustomerLabel(tx),
+                fallbackMethod: tx?.paymentType,
+                fallbackAmount: tx?.cashReceived ?? tx?.subTotal,
               ),
               const SizedBox(height: 24),
               RefundReasonForm(enabled: !_refundUnavailable),
@@ -506,6 +517,209 @@ class _TransactionIdPillState extends State<_TransactionIdPill> {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Per-tender breakdown for the transaction, including the optional payer name
+/// captured at checkout for MoMo / bank lines.
+///
+/// The customer attached to a sale and the person whose account the money came
+/// from are usually the same, so the payer is surfaced only when it was
+/// recorded, and flagged only when it actually differs from the customer.
+class _PaymentBreakdown extends StatefulWidget {
+  const _PaymentBreakdown({
+    required this.transactionId,
+    required this.currency,
+    required this.customerLabel,
+    required this.fallbackMethod,
+    required this.fallbackAmount,
+  });
+
+  final String transactionId;
+  final String currency;
+
+  /// Customer on the transaction, already resolved to name → phone → '—'.
+  final String? customerLabel;
+
+  /// Used when no tender rows exist (older sales, or a receipt written before
+  /// per-payment records were kept).
+  final String? fallbackMethod;
+  final double? fallbackAmount;
+
+  @override
+  State<_PaymentBreakdown> createState() => _PaymentBreakdownState();
+}
+
+class _PaymentBreakdownState extends State<_PaymentBreakdown> {
+  late Future<List<TransactionPaymentRecord>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _loadPayments();
+  }
+
+  @override
+  void didUpdateWidget(covariant _PaymentBreakdown oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.transactionId != widget.transactionId) {
+      _future = _loadPayments();
+    }
+  }
+
+  Future<List<TransactionPaymentRecord>> _loadPayments() async {
+    try {
+      // Capella explicitly: the default strategy is empty off-web in report
+      // contexts, which would silently render an empty breakdown.
+      final records = await ProxyService.getStrategy(
+        Strategy.capella,
+      ).getPaymentType(transactionId: widget.transactionId);
+      return List<TransactionPaymentRecord>.from(records);
+    } catch (_) {
+      return const <TransactionPaymentRecord>[];
+    }
+  }
+
+  bool _payerDiffersFromCustomer(String payer) {
+    final customer = widget.customerLabel?.trim();
+    if (customer == null || customer.isEmpty || customer == '—') return true;
+    return payer.trim().toLowerCase() != customer.toLowerCase();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<TransactionPaymentRecord>>(
+      future: _future,
+      builder: (context, snap) {
+        final loading = snap.connectionState != ConnectionState.done;
+        final records = snap.data ?? const <TransactionPaymentRecord>[];
+
+        final lines = <Widget>[];
+        if (widget.customerLabel != null) {
+          lines.add(
+            _BreakdownRow(label: 'Customer', value: widget.customerLabel!),
+          );
+        }
+
+        if (loading) {
+          lines.add(const _BreakdownRow(label: 'Payments', value: '…'));
+        } else if (records.isEmpty) {
+          final method = (widget.fallbackMethod ?? '').trim();
+          lines.add(
+            _BreakdownRow(
+              label: method.isEmpty ? 'Payment' : method.toUpperCase(),
+              value:
+                  '${widget.currency} '
+                  '${NumberFormat('#,##0.00').format(widget.fallbackAmount ?? 0)}',
+            ),
+          );
+        } else {
+          for (final record in records) {
+            final method = (record.paymentMethod ?? 'Unknown').toUpperCase();
+            lines.add(
+              _BreakdownRow(
+                label: method,
+                value:
+                    '${widget.currency} '
+                    '${NumberFormat('#,##0.00').format(record.amount ?? 0)}',
+              ),
+            );
+            final payer = record.payerName?.trim();
+            if (payer != null && payer.isNotEmpty) {
+              lines.add(
+                _PayerLine(
+                  payerName: payer,
+                  differsFromCustomer: _payerDiffersFromCustomer(payer),
+                ),
+              );
+            }
+          }
+        }
+
+        final spaced = <Widget>[];
+        for (var i = 0; i < lines.length; i++) {
+          if (i > 0) spaced.add(const SizedBox(height: 10));
+          spaced.add(lines[i]);
+        }
+
+        return Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: _PreviewColors.surface2,
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: _PreviewColors.line),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: spaced,
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Sub-line under a tender showing who the money actually came from.
+class _PayerLine extends StatelessWidget {
+  const _PayerLine({
+    required this.payerName,
+    required this.differsFromCustomer,
+  });
+
+  final String payerName;
+  final bool differsFromCustomer;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.person_outline_rounded,
+            size: 15,
+            color: differsFromCustomer
+                ? _PreviewColors.pendingInk
+                : _PreviewColors.ink3,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(
+                    text: 'Paid by ',
+                    style: GoogleFonts.outfit(
+                      fontSize: 12.5,
+                      fontWeight: FontWeight.w500,
+                      color: _PreviewColors.ink3,
+                    ),
+                  ),
+                  TextSpan(
+                    text: payerName,
+                    style: GoogleFonts.outfit(
+                      fontSize: 12.5,
+                      fontWeight: FontWeight.w700,
+                      color: _PreviewColors.ink1,
+                    ),
+                  ),
+                  if (differsFromCustomer)
+                    TextSpan(
+                      text: '  · differs from customer',
+                      style: GoogleFonts.outfit(
+                        fontSize: 11.5,
+                        fontWeight: FontWeight.w600,
+                        color: _PreviewColors.pendingInk,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/packages/flipper_dashboard/lib/data_view_reports/DynamicDataSource.dart
+++ b/packages/flipper_dashboard/lib/data_view_reports/DynamicDataSource.dart
@@ -14,8 +14,8 @@ import 'package:talker_flutter/talker_flutter.dart';
 
 final talker = TalkerFlutter.init();
 
-/// Column count for transaction summary grid (non-PLU): receipt, cashier, …, actions.
-const int kTransactionSummaryColumnCount = 10;
+/// Column count for transaction summary grid (non-PLU): receipt, cashier, customer, …, actions.
+const int kTransactionSummaryColumnCount = 11;
 
 String transactionReportReceiptLabel(ITransaction t) {
   final inv = t.invoiceNumber;
@@ -26,6 +26,16 @@ String transactionReportReceiptLabel(ITransaction t) {
   if (id.isEmpty) return '—';
   final short = id.length > 5 ? id.substring(0, 5) : id;
   return '#${short.toUpperCase()}';
+}
+
+/// Summary grid / export Customer column: stored name, else the phone captured on
+/// the sale, else a dash so walk-in sales stay visually aligned with named ones.
+String transactionReportCustomerLabel(ITransaction t) {
+  final name = t.customerName?.trim();
+  if (name != null && name.isNotEmpty) return name;
+  final phone = (t.customerPhone ?? t.currentSaleCustomerPhoneNumber)?.trim();
+  if (phone != null && phone.isNotEmpty) return phone;
+  return '—';
 }
 
 String _transactionReportStatusLabel(ITransaction tx) {
@@ -72,6 +82,7 @@ Map<String, Object?> transactionSummaryExportRow(
       transaction,
       directory: cashierDirectory,
     ),
+    'Customer': transactionReportCustomerLabel(transaction),
     'Type': transactionReportGridTypeLabel(transaction),
     'Status': _transactionReportStatusLabel(transaction),
     'SaleTotal': _signedReportMoney(transaction.subTotal ?? 0.0, transaction),
@@ -356,6 +367,10 @@ abstract class DynamicDataSource<T> extends DataGridSource {
           ),
         ),
         DataGridCell<String>(
+          columnName: 'Customer',
+          value: transactionReportCustomerLabel(trans),
+        ),
+        DataGridCell<String>(
           columnName: 'Type',
           value: transactionReportGridTypeLabel(trans),
         ),
@@ -577,6 +592,29 @@ abstract class DynamicDataSource<T> extends DataGridSource {
                 ),
               ),
             ],
+          ),
+        );
+      }
+      if (name == 'Customer') {
+        final label = tx != null
+            ? transactionReportCustomerLabel(tx)
+            : (e.value?.toString() ?? '');
+        final unnamed = label == '—' || label.isEmpty;
+        return Container(
+          alignment: Alignment.centerLeft,
+          color: rowBg,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            unnamed ? '—' : label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: unnamed ? FontWeight.w500 : FontWeight.w600,
+              color: unnamed
+                  ? const Color(0xFF9CA3AF)
+                  : const Color(0xFF111827),
+            ),
           ),
         );
       }

--- a/packages/flipper_dashboard/lib/data_view_reports/DynamicDataSource.dart
+++ b/packages/flipper_dashboard/lib/data_view_reports/DynamicDataSource.dart
@@ -33,8 +33,12 @@ String transactionReportReceiptLabel(ITransaction t) {
 String transactionReportCustomerLabel(ITransaction t) {
   final name = t.customerName?.trim();
   if (name != null && name.isNotEmpty) return name;
-  final phone = (t.customerPhone ?? t.currentSaleCustomerPhoneNumber)?.trim();
+  // Fall back per field, not with `??`: an empty-string customerPhone is a
+  // present value, so a single `??` would swallow the sale-time number.
+  final phone = t.customerPhone?.trim();
   if (phone != null && phone.isNotEmpty) return phone;
+  final salePhone = t.currentSaleCustomerPhoneNumber?.trim();
+  if (salePhone != null && salePhone.isNotEmpty) return salePhone;
   return '—';
 }
 

--- a/packages/flipper_dashboard/lib/data_view_reports/HeaderTransactionItem.dart
+++ b/packages/flipper_dashboard/lib/data_view_reports/HeaderTransactionItem.dart
@@ -40,6 +40,10 @@ mixin Headers<T extends ConsumerStatefulWidget> on ConsumerState<T> {
         label: _zReportHeaderLabel(headerPadding, 'CASHIER', active: true),
       ),
       GridColumn(
+        columnName: 'Customer',
+        label: _zReportHeaderLabel(headerPadding, 'CUSTOMER'),
+      ),
+      GridColumn(
         columnName: 'Type',
         label: _zReportHeaderLabel(headerPadding, 'TYPE'),
       ),

--- a/packages/flipper_dashboard/lib/mixins/previewCart.dart
+++ b/packages/flipper_dashboard/lib/mixins/previewCart.dart
@@ -208,7 +208,15 @@ List<PaymentLineForSaleCompletion> paymentLinesForSaleCompletion(
         if (amt <= _tenderEpsilon) {
           amt = double.tryParse(p.controller.text.trim()) ?? 0.0;
         }
-        return PaymentLineForSaleCompletion(amount: amt, method: p.method);
+        return PaymentLineForSaleCompletion(
+          amount: amt,
+          method: p.method,
+          // Only tenders that offer the field can carry a payer; a name left
+          // behind by an earlier method choice must not follow to e.g. CASH.
+          payerName: paymentMethodSupportsPayerName(p.method)
+              ? normalizedPayerName(p.payerName)
+              : null,
+        );
       })
       .toList();
 }
@@ -1038,6 +1046,7 @@ mixin PreviewCartMixin<T extends ConsumerStatefulWidget>
           amount: payment.amount,
           transactionId: transactionId,
           paymentMethod: payment.method,
+          payerName: payment.payerName,
           saleCompletionFastPath: true,
         );
       }
@@ -1202,6 +1211,7 @@ mixin PreviewCartMixin<T extends ConsumerStatefulWidget>
           amount: payment.amount,
           transactionId: transaction.id,
           paymentMethod: payment.method,
+          payerName: payment.payerName,
           saleCompletionFastPath: true,
         );
       }

--- a/packages/flipper_dashboard/lib/transactionList.dart
+++ b/packages/flipper_dashboard/lib/transactionList.dart
@@ -66,6 +66,7 @@ class TransactionListState extends ConsumerState<TransactionList>
   bool _isXReportLoading = false;
   bool _isSaleReportLoading = false;
   bool _isPluReportLoading = false;
+  bool _isRefreshing = false;
 
   /// Sizing for the height this report actually gets. Recomputed at the top of
   /// every layout pass in [_buildReportScaffold] (before any child is built),
@@ -165,6 +166,35 @@ class TransactionListState extends ConsumerState<TransactionList>
           duration: const Duration(seconds: 5),
         );
       }
+    }
+  }
+
+  /// Drops the cached report data and re-reads it, so the grid picks up
+  /// whatever has since arrived from a connected mesh peer or the remote.
+  Future<void> _refreshReportData() async {
+    if (_isRefreshing) return;
+    setState(() => _isRefreshing = true);
+
+    final forceRealData = !(ProxyService.box.enableDebug() ?? false);
+    try {
+      ref.invalidate(transactionItemListProvider);
+      ref.invalidate(transactionReportBusinessCashiersProvider);
+      ref.invalidate(transactionReportChartSnapshotProvider(forceRealData));
+      ref.invalidate(transactionListProvider(forceRealData: forceRealData));
+      ref.invalidate(
+        transactionReportSnapshotProvider(forceRealData: forceRealData),
+      );
+      // Wait for the fresh read so the spinner reflects the actual fetch.
+      await ref.read(
+        transactionReportSnapshotProvider(forceRealData: forceRealData).future,
+      );
+    } catch (e) {
+      // The grid renders its own error state; just surface it once here.
+      if (mounted) {
+        showErrorNotification(context, 'Refresh failed: ${e.toString()}');
+      }
+    } finally {
+      if (mounted) setState(() => _isRefreshing = false);
     }
   }
 
@@ -1004,21 +1034,49 @@ class TransactionListState extends ConsumerState<TransactionList>
           ),
         ),
         const SizedBox(width: 8),
-        TextButton(
-          style: TextButton.styleFrom(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            minimumSize: Size.zero,
-            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          ),
-          onPressed: () => ref
-              .read(transactionReportFiltersProvider.notifier)
-              .setCashierAgentId(null),
-          child: Text(
-            'Clear',
-            style: TextStyle(
-              fontWeight: FontWeight.w600,
-              color: Colors.grey.shade700,
-              fontSize: 13,
+        Tooltip(
+          message: 'Refresh — pull fresh data from mesh peers or the server',
+          child: Material(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(10),
+            child: InkWell(
+              onTap: _isRefreshing ? null : _refreshReportData,
+              borderRadius: BorderRadius.circular(10),
+              child: Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: _metrics.isCompact ? 8 : 10,
+                  vertical: _metrics.isCompact ? 5 : 6,
+                ),
+                decoration: BoxDecoration(
+                  border: Border.all(color: const Color(0xFFD1D5DB)),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: _isRefreshing
+                          ? const CircularProgressIndicator(strokeWidth: 2)
+                          : Icon(
+                              Icons.refresh_rounded,
+                              size: 16,
+                              color: Colors.grey.shade700,
+                            ),
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      'Refresh',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        color: Colors.grey.shade700,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ),
         ),

--- a/packages/flipper_dashboard/lib/widgets/payment_methods_card.dart
+++ b/packages/flipper_dashboard/lib/widgets/payment_methods_card.dart
@@ -39,6 +39,12 @@ class _PaymentMethodsCardState extends ConsumerState<PaymentMethodsCard>
       {}; // Track which fields user has manually edited
   double? _cachedNonCreditPaid;
 
+  /// Payer-name controllers, keyed by [Payment.id] rather than row index so a
+  /// removed or reordered row cannot inherit another row's typed name. Owned
+  /// here (not on [Payment]) because the many call sites that rebuild a
+  /// Payment would otherwise drop the controller mid-typing.
+  final Map<String, TextEditingController> _payerNameControllers = {};
+
   @override
   void initState() {
     super.initState();
@@ -50,6 +56,15 @@ class _PaymentMethodsCardState extends ConsumerState<PaymentMethodsCard>
         talker.error(e);
       }
     });
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _payerNameControllers.values) {
+      controller.dispose();
+    }
+    _payerNameControllers.clear();
+    super.dispose();
   }
 
   Future<void> _loadNonCreditPaid() async {
@@ -309,6 +324,10 @@ class _PaymentMethodsCardState extends ConsumerState<PaymentMethodsCard>
   void _removePaymentMethod(int index, {required String transactionId}) {
     // Clear user edited fields to allow re-balancing of remaining methods
     _userEditedFields.clear();
+    final payments = ref.read(paymentMethodsProvider);
+    if (index >= 0 && index < payments.length) {
+      _payerNameControllers.remove(payments[index].id)?.dispose();
+    }
     ref.read(paymentMethodsProvider.notifier).removePaymentMethod(index);
 
     final transaction = ref.read(transactionByIdProvider(transactionId)).value;
@@ -388,11 +407,18 @@ class _PaymentMethodsCardState extends ConsumerState<PaymentMethodsCard>
     required String transactionId,
   }) {
     final payment = ref.read(paymentMethodsProvider)[index];
+    // A name captured for MoMo must not silently ride along to Cash. Empty
+    // string (not null) is an explicit clear the notifier will not undo.
+    final keepsPayerName = paymentMethodSupportsPayerName(newValue);
+    if (!keepsPayerName) {
+      _payerNameControllers[payment.id]?.clear();
+    }
     final newPayment = Payment(
       amount: payment.amount,
       method: newValue,
       id: payment.id,
       controller: payment.controller,
+      payerName: keepsPayerName ? payment.payerName : '',
     );
     ref
         .read(paymentMethodsProvider.notifier)
@@ -426,6 +452,108 @@ class _PaymentMethodsCardState extends ConsumerState<PaymentMethodsCard>
     updatePaymentAmounts(
       transactionId: widget.transactionId,
       focusedIndex: index,
+    );
+  }
+
+  /// Lazily-created controller for a row's payer name, seeded once from state
+  /// so rebuilds never fight the cursor while the cashier is typing.
+  TextEditingController _payerNameControllerFor(Payment payment) {
+    return _payerNameControllers.putIfAbsent(
+      payment.id,
+      () => TextEditingController(text: payment.payerName ?? ''),
+    );
+  }
+
+  /// Drops controllers for rows that no longer exist — the provider is
+  /// invalidated after each sale, which mints fresh [Payment.id]s. Runs after
+  /// the frame so a controller is never disposed while still attached.
+  void _pruneStalePayerNameControllers(List<Payment> payments) {
+    if (_payerNameControllers.isEmpty) return;
+    final liveIds = payments.map((p) => p.id).toSet();
+    final stale = _payerNameControllers.keys
+        .where((id) => !liveIds.contains(id))
+        .toList();
+    if (stale.isEmpty) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      for (final id in stale) {
+        _payerNameControllers.remove(id)?.dispose();
+      }
+    });
+  }
+
+  void _onPayerNameChanged(int index, String value) {
+    final payment = ref.read(paymentMethodsProvider)[index];
+    ref
+        .read(paymentMethodsProvider.notifier)
+        .updatePaymentMethod(
+          index,
+          Payment(
+            amount: payment.amount,
+            method: payment.method,
+            controller: payment.controller,
+            id: payment.id,
+            // Raw (not normalized) so an emptied field clears rather than
+            // falling back to the previously captured name.
+            payerName: value,
+          ),
+          transactionId: widget.transactionId,
+        );
+  }
+
+  /// Optional "who paid" line, shown only for tenders that arrive from a named
+  /// third-party account (MoMo, bank). Everything else keeps the original
+  /// single-row layout.
+  Widget _buildPayerNameField(int index, {required bool compact}) {
+    final payment = ref.watch(paymentMethodsProvider)[index];
+    final visual = _methodVisual(payment.method);
+    return Container(
+      decoration: BoxDecoration(
+        color: PosTokens.surface2,
+        borderRadius: BorderRadius.circular(9),
+        border: Border.all(color: PosTokens.line),
+      ),
+      padding: EdgeInsets.only(left: compact ? 10 : 9),
+      child: Row(
+        children: [
+          Icon(
+            Icons.person_outline_rounded,
+            size: 15,
+            color: visual.color.withValues(alpha: 0.75),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Semantics(
+              label: context.flipperL10n.payerNameOptional,
+              child: TextFormField(
+                controller: _payerNameControllerFor(payment),
+                textCapitalization: TextCapitalization.words,
+                style: TextStyle(
+                  fontSize: compact ? 13.5 : 13,
+                  fontWeight: FontWeight.w600,
+                  color: PosTokens.ink1,
+                ),
+                decoration: InputDecoration(
+                  hintText: context.flipperL10n.payerNameOptional,
+                  hintStyle: const TextStyle(
+                    color: PosTokens.ink4,
+                    fontSize: 12.5,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  border: InputBorder.none,
+                  contentPadding: EdgeInsets.fromLTRB(
+                    2,
+                    compact ? 11 : 9,
+                    compact ? 10 : 9,
+                    compact ? 11 : 9,
+                  ),
+                  isDense: true,
+                ),
+                onChanged: (value) => _onPayerNameChanged(index, value),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -629,8 +757,10 @@ class _PaymentMethodsCardState extends ConsumerState<PaymentMethodsCard>
     required String transactionId,
     required bool compact,
   }) {
-    final showRemove = ref.watch(paymentMethodsProvider).length > 1;
-    return Row(
+    final payments = ref.watch(paymentMethodsProvider);
+    final showRemove = payments.length > 1;
+    final showPayerName = paymentMethodSupportsPayerName(payments[index].method);
+    final row = Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Expanded(
@@ -657,11 +787,29 @@ class _PaymentMethodsCardState extends ConsumerState<PaymentMethodsCard>
         ],
       ],
     );
+
+    if (!showPayerName) return row;
+
+    // Payer name sits under the row and stops short of the remove column so it
+    // stays aligned with the method + amount cells above it.
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        row,
+        const SizedBox(height: 6),
+        Padding(
+          padding: EdgeInsets.only(right: showRemove ? 32 : 0),
+          child: _buildPayerNameField(index, compact: compact),
+        ),
+      ],
+    );
   }
 
   /// Vertically stacked payment lines with hairline separators.
   List<Widget> _buildPaymentRows({required bool compact}) {
     final payments = ref.watch(paymentMethodsProvider);
+    _pruneStalePayerNameControllers(payments);
     final rows = <Widget>[];
     for (int i = 0; i < payments.length; i++) {
       if (i > 0) {

--- a/packages/flipper_dashboard/test/transaction_report_customer_label_test.dart
+++ b/packages/flipper_dashboard/test/transaction_report_customer_label_test.dart
@@ -1,0 +1,84 @@
+import 'package:flipper_dashboard/data_view_reports/DynamicDataSource.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_models/supabase_models.dart';
+
+ITransaction _tx({
+  String? customerName,
+  String? customerPhone,
+  String? currentSaleCustomerPhoneNumber,
+}) {
+  final now = DateTime(2026, 4, 25, 12);
+  return ITransaction(
+    id: 't1',
+    agentId: 'a1',
+    branchId: 'b1',
+    status: 'COMPLETE',
+    transactionType: 'sale',
+    paymentType: 'CASH',
+    cashReceived: 0,
+    customerChangeDue: 0,
+    updatedAt: now,
+    createdAt: now,
+    isIncome: true,
+    isExpense: false,
+    subTotal: 0,
+    customerName: customerName,
+    customerPhone: customerPhone,
+    currentSaleCustomerPhoneNumber: currentSaleCustomerPhoneNumber,
+  );
+}
+
+void main() {
+  group('transactionReportCustomerLabel', () {
+    test('prefers the stored customer name', () {
+      expect(
+        transactionReportCustomerLabel(
+          _tx(customerName: 'Jane Doe', customerPhone: '0788000000'),
+        ),
+        'Jane Doe',
+      );
+    });
+
+    test('falls back to the customer phone when unnamed', () {
+      expect(
+        transactionReportCustomerLabel(_tx(customerPhone: '0788000000')),
+        '0788000000',
+      );
+    });
+
+    test('falls back past a blank customerPhone to the sale-time phone', () {
+      // `??` would stop at the empty string and lose the number entirely.
+      expect(
+        transactionReportCustomerLabel(
+          _tx(customerPhone: '  ', currentSaleCustomerPhoneNumber: '0788111111'),
+        ),
+        '0788111111',
+      );
+      expect(
+        transactionReportCustomerLabel(
+          _tx(customerPhone: '', currentSaleCustomerPhoneNumber: '0788111111'),
+        ),
+        '0788111111',
+      );
+    });
+
+    test('falls back past a blank name to a phone', () {
+      expect(
+        transactionReportCustomerLabel(
+          _tx(customerName: '   ', customerPhone: '0788222222'),
+        ),
+        '0788222222',
+      );
+    });
+
+    test('shows a dash for a walk-in with nothing captured', () {
+      expect(transactionReportCustomerLabel(_tx()), '—');
+      expect(
+        transactionReportCustomerLabel(
+          _tx(customerName: '', customerPhone: '', currentSaleCustomerPhoneNumber: ' '),
+        ),
+        '—',
+      );
+    });
+  });
+}

--- a/packages/flipper_localize/lib/l10n/app_en.arb
+++ b/packages/flipper_localize/lib/l10n/app_en.arb
@@ -2036,6 +2036,14 @@
     "@paymentMtnMomo": {
         "description": "Payment method display name, brand kept as-is"
     },
+    "payerNameOptional": "Payer name (optional)",
+    "@payerNameOptional": {
+        "description": "Hint for the optional name on the MoMo/bank account that sent the money, when it differs from the customer on the sale"
+    },
+    "paidBy": "Paid by",
+    "@paidBy": {
+        "description": "Label preceding the payer name on a transaction's payment line"
+    },
     "paymentAirtelMoney": "Airtel Money",
     "@paymentAirtelMoney": {
         "description": "Payment method display name, brand kept as-is"

--- a/packages/flipper_localize/lib/l10n/app_fr.arb
+++ b/packages/flipper_localize/lib/l10n/app_fr.arb
@@ -450,6 +450,8 @@
     "paymentBankCheck": "Chèque bancaire",
     "paymentDebitCreditCard": "Carte bancaire",
     "paymentMobileMoney": "Argent mobile",
+    "payerNameOptional": "Nom du payeur (facultatif)",
+    "paidBy": "Payé par",
     "paymentMtnMomo": "MTN MoMo",
     "paymentAirtelMoney": "Airtel Money",
     "paymentOther": "Autre",

--- a/packages/flipper_localize/lib/l10n/app_rw.arb
+++ b/packages/flipper_localize/lib/l10n/app_rw.arb
@@ -450,6 +450,8 @@
     "paymentBankCheck": "Sheki ya banki",
     "paymentDebitCreditCard": "Ikarita ya banki",
     "paymentMobileMoney": "Amafaranga kuri telefoni",
+    "payerNameOptional": "Izina ry'uwishyuye (si ngombwa)",
+    "paidBy": "Yishyuwe na",
     "paymentMtnMomo": "MTN MoMo",
     "paymentAirtelMoney": "Airtel Money",
     "paymentOther": "Ibindi",

--- a/packages/flipper_localize/lib/l10n/app_sw.arb
+++ b/packages/flipper_localize/lib/l10n/app_sw.arb
@@ -450,6 +450,8 @@
     "paymentBankCheck": "Hundi ya benki",
     "paymentDebitCreditCard": "Kadi ya benki",
     "paymentMobileMoney": "Pesa ya simu",
+    "payerNameOptional": "Jina la mlipaji (si lazima)",
+    "paidBy": "Amelipwa na",
     "paymentMtnMomo": "MTN MoMo",
     "paymentAirtelMoney": "Airtel Money",
     "paymentOther": "Nyingine",

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations.dart
@@ -2819,6 +2819,18 @@ abstract class FlipperAppLocalizations {
   /// **'MTN MoMo'**
   String get paymentMtnMomo;
 
+  /// Hint for the optional name on the MoMo/bank account that sent the money, when it differs from the customer on the sale
+  ///
+  /// In en, this message translates to:
+  /// **'Payer name (optional)'**
+  String get payerNameOptional;
+
+  /// Label preceding the payer name on a transaction's payment line
+  ///
+  /// In en, this message translates to:
+  /// **'Paid by'**
+  String get paidBy;
+
   /// Payment method display name, brand kept as-is
   ///
   /// In en, this message translates to:

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_en.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_en.dart
@@ -1516,6 +1516,12 @@ class FlipperAppLocalizationsEn extends FlipperAppLocalizations {
   String get paymentMtnMomo => 'MTN MoMo';
 
   @override
+  String get payerNameOptional => 'Payer name (optional)';
+
+  @override
+  String get paidBy => 'Paid by';
+
+  @override
   String get paymentAirtelMoney => 'Airtel Money';
 
   @override

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_fr.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_fr.dart
@@ -1545,6 +1545,12 @@ class FlipperAppLocalizationsFr extends FlipperAppLocalizations {
   String get paymentMtnMomo => 'MTN MoMo';
 
   @override
+  String get payerNameOptional => 'Nom du payeur (facultatif)';
+
+  @override
+  String get paidBy => 'Payé par';
+
+  @override
   String get paymentAirtelMoney => 'Airtel Money';
 
   @override

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_rw.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_rw.dart
@@ -1535,6 +1535,12 @@ class FlipperAppLocalizationsRw extends FlipperAppLocalizations {
   String get paymentMtnMomo => 'MTN MoMo';
 
   @override
+  String get payerNameOptional => 'Izina ry\'uwishyuye (si ngombwa)';
+
+  @override
+  String get paidBy => 'Yishyuwe na';
+
+  @override
   String get paymentAirtelMoney => 'Airtel Money';
 
   @override

--- a/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_sw.dart
+++ b/packages/flipper_localize/lib/src/l10n/flipper_app_localizations_sw.dart
@@ -1527,6 +1527,12 @@ class FlipperAppLocalizationsSw extends FlipperAppLocalizations {
   String get paymentMtnMomo => 'MTN MoMo';
 
   @override
+  String get payerNameOptional => 'Jina la mlipaji (si lazima)';
+
+  @override
+  String get paidBy => 'Amelipwa na';
+
+  @override
   String get paymentAirtelMoney => 'Airtel Money';
 
   @override

--- a/packages/flipper_models/lib/CoreSync.dart
+++ b/packages/flipper_models/lib/CoreSync.dart
@@ -2888,6 +2888,7 @@ class CoreSync extends AiStrategyImpl
     String? transactionId,
     double amount = 0.0,
     String? paymentMethod,
+    String? payerName,
     required bool singlePaymentOnly,
     bool saleCompletionFastPath = false,
   }) async {
@@ -2955,6 +2956,7 @@ class CoreSync extends AiStrategyImpl
         amount: amount,
         transactionId: transactionId,
         paymentMethod: paymentMethod,
+        payerName: normalizedPayerName(payerName),
       );
 
       await repository.upsert<TransactionPaymentRecord>(

--- a/packages/flipper_models/lib/DatabaseSyncInterface.dart
+++ b/packages/flipper_models/lib/DatabaseSyncInterface.dart
@@ -557,11 +557,16 @@ abstract class DatabaseSyncInterface extends AiStrategy
     required HttpClientInterface flipperHttpClient,
   });
 
+  /// [payerName] is the optional name on the MoMo/bank account that tendered
+  /// this line, for the common case where the payer is not the customer
+  /// attached to the transaction. Blank/whitespace is stored as null. Ignored
+  /// when [paymentRecord] is supplied (that record already carries its own).
   FutureOr<void> savePaymentType({
     TransactionPaymentRecord? paymentRecord,
     String? transactionId,
     double amount = 0.0,
     String? paymentMethod,
+    String? payerName,
     required bool singlePaymentOnly,
     bool saleCompletionFastPath = false,
   });

--- a/packages/flipper_models/lib/db_model_export.dart
+++ b/packages/flipper_models/lib/db_model_export.dart
@@ -26,5 +26,6 @@ export 'helperModels/business_feature.dart';
 export 'helpers/transaction_item_plu_metrics.dart';
 export 'helpers/transaction_item_line_order.dart';
 export 'models/personal_goal.dart';
+export 'helperModels/payer_name.dart';
 export 'helperModels/transaction_payment_sums.dart';
 export 'helperModels/transaction_report_snapshot.dart';

--- a/packages/flipper_models/lib/helperModels/payer_name.dart
+++ b/packages/flipper_models/lib/helperModels/payer_name.dart
@@ -1,0 +1,37 @@
+/// Helpers for the optional "who actually paid" name captured per tender line.
+///
+/// For mobile-money and bank tenders the account the money arrives from is
+/// frequently not the customer attached to the transaction — a relative sends
+/// the MoMo, a company account settles a personal bill. Capturing that name on
+/// the payment line lets the cashier reconcile a statement later without
+/// overwriting the transaction's own customer.
+library;
+
+/// Payment methods for which the payer-name field is offered.
+///
+/// Deliberately limited to the tenders that arrive through a named third-party
+/// account. Cash and credit have no payer to disambiguate, so they keep the
+/// payment row exactly as it was before this field existed.
+const Set<String> payerNameCapablePaymentMethods = {
+  'MOBILE MONEY',
+  'MTN MOMO',
+  'AIRTEL MONEY',
+  'BANK CHECK',
+  'DEBIT&CREDIT CARD',
+};
+
+/// Whether [paymentMethod] should offer/carry a payer name.
+bool paymentMethodSupportsPayerName(String? paymentMethod) {
+  if (paymentMethod == null) return false;
+  return payerNameCapablePaymentMethods.contains(
+    paymentMethod.trim().toUpperCase(),
+  );
+}
+
+/// Trims [payerName] and collapses blank input to null so an untouched field
+/// never persists an empty string.
+String? normalizedPayerName(String? payerName) {
+  final trimmed = payerName?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  return trimmed;
+}

--- a/packages/flipper_models/lib/helperModels/sale_completion_helpers.dart
+++ b/packages/flipper_models/lib/helperModels/sale_completion_helpers.dart
@@ -59,6 +59,31 @@ String applyTicketReviewWorkflowRedirect({
   return saleCompletionStatusPendingReview;
 }
 
+/// Aligned with [PENDING] in `flipper_services/constants.dart` (VM-safe).
+const String saleCompletionStatusPending = 'pending';
+
+/// The report date a POS row should carry once it settles, or `null` to leave
+/// `createdAt` untouched.
+///
+/// A POS cart row is minted the moment the *previous* sale finishes and is then
+/// reused with no age limit, so its `createdAt` is the previous sale's
+/// timestamp — not this sale's. It must therefore be re-stamped on the
+/// transition out of [saleCompletionStatusPending], and only then: every later
+/// write (refunds, receipt counters, RRA fields) has to preserve the sale date.
+///
+/// The returned value is always local time. Report windows are built from local
+/// wall clock with no `Z` suffix and Ditto compares them as strings, so a UTC
+/// stamp shifts sales out of their own day (−2h in Rwanda).
+DateTime? posSettlementCreatedAtStamp({
+  required String? priorStatus,
+  required String? newStatus,
+  required DateTime settledAt,
+}) {
+  if (newStatus == null || newStatus == saleCompletionStatusPending) return null;
+  if (priorStatus != saleCompletionStatusPending) return null;
+  return settledAt.isUtc ? settledAt.toLocal() : settledAt;
+}
+
 /// Statuses that mean "money already collected, tax already signed" for
 /// accounting/reporting purposes, even though the ticket is not yet in its
 /// final [saleCompletionStatusComplete] state.

--- a/packages/flipper_models/lib/helperModels/sale_completion_helpers.dart
+++ b/packages/flipper_models/lib/helperModels/sale_completion_helpers.dart
@@ -103,10 +103,15 @@ class PaymentLineForSaleCompletion {
   const PaymentLineForSaleCompletion({
     required this.amount,
     required this.method,
+    this.payerName,
   });
 
   final double amount;
   final String method;
+
+  /// Optional name on the MoMo/bank account that tendered this line. Carried
+  /// through completion untouched — it plays no part in the amount math.
+  final String? payerName;
 }
 
 /// Result of [deriveSaleCompletionState] — status and balances for persisting a sale.
@@ -246,6 +251,7 @@ List<PaymentLineForSaleCompletion> normalizePaymentLinesToSaleTotal({
       PaymentLineForSaleCompletion(
         amount: _roundToTwoDecimalPlaces(p.amount * factor),
         method: p.method,
+        payerName: p.payerName,
       ),
     );
   }
@@ -262,6 +268,7 @@ List<PaymentLineForSaleCompletion> normalizePaymentLinesToSaleTotal({
       adjusted[i] = PaymentLineForSaleCompletion(
         amount: _roundToTwoDecimalPlaces(p.amount + drift),
         method: p.method,
+        payerName: p.payerName,
       );
       break;
     }

--- a/packages/flipper_models/lib/power_sync/counter_init.sql
+++ b/packages/flipper_models/lib/power_sync/counter_init.sql
@@ -1100,6 +1100,7 @@ id UUID PRIMARY KEY,
 transaction_id UUID,
 amount NUMERIC(10,2),
 payment_method text,
+payer_name text,
 created_at timestamp with time zone
 
 );

--- a/packages/flipper_models/lib/providers/outer_variant_provider.dart
+++ b/packages/flipper_models/lib/providers/outer_variant_provider.dart
@@ -250,8 +250,21 @@ class OuterVariants extends _$OuterVariants {
   }
 
   /// Method to force a full refresh of variants (e.g., after adding new products).
+  ///
+  /// Deliberately a plain local read, not [_fetchVariantsWithColdStartGrace]:
+  /// every caller runs this straight after a local write, so the rows are
+  /// already in the local store. The grace path passes `fetchRemote: true` and,
+  /// on an empty result, sleeps through its own 400/900/1500ms backoff *and*
+  /// `variants()`'s inner 2s/3.5s/5s backoff — up to ~34s of retry loops on a
+  /// machine still busy finishing the save. Cold start is still covered by
+  /// [build], which callers reach via `ref.invalidate`.
+  ///
+  /// Takes a search generation so an in-flight [_applySearchQuery] cannot land
+  /// on top of this refresh (or vice versa) and resurrect stale filtered rows.
   Future<void> refresh() async {
-    final paged = await _fetchVariantsWithColdStartGrace(branchId);
+    final generation = ++_searchGeneration;
+    final paged = await _fetchVariants(branchId, 0, '');
+    if (generation != _searchGeneration) return;
     _currentSearch = '';
     _totalCount = paged.totalCount;
     _pageCache.clear();

--- a/packages/flipper_models/lib/sync/capella/capella_sync.dart
+++ b/packages/flipper_models/lib/sync/capella/capella_sync.dart
@@ -11,6 +11,7 @@ import 'package:flipper_models/cache/utility_cash_variant_cache.dart';
 import 'package:flipper_models/helpers/cash_movement_utility_variant.dart';
 import 'package:flipper_models/flipper_http_client.dart';
 import 'package:flipper_models/helperModels/business_type.dart';
+import 'package:flipper_models/helperModels/payer_name.dart';
 import 'package:flipper_models/sync/capella/mixins/delegation_mixin.dart';
 import 'package:flipper_models/sync/mixins/category_mixin.dart';
 import 'package:brick_offline_first/brick_offline_first.dart';
@@ -1557,6 +1558,7 @@ class CapellaSync extends AiStrategyImpl
     String? transactionId,
     double amount = 0.0,
     String? paymentMethod,
+    String? payerName,
     required bool singlePaymentOnly,
     bool saleCompletionFastPath = false,
   }) async {
@@ -1642,6 +1644,7 @@ class CapellaSync extends AiStrategyImpl
         'transactionId': r.transactionId,
         'amount': r.amount,
         'paymentMethod': r.paymentMethod,
+        'payerName': r.payerName,
         'createdAt': r.createdAt?.toUtc().toIso8601String(),
       };
 
@@ -1681,6 +1684,7 @@ class CapellaSync extends AiStrategyImpl
         amount: amount,
         transactionId: transactionId,
         paymentMethod: paymentMethod,
+        payerName: normalizedPayerName(payerName),
       );
 
       await upsertDitto(newPaymentRecord);

--- a/packages/flipper_models/lib/sync/capella/mixins/getter_operations_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/getter_operations_mixin.dart
@@ -281,6 +281,8 @@ TransactionPaymentRecord? _transactionPaymentRecordFromDittoRow(
     transactionId: tid,
     amount: _parsePaymentAmount(data['amount']) ?? 0.0,
     paymentMethod: data['paymentMethod']?.toString(),
+    // Rows written before the payer-name field existed simply have no key.
+    payerName: data['payerName']?.toString(),
     createdAt: _parsePaymentCreatedAt(data['createdAt']),
   );
 }

--- a/packages/flipper_models/lib/sync/capella/mixins/transaction_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/transaction_mixin.dart
@@ -15,6 +15,7 @@ import 'package:supabase_models/brick/models/sars.model.dart';
 import 'package:supabase_models/brick/repository.dart';
 import 'package:synchronized/synchronized.dart';
 import 'package:talker/talker.dart';
+import 'package:flipper_models/helperModels/sale_completion_helpers.dart';
 import 'package:flipper_models/helperModels/sale_device_id.dart';
 import 'package:flipper_models/sync/utils/rra_sar_sequence.dart';
 import 'package:flipper_models/sync/utils/sale_line_pricing.dart';
@@ -2186,18 +2187,20 @@ mixin CapellaTransactionMixin implements TransactionInterface {
     if (updates.isEmpty) return;
 
     final newStatus = arguments['status'] as String?;
-    Map<String, dynamic>? priorRowForEnsure;
-    if (!skipDittoSync &&
-        !deferEnsureNextPendingCart &&
-        newStatus != null &&
-        newStatus != PENDING) {
+    final leavingPending = newStatus != null && newStatus != PENDING;
+
+    // The prior row answers two questions: whether to prime the next pending
+    // cart, and whether this write is the PENDING → settled transition that
+    // owns the report date (see the createdAt re-stamp below).
+    Map<String, dynamic>? priorRow;
+    if (!skipDittoSync && leavingPending) {
       try {
         final pre = await ditto.store.execute(
           'SELECT * FROM transactions WHERE _id = :id OR id = :id',
           arguments: {'id': targetId},
         );
         if (pre.items.isNotEmpty) {
-          priorRowForEnsure = Map<String, dynamic>.from(pre.items.first.value);
+          priorRow = Map<String, dynamic>.from(pre.items.first.value);
         }
       } catch (e, s) {
         talker.warning(
@@ -2205,6 +2208,22 @@ mixin CapellaTransactionMixin implements TransactionInterface {
           s,
         );
       }
+    }
+    // Unchanged gate: when the caller primes the next cart itself
+    // (markTransactionAsCompleted → manageTransaction) we must not race it.
+    final priorRowForEnsure = deferEnsureNextPendingCart ? null : priorRow;
+
+    // The cart row this write is settling was minted by
+    // [_ensureNextPendingCartIfNeeded] when the *previous* sale finished, so its
+    // createdAt is that sale's timestamp — re-stamp it here, and only here. See
+    // [posSettlementCreatedAtStamp] for the rule and why the stamp is local.
+    if (priorRow != null) {
+      final saleDate = posSettlementCreatedAtStamp(
+        priorStatus: priorRow['status'] as String?,
+        newStatus: newStatus,
+        settledAt: resolvedLastTouched,
+      );
+      if (saleDate != null) addFieldUpdate('createdAt', saleDate);
     }
 
     final statusGuardClause = requireCurrentStatus != null
@@ -2615,7 +2634,11 @@ mixin CapellaTransactionMixin implements TransactionInterface {
 
     final targetId = transaction.id;
     final branchId = transaction.branchId ?? ProxyService.box.getBranchId()!;
-    final nowIso = DateTime.now().toUtc().toIso8601String();
+    final now = DateTime.now();
+    final nowIso = now.toUtc().toIso8601String();
+    // Report windows compare local wall-clock strings — see the createdAt note
+    // on [setClauses] below.
+    final nowLocalIso = now.toIso8601String();
 
     // Ensure peers subscribed to this branch can pull the PARKED update.
     // Pending-cart sync alone is deviceId+PENDING and does not match parks.
@@ -2685,15 +2708,25 @@ mixin CapellaTransactionMixin implements TransactionInterface {
     // POS tickets list filters `isOriginalTransaction = true`; ensure park
     // always lands in that set (kitchen already skips this check).
     transaction.isOriginalTransaction = true;
+    transaction.createdAt = now;
 
-    // Preserve original sale createdAt. Till "sent N min ago" uses lastTouched
-    // captured into SettlingTillTicket at Collect (before resume bumps it).
+    // Park is this ticket's transition out of the shared pending cart, whose
+    // createdAt is the *previous* sale's timestamp (see the re-stamp in
+    // [updateTransaction]) — so stamp the ticket's real open time here, or a
+    // parked ticket files under the wrong day in Transaction Reports. Local,
+    // not UTC, to match the report window's wall-clock string bounds.
+    // [resumeSaleTicketFast] deliberately leaves createdAt alone; the later
+    // PENDING → COMPLETE write re-stamps it to the settlement date.
+    //
+    // Till "sent N min ago" uses lastTouched captured into SettlingTillTicket
+    // at Collect (before resume bumps it), so it is unaffected.
     final setClauses = <String>[
       'status = :status',
       'ticketName = :ticketName',
       'note = :note',
       'isLoan = :isLoan',
       'isOriginalTransaction = :isOriginal',
+      'createdAt = :createdAt',
       'updatedAt = :updatedAt',
       'lastTouched = :lastTouched',
       'subTotal = :subTotal',
@@ -2705,6 +2738,7 @@ mixin CapellaTransactionMixin implements TransactionInterface {
       'note': ticketNote,
       'isLoan': transaction.isLoan ?? false,
       'isOriginal': true,
+      'createdAt': nowLocalIso,
       'updatedAt': nowIso,
       'lastTouched': nowIso,
       'subTotal': subTotal,
@@ -2766,8 +2800,9 @@ mixin CapellaTransactionMixin implements TransactionInterface {
     }
 
     final nowIso = DateTime.now().toUtc().toIso8601String();
-    // Do NOT touch createdAt here: it holds the original sale time (park no
-    // longer overwrites it). Till "sent N min ago" is stamped onto
+    // Do NOT touch createdAt here: resume is not a settlement. The row keeps
+    // the park stamp until the PENDING → COMPLETE write re-stamps it to the
+    // settlement date. Till "sent N min ago" is stamped onto
     // SettlingTillTicket from lastTouched *before* this resume write.
     //
     // Resume the ticket *before* sibling-cart cleanup. Cleanup used to run

--- a/packages/flipper_models/lib/sync/mixins/variant_mixin.dart
+++ b/packages/flipper_models/lib/sync/mixins/variant_mixin.dart
@@ -409,7 +409,10 @@ mixin VariantMixin implements VariantInterface {
             }
             await _ensureCapellaStockDocument(variantToSave);
           }
-          await repository.upsert<Variant>(variantToSave);
+          // Round before the single upsert. This used to upsert, round, then
+          // upsert the same row again, doubling the Brick write plus its Ditto
+          // mirror for every variant on every save. The persisted row is
+          // identical either way — the second write always won.
           if (variantToSave.splyAmt != null) {
             variantToSave.splyAmt = variantToSave.splyAmt!.toPrecision(0);
           }

--- a/packages/flipper_models/lib/view_models/ScannViewModel.dart
+++ b/packages/flipper_models/lib/view_models/ScannViewModel.dart
@@ -707,13 +707,16 @@ class ScannViewModel extends ProductViewModel with RRADEFAULTS {
 
         final boxBhfId = await ProxyService.box.bhfId();
 
-        for (var variant in scannedVariants) {
-          Ebm? ebmCache;
-          Future<Ebm?> loadEbm() async {
-            ebmCache ??= await ProxyService.strategy.ebm(branchId: branchId);
-            return ebmCache;
-          }
+        // Memoised across the whole loop. Declaring [ebmCache] inside the loop
+        // reset it on every iteration, so a save issued one EBM lookup per
+        // variant even though the row is branch-scoped and identical each time.
+        Ebm? ebmCache;
+        Future<Ebm?> loadEbm() async {
+          ebmCache ??= await ProxyService.strategy.ebm(branchId: branchId);
+          return ebmCache;
+        }
 
+        for (var variant in scannedVariants) {
           // Update expiration date if available
           if (dates != null && dates.containsKey(variant.id)) {
             try {

--- a/packages/flipper_models/lib/view_models/mixins/riverpod_states.dart
+++ b/packages/flipper_models/lib/view_models/mixins/riverpod_states.dart
@@ -515,9 +515,14 @@ class CombinedNotifier {
       throw Exception('Branch ID is null!');
     }
 
-    // Trigger search to force UI update
-    ref.read(searchStringProvider.notifier).emitString(value: "search");
-    ref.read(searchStringProvider.notifier).emitString(value: "");
+    // Drop back to the unfiltered catalog view. This used to emit "search" and
+    // then "" back to back: OuterVariants listens on this provider, so the
+    // throwaway "search" value cost a whole extra catalog query (and briefly
+    // blanked the grid) before "" queried again. Emit only when the search is
+    // actually set, so a save on an unfiltered grid costs a single refresh.
+    if (ref.read(searchStringProvider).isNotEmpty) {
+      ref.read(searchStringProvider.notifier).emitString(value: "");
+    }
 
     // Trigger refresh for outerVariantsProvider to show newly imported products
     ref.read(outerVariantsProvider(branchId).notifier).refresh();
@@ -769,11 +774,18 @@ class Payment {
   TextEditingController controller;
   final String id;
 
+  /// Optional name on the MoMo/bank account tendering this line, when it is
+  /// not the customer on the transaction. Null means "not captured" — see
+  /// [PaymentMethodsNotifier.updatePaymentMethod] for how it survives the
+  /// many places that rebuild a [Payment] from an existing one.
+  String? payerName;
+
   Payment({
     required this.amount,
     required this.method,
     String? id,
     TextEditingController? controller,
+    this.payerName,
   }) : controller =
            controller ?? TextEditingController(text: amount.toStringAsFixed(2)),
        id = id ?? UniqueKey().toString();
@@ -804,6 +816,17 @@ class PaymentMethodsNotifier extends Notifier<List<Payment>> {
     });
   }
 
+  /// Many call sites rebuild a [Payment] from an existing one to change only
+  /// the amount or the method, and know nothing about [Payment.payerName].
+  /// Keep the captured name for the same row unless the replacement carries a
+  /// value of its own — including an empty string, which the payment card uses
+  /// to deliberately clear the name (e.g. switching MoMo → Cash).
+  void _carryOverPayerName(Payment oldPayment, Payment newPayment) {
+    if (newPayment.payerName == null && oldPayment.id == newPayment.id) {
+      newPayment.payerName = oldPayment.payerName;
+    }
+  }
+
   // Method to add a payment method
   void addPaymentMethod(Payment method) {
     try {
@@ -812,6 +835,7 @@ class PaymentMethodsNotifier extends Notifier<List<Payment>> {
       );
       if (existingIndex != -1) {
         final oldPayment = state[existingIndex];
+        _carryOverPayerName(oldPayment, method);
         // Only dispose if we are NOT reusing the same controller
         if (oldPayment.controller != method.controller) {
           _safeDispose(oldPayment);
@@ -840,6 +864,7 @@ class PaymentMethodsNotifier extends Notifier<List<Payment>> {
     }
 
     final oldPayment = state[index];
+    _carryOverPayerName(oldPayment, payment);
     // Only dispose if we are NOT reusing the same controller
     if (oldPayment.controller != payment.controller) {
       _safeDispose(oldPayment);

--- a/packages/flipper_models/test/payer_name_test.dart
+++ b/packages/flipper_models/test/payer_name_test.dart
@@ -1,0 +1,46 @@
+import 'package:flipper_models/helperModels/payer_name.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('paymentMethodSupportsPayerName', () {
+    test('accepts the mobile-money and bank tenders', () {
+      for (final method in const [
+        'MOBILE MONEY',
+        'MTN MOMO',
+        'AIRTEL MONEY',
+        'BANK CHECK',
+        'DEBIT&CREDIT CARD',
+      ]) {
+        expect(paymentMethodSupportsPayerName(method), isTrue, reason: method);
+      }
+    });
+
+    test('rejects cash and credit so those rows are unchanged', () {
+      expect(paymentMethodSupportsPayerName('CASH'), isFalse);
+      expect(paymentMethodSupportsPayerName('CREDIT'), isFalse);
+      expect(paymentMethodSupportsPayerName('CASH/CREDIT'), isFalse);
+      expect(paymentMethodSupportsPayerName('OTHER'), isFalse);
+    });
+
+    test('is case and whitespace insensitive', () {
+      expect(paymentMethodSupportsPayerName(' mtn momo '), isTrue);
+      expect(paymentMethodSupportsPayerName('Mobile Money'), isTrue);
+    });
+
+    test('null is not payer-capable', () {
+      expect(paymentMethodSupportsPayerName(null), isFalse);
+    });
+  });
+
+  group('normalizedPayerName', () {
+    test('trims a real name', () {
+      expect(normalizedPayerName('  Jean Uwase '), 'Jean Uwase');
+    });
+
+    test('collapses blank input to null so nothing empty is persisted', () {
+      expect(normalizedPayerName(null), isNull);
+      expect(normalizedPayerName(''), isNull);
+      expect(normalizedPayerName('   '), isNull);
+    });
+  });
+}

--- a/packages/flipper_models/test/sale_completion_helpers_test.dart
+++ b/packages/flipper_models/test/sale_completion_helpers_test.dart
@@ -158,6 +158,40 @@ void main() {
       final cash = normalized.firstWhere((p) => p.method == 'CASH');
       expect(cash.amount, closeTo(40.0, 0.02));
     });
+
+    test('preserves payerName on scaled and drift-corrected rows', () {
+      final normalized = normalizePaymentLinesToSaleTotal(
+        paymentMethods: const [
+          PaymentLineForSaleCompletion(amount: 60, method: 'CASH'),
+          PaymentLineForSaleCompletion(
+            amount: 60,
+            method: 'MTN MOMO',
+            payerName: 'Jean Uwase',
+          ),
+        ],
+        saleTotal: 100,
+        shouldBeLoan: false,
+      );
+      final momo = normalized.firstWhere((p) => p.method == 'MTN MOMO');
+      expect(momo.payerName, 'Jean Uwase');
+      expect(normalized.firstWhere((p) => p.method == 'CASH').payerName, null);
+    });
+
+    test('passthrough (loan) keeps payerName untouched', () {
+      const lines = [
+        PaymentLineForSaleCompletion(
+          amount: 10,
+          method: 'BANK CHECK',
+          payerName: 'Acme Ltd',
+        ),
+      ];
+      final normalized = normalizePaymentLinesToSaleTotal(
+        paymentMethods: lines,
+        saleTotal: 100,
+        shouldBeLoan: true,
+      );
+      expect(normalized.single.payerName, 'Acme Ltd');
+    });
   });
 
   group('saleLineQtyByVariantId', () {

--- a/packages/flipper_models/test/sale_completion_helpers_test.dart
+++ b/packages/flipper_models/test/sale_completion_helpers_test.dart
@@ -264,4 +264,103 @@ void main() {
       expect(isFinanciallySettledSaleStatus(null), isFalse);
     });
   });
+
+  group('posSettlementCreatedAtStamp', () {
+    // The shared pending cart is minted when the previous sale finishes, so its
+    // createdAt is yesterday's last sale for the first sale of a new day.
+    final yesterdayCart = DateTime(2026, 8, 6, 18, 30);
+    final settledNow = DateTime(2026, 8, 7, 9, 15);
+
+    test('re-stamps the sale date when the cart leaves pending', () {
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusPending,
+          newStatus: saleCompletionStatusComplete,
+          settledAt: settledNow,
+        ),
+        settledNow,
+      );
+    });
+
+    test('re-stamps for parked, pendingReview and awaitingHandover too', () {
+      for (final status in [
+        saleCompletionStatusParked,
+        saleCompletionStatusPendingReview,
+        saleCompletionStatusAwaitingHandover,
+      ]) {
+        expect(
+          posSettlementCreatedAtStamp(
+            priorStatus: saleCompletionStatusPending,
+            newStatus: status,
+            settledAt: settledNow,
+          ),
+          settledNow,
+          reason: 'leaving the pending cart for $status owns the report date',
+        );
+      }
+    });
+
+    test('preserves the sale date on later writes (refund, counters, RRA)', () {
+      // Prior row is already settled — createdAt must not move.
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusComplete,
+          newStatus: saleCompletionStatusComplete,
+          settledAt: settledNow,
+        ),
+        isNull,
+      );
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusParked,
+          newStatus: saleCompletionStatusComplete,
+          settledAt: settledNow,
+        ),
+        isNull,
+      );
+    });
+
+    test('does not stamp when the row stays a pending cart', () {
+      // e.g. resumeSaleTicketFast (parked → pending) and cart edits.
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusPending,
+          newStatus: saleCompletionStatusPending,
+          settledAt: settledNow,
+        ),
+        isNull,
+      );
+      expect(
+        posSettlementCreatedAtStamp(
+          priorStatus: saleCompletionStatusPending,
+          newStatus: null,
+          settledAt: settledNow,
+        ),
+        isNull,
+      );
+    });
+
+    test('normalizes a UTC settlement time to local', () {
+      // Report windows are local wall-clock strings with no `Z`, compared
+      // lexicographically — a UTC stamp would file the sale in the wrong day.
+      final stamp = posSettlementCreatedAtStamp(
+        priorStatus: saleCompletionStatusPending,
+        newStatus: saleCompletionStatusComplete,
+        settledAt: settledNow.toUtc(),
+      );
+      expect(stamp!.isUtc, isFalse);
+      expect(stamp, settledNow);
+      expect(stamp.toIso8601String(), isNot(endsWith('Z')));
+    });
+
+    test("the stale cart date is never what lands on the sale", () {
+      final stamp = posSettlementCreatedAtStamp(
+        priorStatus: saleCompletionStatusPending,
+        newStatus: saleCompletionStatusComplete,
+        settledAt: settledNow,
+      );
+      expect(stamp, isNot(yesterdayCart));
+      expect(stamp!.day, 7, reason: 'sold on the 7th, not the cart-mint day');
+    });
+  });
 }

--- a/packages/supabase_models/lib/brick/adapters/transaction_payment_record_adapter.g.dart
+++ b/packages/supabase_models/lib/brick/adapters/transaction_payment_record_adapter.g.dart
@@ -15,6 +15,9 @@ Future<TransactionPaymentRecord> _$TransactionPaymentRecordFromSupabase(
     paymentMethod: data['payment_method'] == null
         ? null
         : data['payment_method'] as String?,
+    payerName: data['payer_name'] == null
+        ? null
+        : data['payer_name'] as String?,
     createdAt: data['created_at'] == null
         ? null
         : data['created_at'] == null
@@ -33,6 +36,7 @@ Future<Map<String, dynamic>> _$TransactionPaymentRecordToSupabase(
     'transaction_id': instance.transactionId,
     'amount': instance.amount,
     'payment_method': instance.paymentMethod,
+    'payer_name': instance.payerName,
     'created_at': instance.createdAt?.toIso8601String(),
   };
 }
@@ -51,6 +55,9 @@ Future<TransactionPaymentRecord> _$TransactionPaymentRecordFromSqlite(
     paymentMethod: data['payment_method'] == null
         ? null
         : data['payment_method'] as String?,
+    payerName: data['payer_name'] == null
+        ? null
+        : data['payer_name'] as String?,
     createdAt: data['created_at'] == null
         ? null
         : data['created_at'] == null
@@ -69,6 +76,7 @@ Future<Map<String, dynamic>> _$TransactionPaymentRecordToSqlite(
     'transaction_id': instance.transactionId,
     'amount': instance.amount,
     'payment_method': instance.paymentMethod,
+    'payer_name': instance.payerName,
     'created_at': instance.createdAt?.toIso8601String(),
   };
 }
@@ -99,6 +107,10 @@ class TransactionPaymentRecordAdapter
     'paymentMethod': const RuntimeSupabaseColumnDefinition(
       association: false,
       columnName: 'payment_method',
+    ),
+    'payerName': const RuntimeSupabaseColumnDefinition(
+      association: false,
+      columnName: 'payer_name',
     ),
     'createdAt': const RuntimeSupabaseColumnDefinition(
       association: false,
@@ -138,6 +150,12 @@ class TransactionPaymentRecordAdapter
     'paymentMethod': const RuntimeSqliteColumnDefinition(
       association: false,
       columnName: 'payment_method',
+      iterable: false,
+      type: String,
+    ),
+    'payerName': const RuntimeSqliteColumnDefinition(
+      association: false,
+      columnName: 'payer_name',
       iterable: false,
       type: String,
     ),

--- a/packages/supabase_models/lib/brick/db/20260807090000.migration.dart
+++ b/packages/supabase_models/lib/brick/db/20260807090000.migration.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE EDIT WITH CAUTION
+// THIS FILE **WILL NOT** BE REGENERATED
+// This file should be version controlled and can be manually edited.
+part of 'schema.g.dart';
+
+const List<MigrationCommand> _migration_20260807090000_up = [
+  InsertColumn(
+    'payer_name',
+    Column.varchar,
+    onTable: 'TransactionPaymentRecord',
+  ),
+];
+
+const List<MigrationCommand> _migration_20260807090000_down = [
+  DropColumn('payer_name', onTable: 'TransactionPaymentRecord'),
+];
+
+@Migratable(
+  version: '20260807090000',
+  up: _migration_20260807090000_up,
+  down: _migration_20260807090000_down,
+)
+class Migration20260807090000 extends Migration {
+  const Migration20260807090000()
+    : super(
+        version: 20260807090000,
+        up: _migration_20260807090000_up,
+        down: _migration_20260807090000_down,
+      );
+}

--- a/packages/supabase_models/lib/brick/db/schema.g.dart
+++ b/packages/supabase_models/lib/brick/db/schema.g.dart
@@ -13,6 +13,7 @@ part '20260705114226.migration.dart';
 part '20260723122459.migration.dart';
 part '20260728113000.migration.dart';
 part '20260728163000.migration.dart';
+part '20260807090000.migration.dart';
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{
@@ -28,11 +29,12 @@ final migrations = <Migration>{
   const Migration20260723122459(),
   const Migration20260728113000(),
   const Migration20260728163000(),
+  const Migration20260807090000(),
 };
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(
-  20260728163000,
+  20260807090000,
   generatorVersion: 1,
   tables: <SchemaTable>{
     SchemaTable(
@@ -1814,6 +1816,7 @@ final schema = Schema(
         SchemaColumn('transaction_id', Column.varchar),
         SchemaColumn('amount', Column.Double),
         SchemaColumn('payment_method', Column.varchar),
+        SchemaColumn('payer_name', Column.varchar),
         SchemaColumn('created_at', Column.datetime),
       },
       indices: <SchemaIndex>{

--- a/packages/supabase_models/lib/brick/models/transaction_payment_record.model.dart
+++ b/packages/supabase_models/lib/brick/models/transaction_payment_record.model.dart
@@ -31,6 +31,12 @@ class TransactionPaymentRecord extends OfflineFirstWithSupabaseModel {
   @Supabase(defaultValue: "0.0")
   double? amount;
   String? paymentMethod;
+
+  /// Name of the person who actually tendered this line, when it differs from
+  /// the customer attached to the transaction (mobile money / bank transfers
+  /// are often paid from someone else's account). Optional — null for cash and
+  /// for every record written before this field existed.
+  String? payerName;
   DateTime? createdAt;
   TransactionPaymentRecord({
     String? id,
@@ -38,5 +44,6 @@ class TransactionPaymentRecord extends OfflineFirstWithSupabaseModel {
     required this.amount,
     required this.paymentMethod,
     required this.createdAt,
+    this.payerName,
   }) : id = id ?? const Uuid().v4();
 }

--- a/packages/supabase_models/lib/brick/models/transaction_payment_record.model.ditto_sync_adapter.g.dart
+++ b/packages/supabase_models/lib/brick/models/transaction_payment_record.model.ditto_sync_adapter.g.dart
@@ -95,6 +95,7 @@ class TransactionPaymentRecordDittoAdapter
       "transactionId": model.transactionId,
       "amount": model.amount,
       "paymentMethod": model.paymentMethod,
+      "payerName": model.payerName,
       "createdAt": model.createdAt?.toIso8601String(),
     };
   }
@@ -133,6 +134,7 @@ class TransactionPaymentRecordDittoAdapter
       transactionId: document["transactionId"],
       amount: document["amount"],
       paymentMethod: document["paymentMethod"],
+      payerName: document["payerName"],
       createdAt: DateTime.tryParse(document["createdAt"]?.toString() ?? ""),
     );
   }

--- a/packages/supabase_models/lib/brick/repository.dart
+++ b/packages/supabase_models/lib/brick/repository.dart
@@ -304,6 +304,12 @@ class Repository extends OfflineFirstWithSupabaseRepository {
       },
     );
 
+    // Tags each write with the signed-in uid. This has to wrap the queue
+    // rather than sit inside it: the queue serializes headers into SQLite
+    // before AuthRefreshingClient runs, so a stamp applied further down would
+    // never be persisted alongside the job.
+    final stampingClient = EnqueuedUserStampClient(client);
+
     final SupabaseClient supabaseClient;
     final mock = SupabaseMockServer(modelDictionary: supabaseModelDictionary);
 
@@ -311,15 +317,15 @@ class Repository extends OfflineFirstWithSupabaseRepository {
       debugPrint('Using mocked Supabase client in test environment');
       // Use the mocked client in a test environment
       await mock.setUp();
-      supabaseClient =
-          SupabaseClient(mock.serverUrl, mock.apiKey, httpClient: client);
+      supabaseClient = SupabaseClient(mock.serverUrl, mock.apiKey,
+          httpClient: stampingClient);
     } else {
       debugPrint('Using real Supabase client in non-test environment');
       // Initialize the real Supabase client in a non-test environment
       supabaseClient = (await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseAnonKey,
-        httpClient: client,
+        httpClient: stampingClient,
       ))
           .client;
     }

--- a/packages/supabase_models/lib/brick/repository.dart
+++ b/packages/supabase_models/lib/brick/repository.dart
@@ -275,23 +275,16 @@ class Repository extends OfflineFirstWithSupabaseRepository {
         http.Client(),
         anonKey: supabaseAnonKey,
       ),
-      // Brick's default list contains 401 and 403, which means an auth
-      // rejection is retried forever. Because the queue is serial and ordered
-      // by created_at, one such job sits at the head and blocks every other
-      // pending write. AuthRefreshingClient already holds requests back (503)
-      // while there is no session, so a 401/403 that still reaches us is a
-      // genuine rejection and the job should be dropped.
-      reattemptForStatusCodes: const [
-        400,
-        404,
-        405,
-        408,
-        429,
-        500,
-        502,
-        503,
-        504,
-      ],
+      // Only transport, throttling and server-side failures are worth
+      // replaying. Brick's default list contains 401/403 (and 404), which means
+      // a rejection the server will never change its mind about is retried
+      // forever; because the queue is serial and ordered by created_at, one
+      // such job sits at the head and blocks every other pending write. The
+      // same argument rules out 400/405 — a malformed request or a wrong verb
+      // is terminal. AuthRefreshingClient already holds requests back with a
+      // synthetic 503 while there is no session, so a 401/403 that still
+      // reaches us is genuine and the job should be dropped.
+      reattemptForStatusCodes: const [408, 429, 500, 502, 503, 504],
       onReattempt: (http.Request request, dynamic object) async {
         _logger.info('Reattempting offline request: ${request.url}');
       },

--- a/packages/supabase_models/lib/brick/repository.dart
+++ b/packages/supabase_models/lib/brick/repository.dart
@@ -11,7 +11,7 @@ import 'package:brick_supabase/brick_supabase.dart' hide Supabase;
 import 'package:flipper_services/constants.dart';
 import 'package:flipper_services/event_bus.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:http/http.dart' as http show Request;
+import 'package:http/http.dart' as http show Client, Request;
 import 'package:supabase_models/brick/brick.g.dart';
 import 'package:supabase_models/brick/databasePath.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, debugPrint;
@@ -25,6 +25,7 @@ import 'package:logging/logging.dart';
 export 'package:brick_core/query.dart'
     show And, Or, Query, QueryAction, Where, WherePhrase, Compare, OrderBy;
 
+import 'repository/auth_refreshing_client.dart';
 import 'repository/database_manager.dart';
 import 'repository/legacy_database_migration.dart';
 import 'repository/queue_manager.dart';
@@ -268,6 +269,29 @@ class Repository extends OfflineFirstWithSupabaseRepository {
     final (client, queue) = OfflineFirstWithSupabaseRepository.clientQueue(
       databaseFactory: PlatformHelpers.getQueueDatabaseFactory(),
       databasePath: queuePath, // This is the path for the queue database
+      // Stamps a live access token onto every request, including queue
+      // replays, which would otherwise carry the JWT frozen at enqueue time.
+      innerClient: AuthRefreshingClient(
+        http.Client(),
+        anonKey: supabaseAnonKey,
+      ),
+      // Brick's default list contains 401 and 403, which means an auth
+      // rejection is retried forever. Because the queue is serial and ordered
+      // by created_at, one such job sits at the head and blocks every other
+      // pending write. AuthRefreshingClient already holds requests back (503)
+      // while there is no session, so a 401/403 that still reaches us is a
+      // genuine rejection and the job should be dropped.
+      reattemptForStatusCodes: const [
+        400,
+        404,
+        405,
+        408,
+        429,
+        500,
+        502,
+        503,
+        504,
+      ],
       onReattempt: (http.Request request, dynamic object) async {
         _logger.info('Reattempting offline request: ${request.url}');
       },
@@ -322,6 +346,14 @@ class Repository extends OfflineFirstWithSupabaseRepository {
       dbPath: dbPath,
     );
     await _singleton!._ensurePendingAnalyticsEventTable();
+
+    // Clear jobs that have already exhausted their reattempts. Queues in the
+    // field can hold requests that looped on a 401 for as long as the app has
+    // been installed, blocking every write behind them.
+    final purged = await _singleton!.purgeExhaustedQueue();
+    if (purged > 0) {
+      _logger.warning('Purged $purged exhausted offline queue request(s)');
+    }
 
     _markReady();
     print('✅ [Repository] Repository marked as ready');
@@ -480,6 +512,25 @@ class Repository extends OfflineFirstWithSupabaseRepository {
     } catch (e) {
       _logger.warning('Error getting queue status: $e');
       return {'locked': 0, 'unlocked': 0, 'total': 0};
+    }
+  }
+
+  /// Drop queued requests that have exhausted their reattempts.
+  /// Returns the number of requests deleted.
+  Future<int> purgeExhaustedQueue() async {
+    if (kIsWeb) {
+      return 0;
+    }
+    if (_isDisposed) {
+      _logger.warning(
+          'Attempted to call purgeExhaustedQueue on a disposed Repository.');
+      return 0;
+    }
+    try {
+      return await _queueManager.purgeExhaustedRequests();
+    } catch (e) {
+      _logger.warning('Error purging exhausted queue: $e');
+      return 0;
     }
   }
 

--- a/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
+++ b/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
@@ -15,6 +15,13 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 /// never sees it. This mirrors Brick's own `X-Brick-OfflineFirstPolicy`.
 const String enqueuedUserHeader = 'X-Flipper-Enqueued-Uid';
 
+/// Ownership stamp for a write created while no one was signed in.
+///
+/// Never equal to a real `auth.uid()`, so [AuthRefreshingClient] discards such
+/// a job instead of committing it under whoever signs in next. A missing stamp
+/// therefore means exactly one thing — a row queued before uid tagging existed.
+const String signedOutEnqueuedUser = 'signed-out';
+
 /// A live access token together with the user it belongs to.
 typedef QueuedAuth = ({String accessToken, String userId});
 
@@ -141,8 +148,11 @@ class EnqueuedUserStampClient extends http.BaseClient {
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     if (_pushMethods.contains(request.method) &&
         _isAuthenticatedPath(request.url.path)) {
-      final uid = _tokenSource.currentUserId;
-      if (uid != null) request.headers[enqueuedUserHeader] = uid;
+      // Stamp unconditionally. Leaving a signed-out write unstamped would make
+      // it indistinguishable from a legacy job, and legacy jobs are replayed
+      // as-is — so the next user to sign in would commit it as their own.
+      request.headers[enqueuedUserHeader] =
+          _tokenSource.currentUserId ?? signedOutEnqueuedUser;
     }
 
     return _inner.send(request);

--- a/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
+++ b/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+// ignore: depend_on_referenced_packages
+import 'package:logging/logging.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// An [http.Client] that stamps a *current* Supabase access token onto every
+/// outgoing PostgREST/Storage/Functions request.
+///
+/// This sits **below** Brick's offline queue. That matters: the queue
+/// serializes a request's entire header map into SQLite when the request is
+/// created (`RestRequestSqliteCache.toSqlite`) and replays it verbatim later,
+/// so a job that waits longer than the access-token lifetime (1h by default)
+/// would otherwise be sent with a dead JWT and rejected by PostgREST with a
+/// 401. Because this client runs on both the first attempt and every replay,
+/// the stored `Authorization` header is always overwritten with a live one.
+///
+/// When no usable token can be obtained, the request is **not** sent — the
+/// client synthesizes a retryable [_noSessionStatus] response so the job stays
+/// in the queue instead of burning an unauthenticated round trip.
+class AuthRefreshingClient extends http.BaseClient {
+  /// Retryable status used when there is no session to authenticate with.
+  /// Must be present in the queue's `reattemptForStatusCodes` so the job is
+  /// kept rather than discarded.
+  static const int _noSessionStatus = 503;
+
+  /// Refresh the token this long before it actually expires, so a request
+  /// that is in flight when the clock rolls over is not rejected.
+  static const Duration _expiryLeeway = Duration(minutes: 1);
+
+  /// After a failed refresh, don't try again for this long. The queue ticks
+  /// every 5 seconds; without a cooldown a broken session would hammer
+  /// `/auth/v1/token`.
+  static const Duration _refreshCooldown = Duration(seconds: 30);
+
+  /// Paths that carry their own credentials and must be forwarded untouched.
+  /// Rewriting the header on the token endpoint would break session refresh
+  /// (and recurse, since refreshes are issued through this same client).
+  static const _passthroughPaths = ['/auth/v1'];
+
+  /// Paths whose requests are authenticated with the user's access token.
+  static const _authenticatedPaths = ['/rest/v1', '/storage/v1', '/functions/v1'];
+
+  final http.Client _inner;
+  final String _anonKey;
+  final Logger _logger;
+
+  /// Deduplicates concurrent refreshes; the queue and the UI can both trip the
+  /// expiry check at the same moment.
+  Future<Session?>? _inFlightRefresh;
+  DateTime? _refreshFailedAt;
+
+  AuthRefreshingClient(
+    this._inner, {
+    required String anonKey,
+    Logger? logger,
+  })  : _anonKey = anonKey,
+        _logger = logger ?? Logger('AuthRefreshingClient');
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final path = request.url.path;
+
+    if (_passthroughPaths.any(path.startsWith) ||
+        !_authenticatedPaths.any(path.startsWith)) {
+      return _inner.send(request);
+    }
+
+    final token = await _currentAccessToken();
+
+    if (token == null) {
+      _logger.warning(
+        'No Supabase session; holding ${request.method} $path in the queue',
+      );
+      // Shaped like a PostgREST error so postgrest_dart raises a normal
+      // PostgrestException rather than choking on an unparseable body.
+      const body =
+          '{"code":"no_session","message":"No active Supabase session",'
+          '"details":null,"hint":null}';
+      return http.StreamedResponse(
+        Stream.value(utf8.encode(body)),
+        _noSessionStatus,
+        request: request,
+        contentLength: body.length,
+        headers: const {'content-type': 'application/json; charset=utf-8'},
+        reasonPhrase: 'No active Supabase session',
+      );
+    }
+
+    // Overwrite rather than add: a replayed request already carries a stale
+    // Authorization header from whenever it was first queued.
+    request.headers['Authorization'] = 'Bearer $token';
+    request.headers['apikey'] = _anonKey;
+
+    return _inner.send(request);
+  }
+
+  /// Returns a non-expired access token, refreshing if necessary, or `null`
+  /// when the user has no session (signed out, or never signed in).
+  Future<String?> _currentAccessToken() async {
+    final GoTrueClient auth;
+    try {
+      auth = Supabase.instance.client.auth;
+    } catch (_) {
+      // Supabase.initialize hasn't completed yet.
+      return null;
+    }
+
+    final session = auth.currentSession;
+    if (session == null) return null;
+    if (!_isExpiring(session)) return session.accessToken;
+
+    final failedAt = _refreshFailedAt;
+    if (failedAt != null &&
+        DateTime.now().difference(failedAt) < _refreshCooldown) {
+      return null;
+    }
+
+    final refreshed = await (_inFlightRefresh ??= _refresh(auth));
+    return refreshed?.accessToken;
+  }
+
+  Future<Session?> _refresh(GoTrueClient auth) async {
+    try {
+      final response = await auth.refreshSession();
+      _refreshFailedAt = null;
+      return response.session;
+    } catch (e) {
+      _refreshFailedAt = DateTime.now();
+      _logger.warning('Failed to refresh Supabase session: $e');
+      return null;
+    } finally {
+      _inFlightRefresh = null;
+    }
+  }
+
+  bool _isExpiring(Session session) {
+    final expiresAt = session.expiresAt;
+    if (expiresAt == null) return session.isExpired;
+
+    final expiry = DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000);
+    return DateTime.now().add(_expiryLeeway).isAfter(expiry);
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}

--- a/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
+++ b/packages/supabase_models/lib/brick/repository/auth_refreshing_client.dart
@@ -6,28 +6,35 @@ import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-/// An [http.Client] that stamps a *current* Supabase access token onto every
-/// outgoing PostgREST/Storage/Functions request.
+/// Header carrying the `auth.uid()` that was signed in when a request was
+/// first enqueued.
 ///
-/// This sits **below** Brick's offline queue. That matters: the queue
-/// serializes a request's entire header map into SQLite when the request is
-/// created (`RestRequestSqliteCache.toSqlite`) and replays it verbatim later,
-/// so a job that waits longer than the access-token lifetime (1h by default)
-/// would otherwise be sent with a dead JWT and rejected by PostgREST with a
-/// 401. Because this client runs on both the first attempt and every replay,
-/// the stored `Authorization` header is always overwritten with a live one.
-///
-/// When no usable token can be obtained, the request is **not** sent — the
-/// client synthesizes a retryable [_noSessionStatus] response so the job stays
-/// in the queue instead of burning an unauthenticated round trip.
-class AuthRefreshingClient extends http.BaseClient {
-  /// Retryable status used when there is no session to authenticate with.
-  /// Must be present in the queue's `reattemptForStatusCodes` so the job is
-  /// kept rather than discarded.
-  static const int _noSessionStatus = 503;
+/// Brick's offline queue serializes a request's headers into SQLite, so this
+/// rides along with the job and survives an app restart. It is stripped by
+/// [AuthRefreshingClient] before the request leaves the device — Supabase
+/// never sees it. This mirrors Brick's own `X-Brick-OfflineFirstPolicy`.
+const String enqueuedUserHeader = 'X-Flipper-Enqueued-Uid';
 
-  /// Refresh the token this long before it actually expires, so a request
-  /// that is in flight when the clock rolls over is not rejected.
+/// A live access token together with the user it belongs to.
+typedef QueuedAuth = ({String accessToken, String userId});
+
+/// Supplies a non-expired access token for outgoing requests.
+///
+/// Exists as a seam so the queue clients can be tested without a live
+/// Supabase session.
+abstract class AccessTokenSource {
+  /// Returns a usable token, refreshing if necessary, or `null` when there is
+  /// no session to authenticate with.
+  Future<QueuedAuth?> current();
+
+  /// The signed-in user, without triggering a refresh. `null` when signed out.
+  String? get currentUserId;
+}
+
+/// [AccessTokenSource] backed by the ambient `Supabase.instance` session.
+class SupabaseAccessTokenSource implements AccessTokenSource {
+  /// Refresh this long before the token actually expires, so a request that is
+  /// in flight when the clock rolls over is not rejected.
   static const Duration _expiryLeeway = Duration(minutes: 1);
 
   /// After a failed refresh, don't try again for this long. The queue ticks
@@ -35,16 +42,6 @@ class AuthRefreshingClient extends http.BaseClient {
   /// `/auth/v1/token`.
   static const Duration _refreshCooldown = Duration(seconds: 30);
 
-  /// Paths that carry their own credentials and must be forwarded untouched.
-  /// Rewriting the header on the token endpoint would break session refresh
-  /// (and recurse, since refreshes are issued through this same client).
-  static const _passthroughPaths = ['/auth/v1'];
-
-  /// Paths whose requests are authenticated with the user's access token.
-  static const _authenticatedPaths = ['/rest/v1', '/storage/v1', '/functions/v1'];
-
-  final http.Client _inner;
-  final String _anonKey;
   final Logger _logger;
 
   /// Deduplicates concurrent refreshes; the queue and the UI can both trip the
@@ -52,65 +49,20 @@ class AuthRefreshingClient extends http.BaseClient {
   Future<Session?>? _inFlightRefresh;
   DateTime? _refreshFailedAt;
 
-  AuthRefreshingClient(
-    this._inner, {
-    required String anonKey,
-    Logger? logger,
-  })  : _anonKey = anonKey,
-        _logger = logger ?? Logger('AuthRefreshingClient');
+  SupabaseAccessTokenSource({Logger? logger})
+      : _logger = logger ?? Logger('SupabaseAccessTokenSource');
 
   @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) async {
-    final path = request.url.path;
+  String? get currentUserId => _auth?.currentSession?.user.id;
 
-    if (_passthroughPaths.any(path.startsWith) ||
-        !_authenticatedPaths.any(path.startsWith)) {
-      return _inner.send(request);
-    }
-
-    final token = await _currentAccessToken();
-
-    if (token == null) {
-      _logger.warning(
-        'No Supabase session; holding ${request.method} $path in the queue',
-      );
-      // Shaped like a PostgREST error so postgrest_dart raises a normal
-      // PostgrestException rather than choking on an unparseable body.
-      const body =
-          '{"code":"no_session","message":"No active Supabase session",'
-          '"details":null,"hint":null}';
-      return http.StreamedResponse(
-        Stream.value(utf8.encode(body)),
-        _noSessionStatus,
-        request: request,
-        contentLength: body.length,
-        headers: const {'content-type': 'application/json; charset=utf-8'},
-        reasonPhrase: 'No active Supabase session',
-      );
-    }
-
-    // Overwrite rather than add: a replayed request already carries a stale
-    // Authorization header from whenever it was first queued.
-    request.headers['Authorization'] = 'Bearer $token';
-    request.headers['apikey'] = _anonKey;
-
-    return _inner.send(request);
-  }
-
-  /// Returns a non-expired access token, refreshing if necessary, or `null`
-  /// when the user has no session (signed out, or never signed in).
-  Future<String?> _currentAccessToken() async {
-    final GoTrueClient auth;
-    try {
-      auth = Supabase.instance.client.auth;
-    } catch (_) {
-      // Supabase.initialize hasn't completed yet.
-      return null;
-    }
+  @override
+  Future<QueuedAuth?> current() async {
+    final auth = _auth;
+    if (auth == null) return null;
 
     final session = auth.currentSession;
     if (session == null) return null;
-    if (!_isExpiring(session)) return session.accessToken;
+    if (!_isExpiring(session)) return _asAuth(session);
 
     final failedAt = _refreshFailedAt;
     if (failedAt != null &&
@@ -119,8 +71,20 @@ class AuthRefreshingClient extends http.BaseClient {
     }
 
     final refreshed = await (_inFlightRefresh ??= _refresh(auth));
-    return refreshed?.accessToken;
+    return refreshed == null ? null : _asAuth(refreshed);
   }
+
+  /// `null` until `Supabase.initialize` has completed.
+  GoTrueClient? get _auth {
+    try {
+      return Supabase.instance.client.auth;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  QueuedAuth _asAuth(Session session) =>
+      (accessToken: session.accessToken, userId: session.user.id);
 
   Future<Session?> _refresh(GoTrueClient auth) async {
     try {
@@ -142,6 +106,167 @@ class AuthRefreshingClient extends http.BaseClient {
 
     final expiry = DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000);
     return DateTime.now().add(_expiryLeeway).isAfter(expiry);
+  }
+}
+
+/// Paths whose requests are authenticated with the user's access token.
+const _authenticatedPaths = ['/rest/v1', '/storage/v1', '/functions/v1'];
+
+/// Paths that carry their own credentials and must be forwarded untouched.
+/// Rewriting the header on the token endpoint would break session refresh
+/// (and recurse, since refreshes are issued through the same client).
+const _passthroughPaths = ['/auth/v1'];
+
+bool _isAuthenticatedPath(String path) =>
+    !_passthroughPaths.any(path.startsWith) &&
+    _authenticatedPaths.any(path.startsWith);
+
+/// Tags outgoing writes with the `auth.uid()` that owns them.
+///
+/// This must sit **above** Brick's offline queue: the queue serializes headers
+/// when the job is written to SQLite, before [AuthRefreshingClient] ever runs,
+/// so a stamp applied lower down would not be persisted with the job.
+class EnqueuedUserStampClient extends http.BaseClient {
+  static const _pushMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+  final http.Client _inner;
+  final AccessTokenSource _tokenSource;
+
+  EnqueuedUserStampClient(
+    this._inner, {
+    AccessTokenSource? tokenSource,
+  }) : _tokenSource = tokenSource ?? SupabaseAccessTokenSource();
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (_pushMethods.contains(request.method) &&
+        _isAuthenticatedPath(request.url.path)) {
+      final uid = _tokenSource.currentUserId;
+      if (uid != null) request.headers[enqueuedUserHeader] = uid;
+    }
+
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}
+
+/// An [http.Client] that stamps a *current* Supabase access token onto every
+/// outgoing PostgREST/Storage/Functions request.
+///
+/// This sits **below** Brick's offline queue. That matters: the queue
+/// serializes a request's entire header map into SQLite when the request is
+/// created (`RestRequestSqliteCache.toSqlite`) and replays it verbatim later,
+/// so a job that waits longer than the access-token lifetime (1h by default)
+/// would otherwise be sent with a dead JWT and rejected by PostgREST with a
+/// 401. Because this client runs on both the first attempt and every replay,
+/// the stored `Authorization` header is always overwritten with a live one.
+///
+/// Two cases are not sent at all:
+///
+/// * No session — synthesizes a retryable [_noSessionStatus] so the job stays
+///   queued rather than burning an unauthenticated round trip.
+/// * The job was enqueued by a *different* user (see [enqueuedUserHeader]) —
+///   synthesizes [_wrongUserStatus], which is outside the queue's reattempt
+///   list, so the job is dropped. Without this, a write parked by user A would
+///   be committed under user B's identity after a handover on a shared device,
+///   which no RLS policy can catch because the credentials really are B's.
+class AuthRefreshingClient extends http.BaseClient {
+  /// Retryable status used when there is no session to authenticate with.
+  /// Must be present in the queue's `reattemptForStatusCodes`.
+  static const int _noSessionStatus = 503;
+
+  /// Terminal status used when a job belongs to a different user. Must be
+  /// absent from `reattemptForStatusCodes` so the job is discarded.
+  static const int _wrongUserStatus = 403;
+
+  final http.Client _inner;
+  final String _anonKey;
+  final AccessTokenSource _tokenSource;
+  final Logger _logger;
+
+  AuthRefreshingClient(
+    this._inner, {
+    required String anonKey,
+    AccessTokenSource? tokenSource,
+    Logger? logger,
+  })  : _anonKey = anonKey,
+        _logger = logger ?? Logger('AuthRefreshingClient'),
+        _tokenSource = tokenSource ?? SupabaseAccessTokenSource();
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final path = request.url.path;
+    if (!_isAuthenticatedPath(path)) return _inner.send(request);
+
+    final auth = await _tokenSource.current();
+
+    if (auth == null) {
+      _logger.warning(
+        'No Supabase session; holding ${request.method} $path in the queue',
+      );
+      return _refuse(
+        request,
+        status: _noSessionStatus,
+        code: 'no_session',
+        message: 'No active Supabase session',
+      );
+    }
+
+    // Strip before forwarding — this header is for us, not for Supabase.
+    final enqueuedBy = request.headers.remove(enqueuedUserHeader);
+
+    // Absent on jobs queued before uid tagging existed; those are sent as-is
+    // rather than discarded.
+    if (enqueuedBy != null && enqueuedBy != auth.userId) {
+      _logger.warning(
+        'Dropping ${request.method} $path: queued by $enqueuedBy but the '
+        'active session is ${auth.userId}',
+      );
+      return _refuse(
+        request,
+        status: _wrongUserStatus,
+        code: 'enqueued_by_other_user',
+        message: 'Queued request belongs to a different user',
+      );
+    }
+
+    // Overwrite rather than add: a replayed request already carries a stale
+    // Authorization header from whenever it was first queued.
+    request.headers['Authorization'] = 'Bearer ${auth.accessToken}';
+    request.headers['apikey'] = _anonKey;
+
+    return _inner.send(request);
+  }
+
+  /// Builds a locally-synthesized response shaped like a PostgREST error, so
+  /// postgrest_dart raises a normal PostgrestException rather than choking on
+  /// an unparseable body.
+  http.StreamedResponse _refuse(
+    http.BaseRequest request, {
+    required int status,
+    required String code,
+    required String message,
+  }) {
+    final body = jsonEncode({
+      'code': code,
+      'message': message,
+      'details': null,
+      'hint': null,
+    });
+
+    return http.StreamedResponse(
+      Stream.value(utf8.encode(body)),
+      status,
+      request: request,
+      contentLength: body.length,
+      headers: const {'content-type': 'application/json; charset=utf-8'},
+      reasonPhrase: message,
+    );
   }
 
   @override

--- a/packages/supabase_models/lib/brick/repository/queue_manager.dart
+++ b/packages/supabase_models/lib/brick/repository/queue_manager.dart
@@ -3,11 +3,7 @@ import 'package:logging/logging.dart';
 import 'package:brick_offline_first/offline_queue.dart';
 // ignore: depend_on_referenced_packages
 import 'package:brick_offline_first_with_rest/offline_queue.dart'
-    show
-        HTTP_JOBS_ATTEMPTS_COLUMN,
-        HTTP_JOBS_REQUEST_METHOD_COLUMN,
-        HTTP_JOBS_TABLE_NAME,
-        HTTP_JOBS_URL_COLUMN;
+    show HTTP_JOBS_ATTEMPTS_COLUMN, HTTP_JOBS_TABLE_NAME;
 
 /// Manages offline request queue operations
 class QueueManager {
@@ -133,18 +129,20 @@ class QueueManager {
 
       if (exhausted.isEmpty) return 0;
 
+      final primaryKeyColumn =
+          offlineRequestQueue.requestManager.primaryKeyColumn;
+
+      // Only the local job id and attempt count: a PostgREST URL carries the
+      // table plus the row filters (ids, phone numbers, names) in its query
+      // string, which must not be written to the log.
       for (final request in exhausted) {
         _logger.warning(
-          'Dropping queue job after ${request[HTTP_JOBS_ATTEMPTS_COLUMN]} '
-          'attempts: ${request[HTTP_JOBS_REQUEST_METHOD_COLUMN]} '
-          '${request[HTTP_JOBS_URL_COLUMN]}',
+          'Dropping queue job ${request[primaryKeyColumn]} after '
+          '${request[HTTP_JOBS_ATTEMPTS_COLUMN]} attempts',
         );
       }
 
-      await _processBatches(
-        exhausted,
-        offlineRequestQueue.requestManager.primaryKeyColumn,
-      );
+      await _processBatches(exhausted, primaryKeyColumn);
 
       return exhausted.length;
     } catch (e) {

--- a/packages/supabase_models/lib/brick/repository/queue_manager.dart
+++ b/packages/supabase_models/lib/brick/repository/queue_manager.dart
@@ -1,6 +1,13 @@
 // ignore: depend_on_referenced_packages
 import 'package:logging/logging.dart';
 import 'package:brick_offline_first/offline_queue.dart';
+// ignore: depend_on_referenced_packages
+import 'package:brick_offline_first_with_rest/offline_queue.dart'
+    show
+        HTTP_JOBS_ATTEMPTS_COLUMN,
+        HTTP_JOBS_REQUEST_METHOD_COLUMN,
+        HTTP_JOBS_TABLE_NAME,
+        HTTP_JOBS_URL_COLUMN;
 
 /// Manages offline request queue operations
 class QueueManager {
@@ -11,6 +18,11 @@ class QueueManager {
   static const int _batchSize = 10;
   // Delay between batches to prevent lock contention
   static const Duration _batchDelay = Duration(milliseconds: 50);
+
+  /// Attempts after which a job is considered unrecoverable and dropped.
+  /// The queue is serial and ordered by `created_at`, so a job that can never
+  /// succeed stays at the head and starves every write behind it.
+  static const int _maxAttempts = 25;
 
   QueueManager(this.offlineRequestQueue);
 
@@ -97,6 +109,46 @@ class QueueManager {
       return requests.length;
     } catch (e) {
       _logger.warning("An error occurred while deleting failed requests: $e");
+      return 0;
+    }
+  }
+
+  /// Drop jobs that have been reattempted more than [maxAttempts] times.
+  ///
+  /// Brick has no built-in attempt ceiling: [RestOfflineQueueClient] only
+  /// removes a job when the response status is outside its reattempt list, so
+  /// a request the server will never accept is replayed every processing
+  /// interval indefinitely. Because processing is serial and ordered by
+  /// `created_at`, that job also blocks everything queued after it.
+  ///
+  /// Returns the number of requests deleted.
+  Future<int> purgeExhaustedRequests({int maxAttempts = _maxAttempts}) async {
+    try {
+      final db = await offlineRequestQueue.requestManager.getDb();
+      final exhausted = await db.query(
+        HTTP_JOBS_TABLE_NAME,
+        where: '$HTTP_JOBS_ATTEMPTS_COLUMN > ?',
+        whereArgs: [maxAttempts],
+      );
+
+      if (exhausted.isEmpty) return 0;
+
+      for (final request in exhausted) {
+        _logger.warning(
+          'Dropping queue job after ${request[HTTP_JOBS_ATTEMPTS_COLUMN]} '
+          'attempts: ${request[HTTP_JOBS_REQUEST_METHOD_COLUMN]} '
+          '${request[HTTP_JOBS_URL_COLUMN]}',
+        );
+      }
+
+      await _processBatches(
+        exhausted,
+        offlineRequestQueue.requestManager.primaryKeyColumn,
+      );
+
+      return exhausted.length;
+    } catch (e) {
+      _logger.warning('Error purging exhausted requests: $e');
       return 0;
     }
   }

--- a/packages/supabase_models/test/auth_refreshing_client_test.dart
+++ b/packages/supabase_models/test/auth_refreshing_client_test.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:supabase_models/brick/repository/auth_refreshing_client.dart';
+
+/// Records what actually reached the wire.
+class _RecordingClient extends http.BaseClient {
+  final List<http.BaseRequest> sent = [];
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    sent.add(request);
+    return http.StreamedResponse(const Stream.empty(), 200, request: request);
+  }
+}
+
+void main() {
+  const anonKey = 'anon-key';
+  late _RecordingClient inner;
+  late AuthRefreshingClient client;
+
+  setUp(() {
+    inner = _RecordingClient();
+    client = AuthRefreshingClient(inner, anonKey: anonKey);
+  });
+
+  http.Request request(String url) => http.Request('POST', Uri.parse(url))
+    ..headers['Authorization'] = 'Bearer stale-token';
+
+  group('with no Supabase session', () {
+    test('holds PostgREST writes instead of sending them unauthenticated',
+        () async {
+      final response = await client.send(
+        request('https://project.supabase.co/rest/v1/logs?id=eq.abc'),
+      );
+
+      expect(response.statusCode, 503,
+          reason: 'must be retryable so the queue keeps the job');
+      expect(inner.sent, isEmpty,
+          reason: 'no request should reach Supabase without a live token');
+    });
+
+    test('synthesized body parses as a PostgREST error', () async {
+      final response = await client.send(
+        request('https://project.supabase.co/rest/v1/logs'),
+      );
+      final body = await response.stream.bytesToString();
+
+      expect(
+        jsonDecode(body),
+        containsPair('message', 'No active Supabase session'),
+      );
+    });
+
+    test('holds storage and functions writes too', () async {
+      for (final path in ['/storage/v1/object/x', '/functions/v1/x']) {
+        final response =
+            await client.send(request('https://project.supabase.co$path'));
+        expect(response.statusCode, 503, reason: path);
+      }
+      expect(inner.sent, isEmpty);
+    });
+  });
+
+  group('passthrough', () {
+    test('forwards auth requests untouched', () async {
+      final auth =
+          request('https://project.supabase.co/auth/v1/token?grant_type=x');
+
+      final response = await client.send(auth);
+
+      expect(response.statusCode, 200);
+      expect(inner.sent, hasLength(1));
+      expect(
+        inner.sent.single.headers['Authorization'],
+        'Bearer stale-token',
+        reason: 'rewriting the token endpoint would break session refresh',
+      );
+    });
+
+    test('forwards non-Supabase requests untouched', () async {
+      await client.send(request('https://example.com/api/thing'));
+
+      expect(inner.sent, hasLength(1));
+      expect(inner.sent.single.headers['Authorization'], 'Bearer stale-token');
+      expect(inner.sent.single.headers.containsKey('apikey'), isFalse);
+    });
+  });
+}

--- a/packages/supabase_models/test/auth_refreshing_client_test.dart
+++ b/packages/supabase_models/test/auth_refreshing_client_test.dart
@@ -200,25 +200,57 @@ void main() {
       expect(inner.sent.single.headers[enqueuedUserHeader], 'user-a');
     });
 
-    test('does not tag reads, auth calls, or signed-out writes', () async {
+    test('does not tag reads or auth calls', () async {
       final signedIn = EnqueuedUserStampClient(
         inner,
         tokenSource: _FakeTokenSource.signedInAs('user-a'),
-      );
-      final signedOut = EnqueuedUserStampClient(
-        inner,
-        tokenSource: _FakeTokenSource(),
       );
 
       await signedIn.send(request(restUrl, method: 'GET'));
       await signedIn
           .send(request('https://project.supabase.co/auth/v1/token?g=x'));
-      await signedOut.send(request(restUrl));
 
       expect(
         inner.sent.where((r) => r.headers.containsKey(enqueuedUserHeader)),
         isEmpty,
       );
+    });
+
+    test('tags signed-out writes with the reserved uid', () async {
+      final signedOut = EnqueuedUserStampClient(
+        inner,
+        tokenSource: _FakeTokenSource(),
+      );
+
+      await signedOut.send(request(restUrl));
+
+      expect(
+        inner.sent.single.headers[enqueuedUserHeader],
+        signedOutEnqueuedUser,
+        reason: 'an unstamped write is indistinguishable from a legacy row',
+      );
+    });
+
+    test('a signed-out write is dropped once someone signs in', () async {
+      // The whole point of the reserved stamp: nobody inherits a write that
+      // was created while no one was signed in.
+      final queued = _RecordingClient();
+      final stamped = EnqueuedUserStampClient(
+        queued,
+        tokenSource: _FakeTokenSource(),
+      );
+      await stamped.send(request(restUrl));
+
+      final replay = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-b'),
+      );
+      final response = await replay.send(queued.sent.single);
+
+      expect(response.statusCode, 403,
+          reason: 'must be outside reattemptForStatusCodes so it is discarded');
+      expect(inner.sent, isEmpty);
     });
 
     test('round-trips through the queue into AuthRefreshingClient', () async {

--- a/packages/supabase_models/test/auth_refreshing_client_test.dart
+++ b/packages/supabase_models/test/auth_refreshing_client_test.dart
@@ -16,36 +16,130 @@ class _RecordingClient extends http.BaseClient {
   }
 }
 
+class _FakeTokenSource implements AccessTokenSource {
+  QueuedAuth? auth;
+  int refreshCount = 0;
+
+  _FakeTokenSource({this.auth});
+
+  factory _FakeTokenSource.signedInAs(String userId) => _FakeTokenSource(
+        auth: (accessToken: 'fresh-$userId', userId: userId),
+      );
+
+  @override
+  String? get currentUserId => auth?.userId;
+
+  @override
+  Future<QueuedAuth?> current() async {
+    refreshCount++;
+    return auth;
+  }
+}
+
 void main() {
   const anonKey = 'anon-key';
-  late _RecordingClient inner;
-  late AuthRefreshingClient client;
+  const restUrl = 'https://project.supabase.co/rest/v1/logs?id=eq.abc';
 
-  setUp(() {
-    inner = _RecordingClient();
-    client = AuthRefreshingClient(inner, anonKey: anonKey);
+  late _RecordingClient inner;
+
+  setUp(() => inner = _RecordingClient());
+
+  http.Request request(String url, {String method = 'POST', String? queuedBy}) {
+    final req = http.Request(method, Uri.parse(url))
+      ..headers['Authorization'] = 'Bearer stale-token';
+    if (queuedBy != null) req.headers[enqueuedUserHeader] = queuedBy;
+    return req;
+  }
+
+  group('token refresh', () {
+    test('replaces the stale token captured when the job was queued', () async {
+      final client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+
+      await client.send(request(restUrl));
+
+      expect(inner.sent.single.headers['Authorization'], 'Bearer fresh-user-a');
+      expect(inner.sent.single.headers['apikey'], anonKey);
+    });
   });
 
-  http.Request request(String url) => http.Request('POST', Uri.parse(url))
-    ..headers['Authorization'] = 'Bearer stale-token';
+  group('cross-user replay', () {
+    test('drops a job queued by a different user', () async {
+      final client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-b'),
+      );
 
-  group('with no Supabase session', () {
+      final response = await client.send(request(restUrl, queuedBy: 'user-a'));
+
+      expect(response.statusCode, 403,
+          reason: 'must be outside reattemptForStatusCodes so it is discarded');
+      expect(inner.sent, isEmpty,
+          reason: "user A's write must not be committed as user B");
+    });
+
+    test('sends a job queued by the same user, without leaking the stamp',
+        () async {
+      final client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+
+      await client.send(request(restUrl, queuedBy: 'user-a'));
+
+      expect(inner.sent, hasLength(1));
+      expect(inner.sent.single.headers.containsKey(enqueuedUserHeader), isFalse,
+          reason: 'the stamp is internal and must not reach Supabase');
+    });
+
+    test('sends untagged jobs queued before uid tagging existed', () async {
+      final client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-b'),
+      );
+
+      await client.send(request(restUrl));
+
+      expect(inner.sent, hasLength(1),
+          reason: 'pre-existing queue rows must not be discarded wholesale');
+    });
+  });
+
+  group('with no session', () {
+    late AuthRefreshingClient client;
+
+    setUp(() {
+      client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource(),
+      );
+    });
+
     test('holds PostgREST writes instead of sending them unauthenticated',
         () async {
-      final response = await client.send(
-        request('https://project.supabase.co/rest/v1/logs?id=eq.abc'),
-      );
+      final response = await client.send(request(restUrl));
 
       expect(response.statusCode, 503,
           reason: 'must be retryable so the queue keeps the job');
-      expect(inner.sent, isEmpty,
-          reason: 'no request should reach Supabase without a live token');
+      expect(inner.sent, isEmpty);
+    });
+
+    test('holds rather than drops a tagged job', () async {
+      final response = await client.send(request(restUrl, queuedBy: 'user-a'));
+
+      expect(response.statusCode, 503,
+          reason: 'user A may sign back in; the write should survive');
     });
 
     test('synthesized body parses as a PostgREST error', () async {
-      final response = await client.send(
-        request('https://project.supabase.co/rest/v1/logs'),
-      );
+      final response = await client.send(request(restUrl));
       final body = await response.stream.bytesToString();
 
       expect(
@@ -65,14 +159,20 @@ void main() {
   });
 
   group('passthrough', () {
+    late AuthRefreshingClient client;
+
+    setUp(() {
+      client = AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+    });
+
     test('forwards auth requests untouched', () async {
-      final auth =
-          request('https://project.supabase.co/auth/v1/token?grant_type=x');
+      await client
+          .send(request('https://project.supabase.co/auth/v1/token?g=x'));
 
-      final response = await client.send(auth);
-
-      expect(response.statusCode, 200);
-      expect(inner.sent, hasLength(1));
       expect(
         inner.sent.single.headers['Authorization'],
         'Bearer stale-token',
@@ -83,9 +183,67 @@ void main() {
     test('forwards non-Supabase requests untouched', () async {
       await client.send(request('https://example.com/api/thing'));
 
-      expect(inner.sent, hasLength(1));
       expect(inner.sent.single.headers['Authorization'], 'Bearer stale-token');
       expect(inner.sent.single.headers.containsKey('apikey'), isFalse);
+    });
+  });
+
+  group('EnqueuedUserStampClient', () {
+    test('tags writes with the signed-in uid', () async {
+      final client = EnqueuedUserStampClient(
+        inner,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+
+      await client.send(request(restUrl));
+
+      expect(inner.sent.single.headers[enqueuedUserHeader], 'user-a');
+    });
+
+    test('does not tag reads, auth calls, or signed-out writes', () async {
+      final signedIn = EnqueuedUserStampClient(
+        inner,
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+      final signedOut = EnqueuedUserStampClient(
+        inner,
+        tokenSource: _FakeTokenSource(),
+      );
+
+      await signedIn.send(request(restUrl, method: 'GET'));
+      await signedIn
+          .send(request('https://project.supabase.co/auth/v1/token?g=x'));
+      await signedOut.send(request(restUrl));
+
+      expect(
+        inner.sent.where((r) => r.headers.containsKey(enqueuedUserHeader)),
+        isEmpty,
+      );
+    });
+
+    test('round-trips through the queue into AuthRefreshingClient', () async {
+      // The stamp is applied above the queue and read below it, so the two
+      // halves must agree on the header.
+      final stamped = EnqueuedUserStampClient(
+        _RecordingClient(),
+        tokenSource: _FakeTokenSource.signedInAs('user-a'),
+      );
+      final outbound = request(restUrl);
+      await stamped.send(outbound);
+
+      // Simulate the queue serializing and replaying the headers verbatim.
+      final replayed = http.Request('POST', outbound.url)
+        ..headers.addAll(jsonDecode(jsonEncode(outbound.headers))
+            .cast<String, String>());
+
+      final response = await AuthRefreshingClient(
+        inner,
+        anonKey: anonKey,
+        tokenSource: _FakeTokenSource.signedInAs('user-b'),
+      ).send(replayed);
+
+      expect(response.statusCode, 403);
+      expect(inner.sent, isEmpty);
     });
   });
 }


### PR DESCRIPTION
Brick's offline queue serializes a request's entire header map into
SQLite when the request is created and replays it verbatim later, so any
job that outlived the access-token lifetime (1h by default) was resent
with a dead JWT and rejected by PostgREST with a 401.

Worse, 401 and 403 are in the queue's default reattemptForStatusCodes, so
the job was never removed. Processing is serial and ordered by
created_at, which meant one permanently-401 request sat at the head of
the queue and starved every write behind it while re-hitting Supabase
every 5 seconds.

- Add AuthRefreshingClient as the queue's innerClient. It sits below the
  queue, so it overwrites Authorization/apikey with a live token on first
  attempts and replays alike, refreshing within 60s of expiry (deduped,
  with a 30s cooldown after a failed refresh). Auth and non-Supabase
  paths pass through untouched. With no session it holds the request
  back with a retryable 503 rather than sending it unauthenticated.
- Drop 401/403 from reattemptForStatusCodes; with the above, a 401 that
  still lands is a genuine rejection and the job should not be retried.
- Add QueueManager.purgeExhaustedRequests to drop jobs past 25 attempts,
  run at startup to clear queues already stalled in the field.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Record optional payer names for supported payment methods.
  - Display payer details and “Paid by” information in payment lines and refund previews.
  - Added localized support in English, French, Kinyarwanda, and Swahili.
  - Added a refresh control for transaction reports with progress and error feedback.

- **Bug Fixes**
  - Improved customer phone fallback handling.
  - Prevented stale search results from replacing newer filtered data.
  - Improved offline queue retry behavior and signed-out write handling.

- **Chores**
  - Updated the application and desktop package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->