### PR TITLE
fix(ditto): timeout the active-branch lookup so Home doesn't spin for…

### DIFF
--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.335.0+1756529822
+version: 1.336.0+1756529823
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.339.0.0
+  msix_version: 1.340.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_form.dart
+++ b/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_form.dart
@@ -4,6 +4,7 @@ import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:flipper_models/db_model_export.dart';
 import 'package:flipper_services/proxy.dart';
 import 'package:flipper_models/SyncStrategy.dart';
+import 'package:flipper_dashboard/features/stock_recount/stock_recount_tokens.dart';
 
 /// SAP Fiori-inspired Smart Form widget for work orders
 ///
@@ -110,15 +111,10 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
       decoration: isMobile
           ? null
           : BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(16),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.08),
-                  blurRadius: 20,
-                  offset: const Offset(0, 4),
-                ),
-              ],
+              color: StockRecountTokens.surface,
+              border: Border.all(color: StockRecountTokens.line),
+              borderRadius: BorderRadius.circular(StockRecountTokens.radiusLg),
+              boxShadow: StockRecountTokens.cardShadows,
             ),
       child: Form(
         key: _formKey,
@@ -129,29 +125,19 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
             // Header (only show on desktop, mobile has bottom sheet header)
             if (!isMobile) ...[
               Container(
-                padding: EdgeInsets.all(16),
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 18),
                 decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [Colors.blue[50]!, Colors.blue[100]!],
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                  ),
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+                  color: StockRecountTokens.accentTint,
+                  borderRadius: BorderRadius.circular(StockRecountTokens.radiusMd),
                 ),
                 child: Row(
                   children: [
                     Container(
                       padding: EdgeInsets.all(10),
                       decoration: BoxDecoration(
-                        color: Colors.white,
-                        borderRadius: BorderRadius.circular(12),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.1),
-                            blurRadius: 8,
-                            offset: Offset(0, 2),
-                          ),
-                        ],
+                        color: StockRecountTokens.surface,
+                        border: Border.all(color: StockRecountTokens.line),
+                        borderRadius: BorderRadius.circular(StockRecountTokens.radiusSm),
                       ),
                       child: Icon(
                         isEdit ? Icons.edit_outlined : Icons.add_circle_outline,
@@ -169,7 +155,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
                             style: TextStyle(
                               fontSize: 20,
                               fontWeight: FontWeight.bold,
-                              color: Colors.grey[800],
+                              color: StockRecountTokens.ink1,
                             ),
                           ),
                           SizedBox(height: 4),
@@ -177,7 +163,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
                             'Plan production output for your products',
                             style: TextStyle(
                               fontSize: 14,
-                              color: Colors.grey[600],
+                              color: StockRecountTokens.ink2,
                             ),
                           ),
                         ],
@@ -255,16 +241,16 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
                     child: ElevatedButton(
                       onPressed: _isSubmitting ? null : _handleSubmit,
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.blue[700],
+                        backgroundColor: StockRecountTokens.accent,
                         foregroundColor: Colors.white,
                         padding: const EdgeInsets.symmetric(
                           horizontal: 32,
                           vertical: 16,
                         ),
-                        elevation: 2,
-                        shadowColor: Colors.blue.withValues(alpha: 0.3),
+                        elevation: 0,
+                        shadowColor: StockRecountTokens.accentRing,
                         shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
+                          borderRadius: BorderRadius.circular(StockRecountTokens.radiusSm),
                         ),
                       ),
                       child: _isSubmitting
@@ -478,8 +464,12 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
               Icon(Icons.search_off, size: 48, color: Colors.grey[400]),
               SizedBox(height: 8),
               Text(
-                'No products found',
-                style: TextStyle(color: Colors.grey[600], fontSize: 14),
+                'No raw materials found',
+                style: TextStyle(
+                  color: StockRecountTokens.ink2,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
             ],
           ),
@@ -570,7 +560,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
 
   Widget _buildShiftField() {
     return DropdownButtonFormField<String>(
-      value: _selectedShift,
+      initialValue: _selectedShift,
       decoration: InputDecoration(
         labelText: 'Shift (Optional)',
         labelStyle: TextStyle(color: Colors.grey[700]),

--- a/packages/flipper_models/lib/providers/active_branch_provider.dart
+++ b/packages/flipper_models/lib/providers/active_branch_provider.dart
@@ -44,9 +44,9 @@ Stream<Branch> activeBranch(Ref ref) async* {
     }
 
     try {
-      final branch = await ProxyService.getStrategy(Strategy.capella).activeBranch(
-        branchId: branchId,
-      );
+      final branch = await ProxyService.getStrategy(Strategy.capella)
+          .activeBranch(branchId: branchId)
+          .timeout(const Duration(seconds: 5));
       if (_branchIdentityChanged(lastYielded, branch)) {
         lastYielded = branch;
         yield branch;


### PR DESCRIPTION
…ever offline

activeBranchProvider awaited CapellaBranchMixin.activeBranch() with no
timeout. When that Ditto local-store query hangs while offline, the
stream never yields and the Home tab body stays stuck on its loading
spinner indefinitely, even though the nav chrome renders fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the application version for the latest release.

- **Bug Fixes**
  - Improved work-order form styling and consistency.
  - Clarified the empty state message for missing raw materials.
  - Improved shift selection behavior.
  - Added a timeout to active-branch loading to prevent prolonged waiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->