### PR TITLE
fix(ditto): timeout the active-branch lookup so Home doesn't spin for…

### DIFF
--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.336.0+1756529823
+version: 1.337.0+1756529824
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.340.0.0
+  msix_version: 1.341.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.341.0+1756529828
+version: 1.342.0+1756529829
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.345.0.0
+  msix_version: 1.346.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.335.0+1756529822
+version: 1.336.0+1756529823
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.339.0.0
+  msix_version: 1.340.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.337.0+1756529824
+version: 1.338.0+1756529825
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.341.0.0
+  msix_version: 1.342.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.338.0+1756529825
+version: 1.339.0+1756529826
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.342.0.0
+  msix_version: 1.343.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.340.0+1756529827
+version: 1.341.0+1756529828
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.344.0.0
+  msix_version: 1.345.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/packages/flipper_dashboard/lib/features/production_output/providers/production_output_derived_providers.dart
+++ b/packages/flipper_dashboard/lib/features/production_output/providers/production_output_derived_providers.dart
@@ -1,0 +1,116 @@
+import 'package:flipper_models/providers/production_output_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_models/brick/models/work_order.model.dart';
+
+import '../models/production_output_models.dart';
+
+/// Number of days plotted by the variance chart, today inclusive.
+const int kVarianceChartDays = 7;
+
+const _kVarianceReasons = <String>[
+  'machine',
+  'material',
+  'labor',
+  'quality',
+  'planning',
+  'other',
+];
+
+/// Live KPI summary for the whole branch.
+///
+/// Derived from [workOrdersStreamProvider] / [actualOutputsStreamProvider]
+/// rather than re-queried, so the header, the analytical cards and the table
+/// can never disagree about what has been produced.
+final productionSummaryProvider = Provider<AsyncValue<ProductionSummary>>((
+  ref,
+) {
+  final workOrders = ref.watch(workOrdersStreamProvider);
+  final outputs = ref.watch(actualOutputsStreamProvider);
+
+  // Outputs only refine the variance-reason breakdown; don't hold the KPIs
+  // hostage to that stream still loading.
+  return workOrders.whenData(
+    (orders) => summarizeWorkOrders(orders, outputs.asData?.value ?? const []),
+  );
+});
+
+/// Live data for the variance chart: one point per day for the last
+/// [kVarianceChartDays] days, bucketed by work-order target date.
+final varianceChartDataProvider = Provider<AsyncValue<List<VarianceDataPoint>>>(
+  (ref) {
+    final now = DateTime.now();
+    return ref
+        .watch(workOrdersStreamProvider)
+        .whenData((orders) => buildVarianceSeries(orders, now: now));
+  },
+);
+
+/// Pure roll-up of work orders into the KPI shape the cards render.
+ProductionSummary summarizeWorkOrders(
+  List<WorkOrder> workOrders,
+  List<dynamic> actualOutputs,
+) {
+  double totalPlanned = 0;
+  double totalActual = 0;
+  int completedOrders = 0;
+
+  for (final wo in workOrders) {
+    totalPlanned += wo.plannedQuantity;
+    totalActual += wo.actualQuantity;
+    if (wo.status == 'completed') completedOrders++;
+  }
+
+  final varianceByReason = <String, double>{for (final r in _kVarianceReasons) r: 0};
+  for (final output in actualOutputs) {
+    final reason = (output.varianceReason as String?)?.toLowerCase();
+    if (reason == null) continue;
+    final key = varianceByReason.containsKey(reason) ? reason : 'other';
+    varianceByReason[key] = varianceByReason[key]! + 1;
+  }
+
+  final totalOrders = workOrders.length;
+  final variance = totalActual - totalPlanned;
+
+  return ProductionSummary(
+    totalPlanned: totalPlanned,
+    totalActual: totalActual,
+    variance: variance,
+    variancePercentage: totalPlanned > 0 ? (variance / totalPlanned) * 100 : 0.0,
+    efficiency: totalPlanned > 0 ? (totalActual / totalPlanned) * 100 : 0.0,
+    totalOrders: totalOrders,
+    completedOrders: completedOrders,
+    completionRate: totalOrders > 0 ? (completedOrders / totalOrders) * 100 : 0.0,
+    varianceByReason: varianceByReason,
+  );
+}
+
+/// Buckets [workOrders] by local target date into the trailing
+/// [kVarianceChartDays]-day series the chart expects, oldest first.
+List<VarianceDataPoint> buildVarianceSeries(
+  List<WorkOrder> workOrders, {
+  required DateTime now,
+  int days = kVarianceChartDays,
+}) {
+  final today = DateTime(now.year, now.month, now.day);
+
+  final planned = <DateTime, double>{};
+  final actual = <DateTime, double>{};
+  for (final wo in workOrders) {
+    final local = wo.targetDate.toLocal();
+    final day = DateTime(local.year, local.month, local.day);
+    planned[day] = (planned[day] ?? 0) + wo.plannedQuantity;
+    actual[day] = (actual[day] ?? 0) + wo.actualQuantity;
+  }
+
+  return List<VarianceDataPoint>.generate(days, (i) {
+    final day = today.subtract(Duration(days: days - 1 - i));
+    final p = planned[day] ?? 0;
+    final a = actual[day] ?? 0;
+    return VarianceDataPoint(
+      date: day,
+      planned: p,
+      actual: a,
+      variance: a - p,
+    );
+  });
+}

--- a/packages/flipper_dashboard/lib/features/production_output/screens/production_output_screen.dart
+++ b/packages/flipper_dashboard/lib/features/production_output/screens/production_output_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flipper_models/helperModels/talker.dart';
 import 'package:flipper_models/providers/production_output_provider.dart';
 import '../models/production_output_models.dart';
 import '../services/production_output_service.dart';
@@ -11,6 +12,10 @@ import '../widgets/work_order_form.dart';
 import '../widgets/variance_reason_dialog.dart';
 import '../widgets/work_order_bottom_sheet.dart';
 import 'package:flipper_ui/dialogs/WorkOrderDetailsDialog.dart';
+import '../../stock_recount/stock_recount_tokens.dart';
+import '../../stock_recount/stock_recount_icons.dart';
+import '../../stock_recount/stock_recount_helpers.dart';
+import '../../stock_recount/stock_recount_ui.dart';
 
 /// Main screen for Production Output feature
 ///
@@ -59,6 +64,33 @@ class _ProductionOutputScreenState
     } catch (e) {
       setState(() {
         _isLoading = false;
+      });
+    }
+  }
+
+  void _openCreateWorkOrder(bool isMobile) {
+    if (isMobile) {
+      // Show bottom sheet on mobile
+      WorkOrderBottomSheet.show(
+        context: context,
+        ref: ref,
+        onSubmit: (data) async {
+          await _service.createWorkOrder(
+            variantId: data['variantId'] as String,
+            variantName: data['variantName'] as String?,
+            plannedQuantity: data['plannedQuantity'] as double,
+            targetDate: data['targetDate'] as DateTime,
+            shiftId: data['shiftId'] as String?,
+            notes: data['notes'] as String?,
+          );
+          _loadData();
+          ref.invalidate(todayWorkOrdersProvider);
+        },
+      );
+    } else {
+      // Toggle inline form on desktop
+      setState(() {
+        _showCreateForm = !_showCreateForm;
       });
     }
   }
@@ -125,33 +157,7 @@ class _ProductionOutputScreenState
                     left: 4,
                   ),
                   child: ElevatedButton.icon(
-                    onPressed: () {
-                      if (isMobile) {
-                        // Show bottom sheet on mobile
-                        WorkOrderBottomSheet.show(
-                          context: context,
-                          ref: ref,
-                          onSubmit: (data) async {
-                            await _service.createWorkOrder(
-                              variantId: data['variantId'] as String,
-                              variantName: data['variantName'] as String?,
-                              plannedQuantity:
-                                  data['plannedQuantity'] as double,
-                              targetDate: data['targetDate'] as DateTime,
-                              shiftId: data['shiftId'] as String?,
-                              notes: data['notes'] as String?,
-                            );
-                            _loadData();
-                            ref.invalidate(todayWorkOrdersProvider);
-                          },
-                        );
-                      } else {
-                        // Toggle inline form on desktop
-                        setState(() {
-                          _showCreateForm = !_showCreateForm;
-                        });
-                      }
-                    },
+                    onPressed: () => _openCreateWorkOrder(isMobile),
                     icon: const Icon(Icons.add, size: 18),
                     label: Text(isMobile ? 'New' : 'New Order'),
                     style: ElevatedButton.styleFrom(
@@ -240,9 +246,8 @@ class _ProductionOutputScreenState
                           workOrders: [],
                           isLoading: true,
                         ),
-                        error: (_, __) => const WorkOrderTable(
-                          workOrders: [],
-                          isLoading: false,
+                        error: (error, stack) => Center(
+                          child: _buildWorkOrdersErrorCard(error, stack),
                         ),
                       ),
                     ),
@@ -301,30 +306,99 @@ class _ProductionOutputScreenState
           child: CircularProgressIndicator(strokeWidth: 2),
         ),
       ),
-      error: (_, __) => _buildEmptyWorkOrdersCard(),
+      error: (error, stack) => _buildWorkOrdersErrorCard(error, stack),
+    );
+  }
+
+  Widget _buildWorkOrdersErrorCard(Object error, StackTrace? stack) {
+    talker.error('ProductionOutput: failed to load work orders', error, stack);
+    return stockRecountCard(
+      borderColor: StockRecountTokens.negBorder,
+      padding: const EdgeInsets.symmetric(vertical: 40, horizontal: 24),
+      child: Center(
+        child: Column(
+          children: [
+            Container(
+              width: 92,
+              height: 92,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: StockRecountTokens.negTint,
+              ),
+              child: Icon(
+                Icons.error_outline,
+                size: 40,
+                color: StockRecountTokens.neg,
+              ),
+            ),
+            const SizedBox(height: 22),
+            Text(
+              "Couldn't load work orders",
+              style: StockRecountHelpers.text(size: 19, weight: FontWeight.w700),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Check your connection and try again.',
+              textAlign: TextAlign.center,
+              style: StockRecountHelpers.text(
+                size: 14.5,
+                color: StockRecountTokens.ink3,
+              ),
+            ),
+            const SizedBox(height: 22),
+            StockRecountPrimaryButton(
+              label: 'Retry',
+              leading: const Icon(Icons.refresh, size: 18, color: Colors.white),
+              onPressed: () => ref.invalidate(todayWorkOrdersProvider),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
   Widget _buildEmptyWorkOrdersCard() {
-    return Container(
-      padding: const EdgeInsets.all(32),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8),
-      ),
+    return stockRecountCard(
+      padding: const EdgeInsets.symmetric(vertical: 40, horizontal: 24),
       child: Center(
         child: Column(
           children: [
-            Icon(Icons.assignment_outlined, size: 48, color: Colors.grey[300]),
-            const SizedBox(height: 16),
-            Text(
-              'No work orders',
-              style: TextStyle(fontSize: 16, color: Colors.grey[500]),
+            Container(
+              width: 92,
+              height: 92,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: RadialGradient(
+                  colors: [
+                    StockRecountTokens.accentTint2,
+                    StockRecountTokens.accentTint,
+                  ],
+                ),
+              ),
+              child: StockRecountIcons.box(
+                size: 40,
+                color: StockRecountTokens.accent,
+              ),
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: 22),
             Text(
-              'Tap + to create a work order',
-              style: TextStyle(fontSize: 12, color: Colors.grey[400]),
+              'No work orders yet',
+              style: StockRecountHelpers.text(size: 19, weight: FontWeight.w700),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Create a work order to start tracking production output.',
+              textAlign: TextAlign.center,
+              style: StockRecountHelpers.text(
+                size: 14.5,
+                color: StockRecountTokens.ink3,
+              ),
+            ),
+            const SizedBox(height: 22),
+            StockRecountPrimaryButton(
+              label: 'New Work Order',
+              leading: StockRecountIcons.plus(size: 19, color: Colors.white),
+              onPressed: () => _openCreateWorkOrder(true),
             ),
           ],
         ),
@@ -341,99 +415,90 @@ class _ProductionOutputScreenState
 
     return Container(
       margin: const EdgeInsets.only(bottom: 12),
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.05),
-            blurRadius: 4,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Header row
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  wo.variantName ?? 'Unknown Product',
-                  style: const TextStyle(
-                    fontWeight: FontWeight.w600,
-                    fontSize: 15,
+      child: stockRecountCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header row
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    wo.variantName ?? 'Unknown Product',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 15,
+                    ),
                   ),
                 ),
-              ),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: Color(status.color).withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: Text(
-                  status.label,
-                  style: TextStyle(
-                    fontSize: 11,
-                    color: Color(status.color),
-                    fontWeight: FontWeight.w500,
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: Color(status.color).withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(4),
                   ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          // Metrics row
-          Row(
-            children: [
-              _buildMetricChip(
-                'Planned',
-                wo.plannedQuantity?.toStringAsFixed(0) ?? '0',
-              ),
-              const SizedBox(width: 12),
-              _buildMetricChip(
-                'Actual',
-                wo.actualQuantity?.toStringAsFixed(0) ?? '0',
-                color: varianceColor,
-              ),
-              const SizedBox(width: 12),
-              _buildMetricChip(
-                'Variance',
-                '${variance >= 0 ? '+' : ''}${variance.toStringAsFixed(0)}',
-                color: varianceColor,
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          // Actions row
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              if (wo.status != 'completed') ...[
-                TextButton.icon(
-                  onPressed: () => _showRecordOutputDialog(wo),
-                  icon: const Icon(Icons.add_circle_outline, size: 18),
-                  label: const Text('Record'),
-                  style: TextButton.styleFrom(
-                    foregroundColor: Color(VarianceColors.neutral),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                TextButton.icon(
-                  onPressed: () => _completeWorkOrder(wo),
-                  icon: const Icon(Icons.check_circle_outline, size: 18),
-                  label: const Text('Complete'),
-                  style: TextButton.styleFrom(
-                    foregroundColor: Color(VarianceColors.positive),
+                  child: Text(
+                    status.label,
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: Color(status.color),
+                      fontWeight: FontWeight.w500,
+                    ),
                   ),
                 ),
               ],
-            ],
-          ),
-        ],
+            ),
+            const SizedBox(height: 12),
+            // Metrics row
+            Row(
+              children: [
+                _buildMetricChip(
+                  'Planned',
+                  wo.plannedQuantity?.toStringAsFixed(0) ?? '0',
+                ),
+                const SizedBox(width: 12),
+                _buildMetricChip(
+                  'Actual',
+                  wo.actualQuantity?.toStringAsFixed(0) ?? '0',
+                  color: varianceColor,
+                ),
+                const SizedBox(width: 12),
+                _buildMetricChip(
+                  'Variance',
+                  '${variance >= 0 ? '+' : ''}${variance.toStringAsFixed(0)}',
+                  color: varianceColor,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            // Actions row
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                if (wo.status != 'completed') ...[
+                  TextButton.icon(
+                    onPressed: () => _showRecordOutputDialog(wo),
+                    icon: const Icon(Icons.add_circle_outline, size: 18),
+                    label: const Text('Record'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: Color(VarianceColors.neutral),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  TextButton.icon(
+                    onPressed: () => _completeWorkOrder(wo),
+                    icon: const Icon(Icons.check_circle_outline, size: 18),
+                    label: const Text('Complete'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: Color(VarianceColors.positive),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/packages/flipper_dashboard/lib/features/production_output/screens/production_output_screen.dart
+++ b/packages/flipper_dashboard/lib/features/production_output/screens/production_output_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flipper_models/helperModels/talker.dart';
 import 'package:flipper_models/providers/production_output_provider.dart';
 import '../models/production_output_models.dart';
+import '../providers/production_output_derived_providers.dart';
 import '../services/production_output_service.dart';
 import '../widgets/object_page_header.dart';
 import '../widgets/analytical_cards.dart';
@@ -12,6 +13,7 @@ import '../widgets/work_order_form.dart';
 import '../widgets/variance_reason_dialog.dart';
 import '../widgets/work_order_bottom_sheet.dart';
 import 'package:flipper_ui/dialogs/WorkOrderDetailsDialog.dart';
+import 'package:flipper_ui/snack_bar_utils.dart';
 import '../../stock_recount/stock_recount_tokens.dart';
 import '../../stock_recount/stock_recount_icons.dart';
 import '../../stock_recount/stock_recount_helpers.dart';
@@ -36,36 +38,14 @@ class _ProductionOutputScreenState
     extends ConsumerState<ProductionOutputScreen> {
   final ProductionOutputService _service = ProductionOutputService();
 
-  ProductionSummary _summary = ProductionSummary.empty;
-  List<VarianceDataPoint> _chartData = [];
-  bool _isLoading = true;
   bool _showCreateForm = false;
 
-  @override
-  void initState() {
-    super.initState();
-    _loadData();
-  }
-
-  Future<void> _loadData() async {
-    setState(() {
-      _isLoading = true;
-    });
-
-    try {
-      final summary = await _service.getProductionSummary();
-      final chartData = await _service.getVarianceChartData(days: 7);
-
-      setState(() {
-        _summary = summary;
-        _chartData = chartData;
-        _isLoading = false;
-      });
-    } catch (e) {
-      setState(() {
-        _isLoading = false;
-      });
-    }
+  /// Re-registers the Ditto observers. Writes reach the UI on their own, so
+  /// this is only for the explicit pull-to-refresh / refresh-button gesture.
+  Future<void> _refresh() async {
+    ref.invalidate(workOrdersStreamProvider);
+    ref.invalidate(actualOutputsStreamProvider);
+    await ref.read(workOrdersStreamProvider.future);
   }
 
   void _openCreateWorkOrder(bool isMobile) {
@@ -83,8 +63,8 @@ class _ProductionOutputScreenState
             shiftId: data['shiftId'] as String?,
             notes: data['notes'] as String?,
           );
-          _loadData();
-          ref.invalidate(todayWorkOrdersProvider);
+          // No refetch: the Ditto observer behind workOrdersStreamProvider
+          // pushes the new order as soon as its document lands.
         },
       );
     } else {
@@ -98,13 +78,18 @@ class _ProductionOutputScreenState
   @override
   Widget build(BuildContext context) {
     final workOrdersAsync = ref.watch(todayWorkOrdersProvider);
+    final summaryAsync = ref.watch(productionSummaryProvider);
+    final chartAsync = ref.watch(varianceChartDataProvider);
+    final summary = summaryAsync.asData?.value ?? ProductionSummary.empty;
+    final chartData = chartAsync.asData?.value ?? const <VarianceDataPoint>[];
+    final isSummaryLoading = summaryAsync.isLoading;
     final screenWidth = MediaQuery.of(context).size.width;
     final isMobile = screenWidth < 600;
 
     return Scaffold(
       backgroundColor: Colors.grey[100],
       body: RefreshIndicator(
-        onRefresh: _loadData,
+        onRefresh: _refresh,
         child: CustomScrollView(
           slivers: [
             // App bar
@@ -138,7 +123,7 @@ class _ProductionOutputScreenState
                       color: Colors.black54,
                       size: 20,
                     ),
-                    onPressed: _loadData,
+                    onPressed: _refresh,
                     tooltip: 'Refresh',
                     style: IconButton.styleFrom(
                       backgroundColor: Colors.grey[50],
@@ -193,8 +178,6 @@ class _ProductionOutputScreenState
                         setState(() {
                           _showCreateForm = false;
                         });
-                        _loadData();
-                        ref.invalidate(todayWorkOrdersProvider);
                       },
                       onCancel: () {
                         setState(() {
@@ -206,15 +189,15 @@ class _ProductionOutputScreenState
                   ],
                   // Object Page Header with KPIs
                   ObjectPageHeader(
-                    summary: _summary,
-                    isLoading: _isLoading,
+                    summary: summary,
+                    isLoading: isSummaryLoading,
                     isMobile: isMobile,
                   ),
                   const SizedBox(height: 16),
                   // Analytical Cards
                   AnalyticalCards(
-                    summary: _summary,
-                    isLoading: _isLoading,
+                    summary: summary,
+                    isLoading: isSummaryLoading,
                     isMobile: isMobile,
                   ),
                   const SizedBox(height: 16),
@@ -222,8 +205,8 @@ class _ProductionOutputScreenState
                   SizedBox(
                     height: isMobile ? 220 : 280,
                     child: VarianceChart(
-                      dataPoints: _chartData,
-                      isLoading: _isLoading,
+                      dataPoints: chartData,
+                      isLoading: chartAsync.isLoading,
                     ),
                   ),
                   const SizedBox(height: 16),
@@ -349,7 +332,7 @@ class _ProductionOutputScreenState
             StockRecountPrimaryButton(
               label: 'Retry',
               leading: const Icon(Icons.refresh, size: 18, color: Colors.white),
-              onPressed: () => ref.invalidate(todayWorkOrdersProvider),
+              onPressed: _refresh,
             ),
           ],
         ),
@@ -538,14 +521,31 @@ class _ProductionOutputScreenState
     );
 
     if (result != null) {
-      await _service.recordActualOutput(
-        workOrderId: workOrder.id as String,
-        actualQuantity: result['quantity'] as double,
-        varianceReason: result['varianceReason'] as String?,
-        notes: null,
-      );
-      _loadData();
-      ref.invalidate(todayWorkOrdersProvider);
+      await _guard('record output', () async {
+        await _service.recordActualOutput(
+          workOrderId: workOrder.id as String,
+          actualQuantity: result['quantity'] as double,
+          varianceReason: result['varianceReason'] as String?,
+          notes: null,
+        );
+      });
+    }
+  }
+
+  /// These handlers are invoked as fire-and-forget callbacks, so an escaping
+  /// error would become an unhandled zone error instead of reaching the user.
+  Future<void> _guard(String action, Future<void> Function() run) async {
+    try {
+      await run();
+    } catch (e, s) {
+      talker.error('ProductionOutput: failed to $action', e, s);
+      if (mounted) {
+        showCustomSnackBarUtil(
+          context,
+          'Could not $action. Please try again.',
+          type: NotificationType.error,
+        );
+      }
     }
   }
 
@@ -572,9 +572,10 @@ class _ProductionOutputScreenState
     );
 
     if (confirm == true) {
-      await _service.completeWorkOrder(workOrder.id as String);
-      _loadData();
-      ref.invalidate(todayWorkOrdersProvider);
+      await _guard(
+        'complete this work order',
+        () => _service.completeWorkOrder(workOrder.id as String),
+      );
     }
   }
 
@@ -599,9 +600,10 @@ class _ProductionOutputScreenState
     );
 
     if (confirm == true) {
-      await _service.startWorkOrder(workOrder.id as String);
-      _loadData();
-      ref.invalidate(todayWorkOrdersProvider);
+      await _guard(
+        'start this work order',
+        () => _service.startWorkOrder(workOrder.id as String),
+      );
     }
   }
 }

--- a/packages/flipper_dashboard/lib/features/production_output/services/production_output_service.dart
+++ b/packages/flipper_dashboard/lib/features/production_output/services/production_output_service.dart
@@ -3,222 +3,37 @@ import 'package:supabase_models/brick/models/actual_output.model.dart';
 import 'package:supabase_models/brick/models/all_models.dart' as models;
 import 'package:uuid/uuid.dart';
 import 'package:flipper_services/proxy.dart';
-import 'package:flipper_models/sync/dql_for_sync_subscription.dart';
-import '../models/production_output_models.dart';
 
-/// Service layer for production output feature
+/// Service layer for the production output feature.
 ///
-/// Provides business logic and data formatting for the UI.
-/// ENFORCES Reads from Ditto (Capella) while Writes delegate to strategy.
+/// A thin write facade over Capella/Ditto. Reads are served reactively by
+/// `workOrdersStreamProvider` / `actualOutputsStreamProvider` and the derived
+/// providers in `../providers/production_output_derived_providers.dart`; this
+/// class deliberately keeps no read logic of its own beyond [getWorkOrders],
+/// which the raw-material deduction and the forecasting service still need
+/// as a one-shot.
 class ProductionOutputService {
-  /// Get production summary for a date range
-  Future<ProductionSummary> getProductionSummary({
-    String? branchId,
-    DateTime? startDate,
-    DateTime? endDate,
-  }) async {
-    try {
-      final bId = branchId ?? ProxyService.box.getBranchId();
-      if (bId == null) return ProductionSummary.empty;
-
-      // Always calculate from Ditto data directly
-      return await _calculateSummarySafely(bId, startDate, endDate);
-    } catch (e) {
-      print('Error getting production summary: $e');
-      return ProductionSummary.empty;
-    }
-  }
-
-  Future<ProductionSummary> _calculateSummarySafely(
-    String branchId,
-    DateTime? startDate,
-    DateTime? endDate,
-  ) async {
-    // These calls now go to Ditto
-    final workOrders = await getWorkOrders(
-      branchId: branchId,
-      startDate: startDate,
-      endDate: endDate,
-    );
-
-    double totalPlanned = 0;
-    double totalActual = 0;
-    int completedOrders = 0;
-    final totalOrders = workOrders.length;
-
-    final varianceByReason = <String, double>{
-      'machine': 0,
-      'material': 0,
-      'labor': 0,
-      'quality': 0,
-      'planning': 0,
-      'other': 0,
-    };
-
-    for (final wo in workOrders) {
-      totalPlanned += wo.plannedQuantity;
-      totalActual += wo.actualQuantity;
-      if (wo.status == 'completed') completedOrders++;
-    }
-
-    final variance = totalActual - totalPlanned;
-    final variancePercentage = totalPlanned > 0
-        ? (variance / totalPlanned) * 100
-        : 0.0;
-    final efficiency = totalPlanned > 0
-        ? (totalActual / totalPlanned) * 100
-        : 0.0;
-
-    final outputs = await getActualOutputs(
-      branchId: branchId,
-      startDate: startDate,
-      endDate: endDate,
-    );
-
-    for (final output in outputs) {
-      if (output.varianceReason != null) {
-        final reason = output.varianceReason!.toLowerCase();
-        if (varianceByReason.containsKey(reason)) {
-          varianceByReason[reason] = varianceByReason[reason]! + 1;
-        } else {
-          varianceByReason['other'] = varianceByReason['other']! + 1;
-        }
-      }
-    }
-
-    return ProductionSummary(
-      totalPlanned: totalPlanned,
-      totalActual: totalActual,
-      variance: variance,
-      variancePercentage: variancePercentage,
-      efficiency: efficiency,
-      totalOrders: totalOrders,
-      completedOrders: completedOrders,
-      completionRate: totalOrders > 0
-          ? (completedOrders / totalOrders) * 100
-          : 0.0,
-      varianceByReason: varianceByReason,
-    );
-  }
-
-  /// Get actual outputs from Ditto
-  Future<List<ActualOutput>> getActualOutputs({
-    String? branchId,
-    DateTime? startDate,
-    DateTime? endDate,
-  }) async {
-    try {
-      final bId = branchId ?? ProxyService.box.getBranchId();
-      if (bId == null) return [];
-
-      final ditto = ProxyService.ditto.dittoInstance;
-      if (ditto == null) return [];
-
-      final List<String> whereClauses = ['branchId = :branchId'];
-      final Map<String, dynamic> arguments = {'branchId': bId};
-
-      if (startDate != null) {
-        whereClauses.add('recordedAt >= :startDate');
-        arguments['startDate'] = startDate.toIso8601String();
-      }
-      if (endDate != null) {
-        whereClauses.add('recordedAt <= :endDate');
-        arguments['endDate'] = endDate.toIso8601String();
-      }
-
-      final query =
-          "SELECT * FROM actual_outputs WHERE ${whereClauses.join(' AND ')}";
-
-      final preparedOut = prepareDqlSyncSubscription(query, arguments);
-      ditto.sync.registerSubscription(
-        preparedOut.dql,
-        arguments: preparedOut.arguments,
-      );
-
-      final result = await ditto.store.execute(query, arguments: arguments);
-
-      return result.items.map((item) {
-        return ActualOutput.fromJson(Map<String, dynamic>.from(item.value));
-      }).toList();
-    } catch (e) {
-      print('Error getting actual outputs from Ditto: $e');
-      return [];
-    }
-  }
-
-  /// Get work orders for display from DITTO
+  /// One-shot work-order read. Prefer the stream providers in UI code.
   Future<List<WorkOrder>> getWorkOrders({
     String? branchId,
     DateTime? startDate,
     DateTime? endDate,
     String? status,
   }) async {
-    try {
-      final bId = branchId ?? ProxyService.box.getBranchId();
-      if (bId == null) return [];
+    final bId = branchId ?? ProxyService.box.getBranchId();
+    if (bId == null) return [];
 
-      final ditto = ProxyService.ditto.dittoInstance;
-      if (ditto == null) return [];
-
-      final List<String> whereClauses = ['branchId = :branchId'];
-      final Map<String, dynamic> arguments = {'branchId': bId};
-
-      if (status != null) {
-        whereClauses.add('status = :status');
-        arguments['status'] = status;
-      }
-      if (startDate != null) {
-        whereClauses.add('targetDate >= :startDate');
-        arguments['startDate'] = startDate.toIso8601String();
-      }
-      if (endDate != null) {
-        whereClauses.add('targetDate <= :endDate');
-        arguments['endDate'] = endDate.toIso8601String();
-      }
-
-      final query =
-          "SELECT * FROM work_orders WHERE ${whereClauses.join(' AND ')}";
-
-      final preparedOut = prepareDqlSyncSubscription(query, arguments);
-      ditto.sync.registerSubscription(
-        preparedOut.dql,
-        arguments: preparedOut.arguments,
-      );
-
-      final result = await ditto.store.execute(query, arguments: arguments);
-
-      return result.items.map((item) {
-        return WorkOrder.fromJson(Map<String, dynamic>.from(item.value));
-      }).toList();
-    } catch (e) {
-      print('Error getting work orders from Ditto: $e');
-      return [];
-    }
-  }
-
-  /// Get today's work orders
-  Future<List<WorkOrder>> getTodayWorkOrders() async {
-    final now = DateTime.now();
-    final startOfDay = DateTime(now.year, now.month, now.day);
-    final endOfDay = startOfDay.add(const Duration(days: 1));
-
-    return getWorkOrders(startDate: startOfDay, endDate: endOfDay);
-  }
-
-  /// Get this week's work orders
-  Future<List<WorkOrder>> getWeekWorkOrders() async {
-    final now = DateTime.now();
-    final startOfWeek = now.subtract(Duration(days: now.weekday - 1));
-    final endOfWeek = startOfWeek.add(const Duration(days: 7));
-
-    return getWorkOrders(
-      startDate: DateTime(startOfWeek.year, startOfWeek.month, startOfWeek.day),
-      endDate: DateTime(endOfWeek.year, endOfWeek.month, endOfWeek.day),
+    final rows = await ProxyService.strategy.getWorkOrders(
+      branchId: bId,
+      startDate: startDate,
+      endDate: endDate,
+      status: status,
     );
+    return rows.cast<WorkOrder>().toList();
   }
 
-  /// Create a new work order
-  /// Uses strategy to allow dual write logic in CapellaSync
+  /// Create a new work order. Throws if Capella/Ditto is unavailable — the
+  /// caller must surface that rather than leave the tap looking like a no-op.
   Future<WorkOrder?> createWorkOrder({
     required String variantId,
     String? variantName,
@@ -227,103 +42,55 @@ class ProductionOutputService {
     String? shiftId,
     String? notes,
   }) async {
-    try {
-      final branchId = ProxyService.box.getBranchId();
-      final businessId = ProxyService.box.getBusinessId();
+    final branchId = ProxyService.box.getBranchId();
+    final businessId = ProxyService.box.getBusinessId();
 
-      if (branchId == null || businessId == null) return null;
+    if (branchId == null || businessId == null) return null;
 
-      return await ProxyService.strategy.createWorkOrder(
-        branchId: branchId,
-        businessId: businessId,
-        variantId: variantId,
-        variantName: variantName,
-        plannedQuantity: plannedQuantity,
-        targetDate: targetDate,
-        shiftId: shiftId,
-        notes: notes,
-      );
-    } catch (e) {
-      print('Error creating work order: $e');
-      return null;
-    }
+    return await ProxyService.strategy.createWorkOrder(
+      branchId: branchId,
+      businessId: businessId,
+      variantId: variantId,
+      variantName: variantName,
+      plannedQuantity: plannedQuantity,
+      targetDate: targetDate,
+      shiftId: shiftId,
+      notes: notes,
+    );
   }
 
-  /// Record actual output for a work order
-  /// Uses strategy to allow dual write logic in CapellaSync
+  /// Record actual output for a work order. Throws on failure — see
+  /// [createWorkOrder].
   Future<ActualOutput?> recordActualOutput({
     required String workOrderId,
     required double actualQuantity,
     String? varianceReason,
     String? notes,
   }) async {
-    try {
-      final branchId = ProxyService.box.getBranchId();
-      final userId = ProxyService.box.getUserId();
+    final branchId = ProxyService.box.getBranchId();
+    final userId = ProxyService.box.getUserId();
 
-      if (branchId == null || userId == null) return null;
+    if (branchId == null || userId == null) return null;
 
-      return await ProxyService.strategy.recordActualOutput(
-        workOrderId: workOrderId,
-        branchId: branchId,
-        actualQuantity: actualQuantity,
-        userId: userId.toString(),
-        varianceReason: varianceReason,
-        notes: notes,
-      );
-    } catch (e) {
-      print('Error recording actual output: $e');
-      return null;
-    }
+    return await ProxyService.strategy.recordActualOutput(
+      workOrderId: workOrderId,
+      branchId: branchId,
+      actualQuantity: actualQuantity,
+      userId: userId.toString(),
+      varianceReason: varianceReason,
+      notes: notes,
+    );
   }
 
-  /// Get variance chart data for a period
-  Future<List<VarianceDataPoint>> getVarianceChartData({int days = 7}) async {
-    try {
-      final now = DateTime.now();
-      final dataPoints = <VarianceDataPoint>[];
-
-      for (int i = days - 1; i >= 0; i--) {
-        final date = now.subtract(Duration(days: i));
-        final startOfDay = DateTime(date.year, date.month, date.day);
-        final endOfDay = startOfDay.add(const Duration(days: 1));
-
-        // Start fetching data for the day using new summary logic (Ditto backed)
-        final summary = await getProductionSummary(
-          startDate: startOfDay,
-          endDate: endOfDay,
-        );
-
-        dataPoints.add(
-          VarianceDataPoint(
-            date: startOfDay,
-            planned: summary.totalPlanned,
-            actual: summary.totalActual,
-            variance: summary.variance,
-          ),
-        );
-      }
-
-      return dataPoints;
-    } catch (e) {
-      print('Error getting variance chart data: $e');
-      return [];
-    }
-  }
-
-  /// Update work order status
+  /// Update work order status. Throws on failure — see [createWorkOrder].
   Future<void> updateWorkOrderStatus({
     required String workOrderId,
     required String status,
   }) async {
-    try {
-      await ProxyService.strategy.updateWorkOrder(
-        workOrderId: workOrderId,
-        status: status,
-      );
-    } catch (e) {
-      print('Error updating work order status: $e');
-    }
+    await ProxyService.strategy.updateWorkOrder(
+      workOrderId: workOrderId,
+      status: status,
+    );
   }
 
   /// Start a work order (change status to in_progress)

--- a/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_form.dart
+++ b/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_form.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'package:flipper_models/helperModels/talker.dart';
+import 'package:flipper_ui/snack_bar_utils.dart';
 import 'package:flipper_models/db_model_export.dart';
 import 'package:flipper_services/proxy.dart';
 import 'package:flipper_models/SyncStrategy.dart';
@@ -38,7 +40,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
   final _formKey = GlobalKey<FormState>();
   final _plannedQtyController = TextEditingController();
   final _notesController = TextEditingController();
-  TextEditingController? _typeAheadController;
+  final TextEditingController _typeAheadController = TextEditingController();
 
   String? _selectedVariantId;
   Variant? _selectedVariant;
@@ -51,9 +53,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
     super.initState();
     if (widget.initialVariantId != null) {
       _selectedVariantId = widget.initialVariantId;
-      _typeAheadController = TextEditingController(
-        text: widget.initialVariantName ?? '',
-      );
+      _typeAheadController.text = widget.initialVariantName ?? '';
       // Create a temporary variant object for display if we have the name
       if (widget.initialVariantName != null) {
         _selectedVariant = Variant(
@@ -95,10 +95,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
   void dispose() {
     _plannedQtyController.dispose();
     _notesController.dispose();
-    // Only dispose if we created it locally in initState
-    if (widget.initialVariantId != null) {
-      _typeAheadController?.dispose();
-    }
+    _typeAheadController.dispose();
     super.dispose();
   }
 
@@ -317,7 +314,10 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
         );
         return paged.variants.cast<Variant>().toList();
       },
-      controller: _typeAheadController, // Use the controller if initialized
+      // Must be a stable, non-null instance: RawTypeAheadField.didUpdateWidget
+      // disposes its internally-created controller the moment `controller`
+      // goes from null to non-null, which used to kill the live controller.
+      controller: _typeAheadController,
       itemBuilder: (context, Variant variant) {
         return Container(
           decoration: BoxDecoration(
@@ -352,13 +352,12 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
       },
       onSelected: (Variant variant) {
         setState(() {
-          _typeAheadController?.text = variant.name;
+          _typeAheadController.text = variant.name;
           _selectedVariantId = variant.id;
           _selectedVariant = variant;
         });
       },
       builder: (context, controller, focusNode) {
-        _typeAheadController = controller;
         if (_selectedVariant != null) {
           return InkWell(
             onTap: () {
@@ -688,9 +687,19 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
 
       try {
         await widget.onSubmit?.call(data);
-      } catch (e) {
-        // Optionally handle/report errors here
-        print('Error submitting work order: $e');
+      } catch (e, s) {
+        // The form deliberately stays open on failure — this is the single
+        // catch behind every create path (mobile sheet, desktop inline form,
+        // and the incoming-orders "produce" flow), so the user has to be told
+        // here or the tap looks like it did nothing.
+        talker.error('Error submitting work order', e, s);
+        if (mounted) {
+          showCustomSnackBarUtil(
+            context,
+            'Could not save the work order. Please try again.',
+            type: NotificationType.error,
+          );
+        }
       } finally {
         if (mounted) {
           setState(() {

--- a/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_form.dart
+++ b/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_form.dart
@@ -4,6 +4,9 @@ import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:flipper_models/db_model_export.dart';
 import 'package:flipper_services/proxy.dart';
 import 'package:flipper_models/SyncStrategy.dart';
+import '../../stock_recount/stock_recount_tokens.dart';
+import '../../stock_recount/stock_recount_icons.dart';
+import '../../stock_recount/stock_recount_helpers.dart';
 
 /// SAP Fiori-inspired Smart Form widget for work orders
 ///
@@ -311,6 +314,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
 
   Widget _buildProductField() {
     return TypeAheadField<Variant>(
+      constraints: const BoxConstraints(maxHeight: 260),
       suggestionsCallback: (search) async {
         if (search.isEmpty) return [];
         final branchId = ProxyService.box.getBranchId();
@@ -471,18 +475,47 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
         );
       },
       emptyBuilder: (context) => Padding(
-        padding: EdgeInsets.all(16.0),
-        child: Center(
-          child: Column(
-            children: [
-              Icon(Icons.search_off, size: 48, color: Colors.grey[400]),
-              SizedBox(height: 8),
-              Text(
-                'No products found',
-                style: TextStyle(color: Colors.grey[600], fontSize: 14),
+        padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 56,
+              height: 56,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: RadialGradient(
+                  colors: [
+                    StockRecountTokens.accentTint2,
+                    StockRecountTokens.accentTint,
+                  ],
+                ),
               ),
-            ],
-          ),
+              child: Center(
+                child: StockRecountIcons.search(
+                  size: 22,
+                  color: StockRecountTokens.accent,
+                ),
+              ),
+            ),
+            const SizedBox(height: 10),
+            Text(
+              'No products found',
+              style: StockRecountHelpers.text(
+                size: 15,
+                weight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Try a different product name or SKU',
+              textAlign: TextAlign.center,
+              style: StockRecountHelpers.text(
+                size: 13,
+                color: StockRecountTokens.ink3,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_form.dart
+++ b/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_form.dart
@@ -4,6 +4,7 @@ import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:flipper_models/db_model_export.dart';
 import 'package:flipper_services/proxy.dart';
 import 'package:flipper_models/SyncStrategy.dart';
+import 'package:flipper_dashboard/features/stock_recount/stock_recount_tokens.dart';
 
 /// SAP Fiori-inspired Smart Form widget for work orders
 ///
@@ -110,15 +111,10 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
       decoration: isMobile
           ? null
           : BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(16),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.08),
-                  blurRadius: 20,
-                  offset: const Offset(0, 4),
-                ),
-              ],
+              color: StockRecountTokens.surface,
+              border: Border.all(color: StockRecountTokens.line),
+              borderRadius: BorderRadius.circular(StockRecountTokens.radiusLg),
+              boxShadow: StockRecountTokens.cardShadows,
             ),
       child: Form(
         key: _formKey,
@@ -129,29 +125,19 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
             // Header (only show on desktop, mobile has bottom sheet header)
             if (!isMobile) ...[
               Container(
-                padding: EdgeInsets.all(16),
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 18),
                 decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [Colors.blue[50]!, Colors.blue[100]!],
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                  ),
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+                  color: StockRecountTokens.accentTint,
+                  borderRadius: BorderRadius.circular(StockRecountTokens.radiusMd),
                 ),
                 child: Row(
                   children: [
                     Container(
                       padding: EdgeInsets.all(10),
                       decoration: BoxDecoration(
-                        color: Colors.white,
-                        borderRadius: BorderRadius.circular(12),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.1),
-                            blurRadius: 8,
-                            offset: Offset(0, 2),
-                          ),
-                        ],
+                        color: StockRecountTokens.surface,
+                        border: Border.all(color: StockRecountTokens.line),
+                        borderRadius: BorderRadius.circular(StockRecountTokens.radiusSm),
                       ),
                       child: Icon(
                         isEdit ? Icons.edit_outlined : Icons.add_circle_outline,
@@ -169,7 +155,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
                             style: TextStyle(
                               fontSize: 20,
                               fontWeight: FontWeight.bold,
-                              color: Colors.grey[800],
+                              color: StockRecountTokens.ink1,
                             ),
                           ),
                           SizedBox(height: 4),
@@ -177,7 +163,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
                             'Plan production output for your products',
                             style: TextStyle(
                               fontSize: 14,
-                              color: Colors.grey[600],
+                              color: StockRecountTokens.ink2,
                             ),
                           ),
                         ],
@@ -255,16 +241,16 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
                     child: ElevatedButton(
                       onPressed: _isSubmitting ? null : _handleSubmit,
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.blue[700],
+                        backgroundColor: StockRecountTokens.accent,
                         foregroundColor: Colors.white,
                         padding: const EdgeInsets.symmetric(
                           horizontal: 32,
                           vertical: 16,
                         ),
-                        elevation: 2,
-                        shadowColor: Colors.blue.withValues(alpha: 0.3),
+                        elevation: 0,
+                        shadowColor: StockRecountTokens.accentRing,
                         shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
+                          borderRadius: BorderRadius.circular(StockRecountTokens.radiusSm),
                         ),
                       ),
                       child: _isSubmitting
@@ -478,8 +464,12 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
               Icon(Icons.search_off, size: 48, color: Colors.grey[400]),
               SizedBox(height: 8),
               Text(
-                'No products found',
-                style: TextStyle(color: Colors.grey[600], fontSize: 14),
+                'No raw materials found',
+                style: TextStyle(
+                  color: StockRecountTokens.ink2,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
             ],
           ),
@@ -570,7 +560,7 @@ class _WorkOrderFormState extends ConsumerState<WorkOrderForm> {
 
   Widget _buildShiftField() {
     return DropdownButtonFormField<String>(
-      value: _selectedShift,
+      initialValue: _selectedShift,
       decoration: InputDecoration(
         labelText: 'Shift (Optional)',
         labelStyle: TextStyle(color: Colors.grey[700]),

--- a/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_table.dart
+++ b/packages/flipper_dashboard/lib/features/production_output/widgets/work_order_table.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_models/brick/models/work_order.model.dart';
 import '../models/production_output_models.dart';
+import '../../stock_recount/stock_recount_tokens.dart';
+import '../../stock_recount/stock_recount_icons.dart';
+import '../../stock_recount/stock_recount_helpers.dart';
 
 /// SAP Fiori-inspired Responsive Table widget (ALV-style)
 ///
@@ -310,16 +313,36 @@ class _WorkOrderTableState extends State<WorkOrderTable> {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Icons.assignment_outlined, size: 48, color: Colors.grey[300]),
-          const SizedBox(height: 16),
+          Container(
+            width: 92,
+            height: 92,
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: RadialGradient(
+                colors: [
+                  StockRecountTokens.accentTint2,
+                  StockRecountTokens.accentTint,
+                ],
+              ),
+            ),
+            child: StockRecountIcons.box(
+              size: 40,
+              color: StockRecountTokens.accent,
+            ),
+          ),
+          const SizedBox(height: 22),
           Text(
             'No work orders found',
-            style: TextStyle(fontSize: 16, color: Colors.grey[500]),
+            style: StockRecountHelpers.text(size: 19, weight: FontWeight.w700),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: 6),
           Text(
             'Create a work order to start tracking production',
-            style: TextStyle(fontSize: 12, color: Colors.grey[400]),
+            textAlign: TextAlign.center,
+            style: StockRecountHelpers.text(
+              size: 14.5,
+              color: StockRecountTokens.ink3,
+            ),
           ),
         ],
       ),

--- a/packages/flipper_dashboard/lib/logout/shift_before_logout.dart
+++ b/packages/flipper_dashboard/lib/logout/shift_before_logout.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flipper_routing/app.dialogs.dart';
+import 'package:flipper_models/helperModels/talker.dart';
 import 'package:flipper_models/sync/shift_sync.dart';
 import 'package:flipper_services/proxy.dart';
 import 'package:flutter/material.dart';
@@ -53,6 +54,43 @@ void _hideBlockingLoader(
   if (nav.canPop()) nav.pop();
 }
 
+/// Offers "sign out anyway" when the shift could not be verified or closed.
+///
+/// Blocking sign-out on a shift failure is worse than leaving a shift open:
+/// it strands the previous agent's session on a shared device, which is the
+/// exact thing tapping Sign out was meant to prevent — and on a flaky mobile
+/// connection [_kGetCurrentShiftTimeout] fires often enough that sign-out can
+/// become unreachable. An open shift is recoverable (it stays in the ledger and
+/// can be closed on the next sign in); a session that refuses to end is not.
+///
+/// A user *switch* keeps the hard block: aborting it drops back into a working
+/// session, so there is nothing to strand.
+Future<bool> _confirmExitWithoutClosingShift({
+  required BuildContext context,
+  required String title,
+  required String description,
+}) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    useRootNavigator: true,
+    builder: (ctx) => AlertDialog(
+      title: Text(title),
+      content: SingleChildScrollView(child: Text(description)),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(ctx, false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(ctx, true),
+          child: const Text('Sign out anyway'),
+        ),
+      ],
+    ),
+  );
+  return confirmed == true;
+}
+
 double _parseClosingBalance(dynamic raw) {
   if (raw is num) return raw.toDouble();
   if (raw is String) return double.tryParse(raw) ?? 0.0;
@@ -73,7 +111,13 @@ double _parseClosingBalance(dynamic raw) {
 /// that dialog so the confirmation never appears.
 ///
 /// Returns `true` if the caller should proceed to login / complete logout.
-/// Returns `false` if the user cancelled or an error blocked leaving.
+/// Returns `false` only when the user chose to stay — or, for [forUserSwitch],
+/// when the shift could not be verified or closed.
+///
+/// A failure to verify or close a shift never silently cancels a *sign-out*:
+/// the user is offered "Sign out anyway", because a session that cannot be
+/// ended leaves the previous agent signed in on a shared device. Choosing it
+/// leaves the shift open (recoverable on the next sign in) and logs a warning.
 Future<bool> prepareSessionExitAfterShiftHandling({
   required BuildContext context,
   required DialogService dialogService,
@@ -108,18 +152,32 @@ Future<bool> prepareSessionExitAfterShiftHandling({
     if (currentShift != null) {
       // Only close a shift owned by the signed-in agent.
       if (currentShift.userId != userId) {
-        if (context.mounted) {
+        if (!context.mounted) return false;
+        if (forUserSwitch) {
           await dialogService.showCustomDialog(
             variant: DialogType.info,
             title: 'Cannot close shift',
-            description: forUserSwitch
-                ? 'The open shift belongs to another user. Ask that agent '
-                    'to close their shift first, then try switching again.'
-                : 'The open shift belongs to another user. Sign out without '
-                    'closing it, or ask that agent to close their shift first.',
+            description: 'The open shift belongs to another user. Ask that '
+                'agent to close their shift first, then try switching again.',
+          );
+          return false;
+        }
+        // The old copy already told the user they could "sign out without
+        // closing it" — but the code returned false, so they could not.
+        final proceed = await _confirmExitWithoutClosingShift(
+          context: context,
+          title: 'Shift belongs to another user',
+          description: 'The open shift was started by another agent, so it '
+              'cannot be closed from here.\n\nYou can still sign out. The '
+              'shift stays open for that agent to close.',
+        );
+        if (proceed) {
+          talker.warning(
+            'Signing out with shift ${currentShift.id} left open '
+            '(owned by ${currentShift.userId}, not $userId)',
           );
         }
-        return false;
+        return proceed;
       }
 
       final cashSales = currentShift.cashSales ?? 0.0;
@@ -164,14 +222,28 @@ Future<bool> prepareSessionExitAfterShiftHandling({
           note: notes,
         );
       } catch (e) {
-        if (context.mounted) {
+        if (!context.mounted) return false;
+        if (forUserSwitch) {
           await dialogService.showCustomDialog(
             variant: DialogType.info,
             title: 'Could not close shift',
             description: e.toString(),
           );
+          return false;
         }
-        return false;
+        final proceed = await _confirmExitWithoutClosingShift(
+          context: context,
+          title: 'Could not close shift',
+          description: 'The shift could not be closed:\n\n$e\n\nYou can '
+              'sign out anyway. The shift stays open and can be closed the '
+              'next time you sign in.',
+        );
+        if (proceed) {
+          talker.warning(
+            'Signing out with shift ${currentShift.id} left open: $e',
+          );
+        }
+        return proceed;
       }
 
       if (context.mounted) {
@@ -227,37 +299,78 @@ Future<bool> prepareSessionExitAfterShiftHandling({
     }
     return true;
   } on TimeoutException catch (e) {
-    if (context.mounted) {
-      if (!forUserSwitch) {
-        _hideBlockingLoader(
-          context,
-          rootNavigator: loaderUseRootNavigator,
-        );
-      }
-      await dialogService.showCustomDialog(
-        variant: DialogType.info,
-        title: 'Could not verify shift',
-        description:
-            'This is taking too long. Check your connection and try again.\n\n$e',
-      );
-    }
-    return false;
+    return _handleShiftVerificationFailure(
+      context: context,
+      dialogService: dialogService,
+      forUserSwitch: forUserSwitch,
+      loaderUseRootNavigator: loaderUseRootNavigator,
+      userId: userId,
+      blockedDescription:
+          'This is taking too long. Check your connection and try again.\n\n$e',
+      signOutAnywayDescription:
+          'Checking your shift is taking too long — you may be offline.\n\n'
+          'You can sign out anyway. Any open shift stays open and can be '
+          'closed the next time you sign in.',
+      logDetail: 'timed out: $e',
+    );
   } catch (e) {
-    if (context.mounted) {
-      if (!forUserSwitch) {
-        _hideBlockingLoader(
-          context,
-          rootNavigator: loaderUseRootNavigator,
-        );
-      }
-      await dialogService.showCustomDialog(
-        variant: DialogType.info,
-        title: 'Could not verify shift',
-        description:
-            'Please try again. If the problem continues, check your connection.\n\n$e',
-      );
-    }
+    return _handleShiftVerificationFailure(
+      context: context,
+      dialogService: dialogService,
+      forUserSwitch: forUserSwitch,
+      loaderUseRootNavigator: loaderUseRootNavigator,
+      userId: userId,
+      blockedDescription:
+          'Please try again. If the problem continues, check your connection.\n\n$e',
+      signOutAnywayDescription:
+          'Your shift could not be checked:\n\n$e\n\nYou can sign out '
+          'anyway. Any open shift stays open and can be closed the next time '
+          'you sign in.',
+      logDetail: 'failed: $e',
+    );
+  }
+}
+
+/// Shared tail for the two "could not verify the shift" handlers.
+///
+/// A switch-user attempt still hard-stops (it falls back into a live session);
+/// a sign-out offers the escape hatch, because refusing it is what leaves the
+/// device signed in as the previous agent.
+Future<bool> _handleShiftVerificationFailure({
+  required BuildContext context,
+  required DialogService dialogService,
+  required bool forUserSwitch,
+  required bool loaderUseRootNavigator,
+  required String userId,
+  required String blockedDescription,
+  required String signOutAnywayDescription,
+  required String logDetail,
+}) async {
+  if (!context.mounted) return false;
+  if (!forUserSwitch) {
+    _hideBlockingLoader(context, rootNavigator: loaderUseRootNavigator);
+  }
+  if (!context.mounted) return false;
+
+  if (forUserSwitch) {
+    await dialogService.showCustomDialog(
+      variant: DialogType.info,
+      title: 'Could not verify shift',
+      description: blockedDescription,
+    );
     return false;
   }
+
+  final proceed = await _confirmExitWithoutClosingShift(
+    context: context,
+    title: 'Could not verify shift',
+    description: signOutAnywayDescription,
+  );
+  if (proceed) {
+    talker.warning(
+      'Signing out $userId without verifying the shift — lookup $logDetail',
+    );
+  }
+  return proceed;
 }
 

--- a/packages/flipper_models/lib/providers/active_branch_provider.dart
+++ b/packages/flipper_models/lib/providers/active_branch_provider.dart
@@ -63,10 +63,11 @@ Stream<Branch> activeBranch(Ref ref) async* {
       }
     } catch (error, stackTrace) {
       if (error is! TimeoutException) {
-        // The original call itself failed, so it's done: safe to issue a
-        // fresh one next turn. On a plain TimeoutException, pendingFetch is
-        // still running and is kept so the next turn re-awaits it instead.
+        // The original call itself failed, so clear it before propagating.
+        // On a plain TimeoutException, pendingFetch is still running and is
+        // kept so the next turn re-awaits it instead.
         pendingFetch = null;
+        rethrow;
       }
 
       print('Error fetching active branch: $error');

--- a/packages/flipper_models/lib/providers/active_branch_provider.dart
+++ b/packages/flipper_models/lib/providers/active_branch_provider.dart
@@ -24,6 +24,11 @@ bool _branchIdentityChanged(Branch? a, Branch b) {
 Stream<Branch> activeBranch(Ref ref) async* {
   Branch? lastYielded;
   String? trackedBranchId;
+  // A previous attempt that timed out but is still running in the
+  // background (Future.timeout races a timer, it never cancels the
+  // original call). Re-awaited on the next loop turn instead of starting
+  // a duplicate query, so a hung lookup can't pile up concurrent calls.
+  Future<Branch>? pendingFetch;
 
   while (true) {
     final branchId = ProxyService.box.getBranchId();
@@ -41,17 +46,29 @@ Stream<Branch> activeBranch(Ref ref) async* {
     if (trackedBranchId != branchId) {
       trackedBranchId = branchId;
       lastYielded = null;
+      pendingFetch = null;
     }
 
+    pendingFetch ??=
+        ProxyService.getStrategy(Strategy.capella).activeBranch(
+      branchId: branchId,
+    );
+
     try {
-      final branch = await ProxyService.getStrategy(Strategy.capella)
-          .activeBranch(branchId: branchId)
-          .timeout(const Duration(seconds: 5));
+      final branch = await pendingFetch.timeout(const Duration(seconds: 5));
+      pendingFetch = null;
       if (_branchIdentityChanged(lastYielded, branch)) {
         lastYielded = branch;
         yield branch;
       }
     } catch (error, stackTrace) {
+      if (error is! TimeoutException) {
+        // The original call itself failed, so it's done: safe to issue a
+        // fresh one next turn. On a plain TimeoutException, pendingFetch is
+        // still running and is kept so the next turn re-awaits it instead.
+        pendingFetch = null;
+      }
+
       print('Error fetching active branch: $error');
       print('Stack trace: $stackTrace');
 

--- a/packages/flipper_models/lib/providers/active_branch_provider.dart
+++ b/packages/flipper_models/lib/providers/active_branch_provider.dart
@@ -44,9 +44,9 @@ Stream<Branch> activeBranch(Ref ref) async* {
     }
 
     try {
-      final branch = await ProxyService.getStrategy(Strategy.capella).activeBranch(
-        branchId: branchId,
-      );
+      final branch = await ProxyService.getStrategy(Strategy.capella)
+          .activeBranch(branchId: branchId)
+          .timeout(const Duration(seconds: 5));
       if (_branchIdentityChanged(lastYielded, branch)) {
         lastYielded = branch;
         yield branch;

--- a/packages/flipper_models/lib/providers/production_output_provider.dart
+++ b/packages/flipper_models/lib/providers/production_output_provider.dart
@@ -2,6 +2,7 @@ import 'package:flipper_models/SyncStrategy.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flipper_services/proxy.dart';
 import 'package:supabase_models/brick/models/work_order.model.dart';
+import 'package:supabase_models/brick/models/actual_output.model.dart';
 
 /// Parameters for fetching work orders
 class WorkOrdersParams {
@@ -60,24 +61,56 @@ class VarianceSummaryParams {
   int get hashCode => branchId.hashCode ^ startDate.hashCode ^ endDate.hashCode;
 }
 
-/// Provider for today's work orders
-final todayWorkOrdersProvider = FutureProvider<List<WorkOrder>>((ref) async {
+/// Live work orders for the active branch, backed by a Ditto observer.
+///
+/// Everything on the production dashboard derives from this one stream. Writes
+/// are Ditto-native and committed before `createWorkOrder` returns, so the
+/// observer fires for local edits immediately; the stream also carries changes
+/// made on other devices without anyone hitting refresh.
+///
+/// Deliberately unfiltered by date: `targetDate` windows are applied by the
+/// derived providers below, which keeps one observer per branch instead of one
+/// per window and lets a work order move between windows without a refetch.
+final workOrdersStreamProvider = StreamProvider<List<WorkOrder>>((ref) {
   final branchId = ProxyService.box.getBranchId() ?? '';
-  final now = DateTime.now();
-  final startOfDay = DateTime(now.year, now.month, now.day);
-  final endOfDay = startOfDay.add(const Duration(days: 1));
+  if (branchId.isEmpty) return Stream.value(<WorkOrder>[]);
 
-  try {
-    final workOrders = await ProxyService.getStrategy(Strategy.capella)
-        .getWorkOrders(
-          branchId: branchId,
-          startDate: startOfDay,
-          endDate: endOfDay,
-        );
-    return workOrders.cast<WorkOrder>().toList();
-  } catch (e) {
-    return <WorkOrder>[];
-  }
+  return ProxyService.getStrategy(Strategy.capella)
+      .workOrdersStream(branchId: branchId)
+      .map((rows) => rows.cast<WorkOrder>().toList())
+      .handleError((_) => <WorkOrder>[]);
+});
+
+/// Live actual-output records for the active branch.
+///
+/// Work orders already carry the rolled-up `actualQuantity`; this stream is what
+/// keeps the variance-by-reason breakdown current.
+final actualOutputsStreamProvider = StreamProvider<List<ActualOutput>>((ref) {
+  final branchId = ProxyService.box.getBranchId() ?? '';
+  if (branchId.isEmpty) return Stream.value(<ActualOutput>[]);
+
+  return ProxyService.getStrategy(Strategy.capella)
+      .actualOutputsStream(branchId: branchId)
+      .map((rows) => rows.cast<ActualOutput>().toList())
+      .handleError((_) => <ActualOutput>[]);
+});
+
+/// True when [date] falls on the same calendar day as [now] in local time.
+bool isSameLocalDay(DateTime date, DateTime now) {
+  final local = date.toLocal();
+  return local.year == now.year &&
+      local.month == now.month &&
+      local.day == now.day;
+}
+
+/// Provider for today's work orders — a live view over [workOrdersStreamProvider].
+final todayWorkOrdersProvider = Provider<AsyncValue<List<WorkOrder>>>((ref) {
+  final now = DateTime.now();
+  return ref.watch(workOrdersStreamProvider).whenData(
+        (workOrders) => workOrders
+            .where((wo) => isSameLocalDay(wo.targetDate, now))
+            .toList(),
+      );
 });
 
 /// Provider for this week's variance summary

--- a/packages/flipper_models/lib/sync/capella/mixins/branch_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/branch_mixin.dart
@@ -382,12 +382,7 @@ mixin CapellaBranchMixin implements BranchInterface {
   Future<Branch> activeBranch({required String branchId}) async {
     if (dittoService.dittoInstance == null) {
       talker.error('Ditto not initialized for active branch');
-      return Branch(
-        id: branchId,
-        name: 'Branch',
-        businessId: '',
-        isDefault: false,
-      );
+      throw Exception('Ditto not initialized for active branch query');
     }
 
     try {
@@ -397,20 +392,13 @@ mixin CapellaBranchMixin implements BranchInterface {
       );
 
       if (result.items.isEmpty) {
-        // Return default branch if none found
-        return Branch(
-          id: branchId,
-          name: 'Branch',
-          businessId: '',
-          isDefault: false,
-        );
+        throw Exception('Active branch not found for id: $branchId');
       }
 
       final data = Map<String, dynamic>.from(result.items.first.value);
       return Branch.fromMap(data);
     } catch (e) {
       talker.error('Error fetching active branch: $e');
-      await logOut();
       rethrow;
     }
   }
@@ -419,9 +407,7 @@ mixin CapellaBranchMixin implements BranchInterface {
   Stream<Branch> activeBranchStream({required String branchId}) {
     if (dittoService.dittoInstance == null) {
       talker.error('Ditto not initialized for active branch stream');
-      return Stream.value(
-        Branch(id: branchId, name: 'Branch', businessId: '', isDefault: false),
-      );
+      throw Exception('Ditto not initialized for active branch stream');
     }
 
     final controller = StreamController<Branch>.broadcast();
@@ -436,14 +422,8 @@ mixin CapellaBranchMixin implements BranchInterface {
         if (controller.isClosed) return;
 
         if (queryResult.items.isEmpty) {
-          // Return default branch if none found
-          controller.add(
-            Branch(
-              id: branchId,
-              name: 'Branch',
-              businessId: '',
-              isDefault: false,
-            ),
+          controller.addError(
+            Exception('Active branch not found for id: $branchId'),
           );
         } else {
           final data = Map<String, dynamic>.from(queryResult.items.first.value);

--- a/packages/flipper_models/lib/sync/capella/mixins/production_output_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/production_output_mixin.dart
@@ -1,20 +1,44 @@
 import 'dart:async';
 import 'package:flipper_models/sync/interfaces/production_output_interface.dart';
 import 'package:flipper_models/sync/dql_for_sync_subscription.dart';
+import 'package:flipper_models/helperModels/talker.dart';
 import 'package:flipper_web/services/ditto_service.dart';
-import 'package:supabase_models/brick/repository.dart';
 import 'package:uuid/uuid.dart';
 import 'package:flipper_models/db_model_export.dart';
 import 'package:flipper_services/proxy.dart';
 
-/// Capella (Ditto) implementation of ProductionOutputInterface
+/// Capella (Ditto) implementation of ProductionOutputInterface.
 ///
-/// Provides production output functionality using the Ditto sync engine for reads,
-/// and Dual Write (Brick + Ditto) for writes to satisfy the requirement:
-/// "create use standard sqlite, supabase while retrieving data should use capella"
+/// Production output is **Ditto-only**: every read and every write in this
+/// mixin goes straight to the Ditto store, with no Brick/Turso leg. Writes are
+/// committed before the future completes, so a caller (or an observer) that
+/// looks immediately afterwards always sees them — the old Brick-first path
+/// only reached Ditto through an unawaited `DittoSyncCoordinator` hop, which
+/// is what made freshly created work orders look like they never arrived.
+///
+/// Consequence to be aware of: `work_orders` / `actual_outputs` are not in the
+/// data-connector's `SYNC_TABLES` and their generated adapters are `sendOnly`,
+/// so these documents live in Ditto (device + Capella cloud) and no longer
+/// reach Postgres.
+///
+/// When Ditto is unavailable these methods throw rather than silently falling
+/// back — a write that bypasses Ditto would be invisible to the whole feature.
 mixin CapellaProductionOutputMixin implements ProductionOutputInterface {
   DittoService get dittoService => DittoService.instance;
-  Repository get repository;
+
+  /// The live Ditto handle, or a loud failure. Every write goes through here.
+  dynamic _dittoOrThrow(String operation) {
+    final ditto = dittoService.dittoInstance;
+    if (ditto == null) {
+      talker.error('Ditto not initialized ($operation)');
+      throw StateError('Ditto not initialized for $operation');
+    }
+    return ditto;
+  }
+
+  /// `field = :field, other = :other` for a partial DQL update.
+  String _setClause(Map<String, dynamic> updates) =>
+      updates.keys.map((key) => '$key = :$key').join(', ');
 
   @override
   Future<List<WorkOrder>> getWorkOrders({
@@ -63,7 +87,7 @@ mixin CapellaProductionOutputMixin implements ProductionOutputInterface {
         return WorkOrder.fromJson(Map<String, dynamic>.from(item.value));
       }).toList();
     } catch (e) {
-      print('Error getting work orders from Capella: $e');
+      talker.error('Error getting work orders from Capella: $e');
       return [];
     }
   }
@@ -79,59 +103,47 @@ mixin CapellaProductionOutputMixin implements ProductionOutputInterface {
     String? shiftId,
     String? notes,
   }) async {
-    try {
-      // Use provided variantName if available, otherwise fetch variant
-      String? effectiveVariantName = variantName;
-      String? unitOfMeasure;
+    final ditto = _dittoOrThrow('createWorkOrder');
 
-      if (effectiveVariantName == null) {
-        final variants = await repository.get<Variant>(
-          query: Query(where: [Where('id').isExactly(variantId)]),
-        );
+    // Name may be supplied by the caller; the unit only ever comes from the
+    // variant, so one read covers both cases.
+    String? effectiveVariantName = variantName;
+    String? unitOfMeasure;
 
-        if (variants.isNotEmpty) {
-          final variant = variants.first;
-          effectiveVariantName = variant.name;
-          unitOfMeasure = variant.unit;
-        }
-      } else {
-        // If variantName is provided, still fetch unit if needed
-        final variants = await repository.get<Variant>(
-          query: Query(where: [Where('id').isExactly(variantId)]),
-        );
-        if (variants.isNotEmpty) {
-          unitOfMeasure = variants.first.unit;
-        }
-      }
-
-      final userId = ProxyService.box.getUserId();
-
-      final workOrder = WorkOrder(
-        id: const Uuid().v4(),
-        branchId: branchId,
-        businessId: businessId,
-        variantId: variantId,
-        variantName: effectiveVariantName,
-        plannedQuantity: plannedQuantity,
-        targetDate: targetDate,
-        shiftId: shiftId,
-        notes: notes,
-        status: 'planned', // Default status
-        unitOfMeasure: unitOfMeasure,
-        createdBy: userId?.toString(),
-        lastTouched: DateTime.now().toUtc(),
-      );
-
-      // 1. Write to Standard SQLite/Supabase (Brick)
-      await repository.upsert<WorkOrder>(workOrder);
-
-      // 2. Write to Ditto (Capella) - REMOVED, handled by repository.upsert
-
-      return workOrder;
-    } catch (e) {
-      print('Error creating work order in Capella (Dual Write): $e');
-      return null;
+    final variantResult = await ditto.store.execute(
+      'SELECT * FROM variants WHERE _id = :id OR id = :id LIMIT 1',
+      arguments: {'id': variantId},
+    );
+    if (variantResult.items.isNotEmpty) {
+      final variant = Map<String, dynamic>.from(variantResult.items.first.value);
+      effectiveVariantName ??= variant['name'] as String?;
+      unitOfMeasure = variant['unit'] as String?;
     }
+
+    final workOrder = WorkOrder(
+      id: const Uuid().v4(),
+      branchId: branchId,
+      businessId: businessId,
+      variantId: variantId,
+      variantName: effectiveVariantName,
+      plannedQuantity: plannedQuantity,
+      targetDate: targetDate,
+      shiftId: shiftId,
+      notes: notes,
+      status: 'planned', // Default status
+      unitOfMeasure: unitOfMeasure,
+      createdBy: ProxyService.box.getUserId()?.toString(),
+      lastTouched: DateTime.now().toUtc(),
+    );
+
+    await ditto.store.execute(
+      'INSERT INTO work_orders DOCUMENTS (:doc) ON ID CONFLICT DO UPDATE',
+      arguments: {
+        'doc': await WorkOrderDittoAdapter.instance.toDittoDocument(workOrder),
+      },
+    );
+
+    return workOrder;
   }
 
   @override
@@ -141,48 +153,42 @@ mixin CapellaProductionOutputMixin implements ProductionOutputInterface {
     String? status,
     String? notes,
   }) async {
-    try {
-      // 1. Update in Brick
-      // We need to fetch it first to update properly with Brick usually,
-      // or if we have the object we upsert. Here we only have ID.
-      // Brick's repository doesn't have partial update easily without fetching.
-      // But we can try to fetch from Brick first.
-      final workOrderList = await repository.get<WorkOrder>(
-        query: Query(where: [Where('id').isExactly(workOrderId)]),
-      );
+    final ditto = _dittoOrThrow('updateWorkOrder');
 
-      if (workOrderList.isNotEmpty) {
-        final workOrder = workOrderList.first;
-        final updatedWorkOrder = workOrder.copyWith(
-          plannedQuantity: plannedQuantity,
-          status: status,
-          notes: notes,
-          lastTouched: DateTime.now().toUtc(),
-        );
-        await repository.upsert<WorkOrder>(updatedWorkOrder);
-      }
+    // Partial UPDATE rather than a whole-document upsert: a null argument means
+    // "leave alone" (matching the old copyWith semantics), and we never write
+    // back fields another device may have changed in the meantime.
+    final updates = <String, dynamic>{};
+    if (plannedQuantity != null) updates['plannedQuantity'] = plannedQuantity;
+    if (status != null) updates['status'] = status;
+    if (notes != null) updates['notes'] = notes;
+    if (updates.isEmpty) return;
+    updates['lastTouched'] = DateTime.now().toUtc().toIso8601String();
 
-      // 2. Update in Ditto - REMOVED, handled by repository.upsert
-    } catch (e) {
-      print('Error updating work order in Capella: $e');
-    }
+    await ditto.store.execute(
+      'UPDATE work_orders SET ${_setClause(updates)} '
+      'WHERE _id = :id OR id = :id',
+      arguments: {...updates, 'id': workOrderId},
+    );
   }
 
   @override
   Future<void> deleteWorkOrder({required String workOrderId}) async {
-    try {
-      // 1. Delete from Brick
-      final workOrderList = await repository.get<WorkOrder>(
-        query: Query(where: [Where('id').isExactly(workOrderId)]),
-      );
-      if (workOrderList.isNotEmpty) {
-        await repository.delete<WorkOrder>(workOrderList.first);
-      }
+    final ditto = _dittoOrThrow('deleteWorkOrder');
 
-      // 2. Delete from Ditto - REMOVED, handled by repository.delete
-    } catch (e) {
-      print('Error deleting work order: $e');
-    }
+    // Cascade to the child outputs: the actual-outputs stream is branch-wide,
+    // so orphans would keep inflating the variance-by-reason breakdown with no
+    // work order left to clear them from.
+    await ditto.store.transaction((txn) async {
+      await txn.execute(
+        'DELETE FROM actual_outputs WHERE workOrderId = :id',
+        arguments: {'id': workOrderId},
+      );
+      await txn.execute(
+        'DELETE FROM work_orders WHERE (_id = :id OR id = :id)',
+        arguments: {'id': workOrderId},
+      );
+    });
   }
 
   @override
@@ -227,9 +233,27 @@ mixin CapellaProductionOutputMixin implements ProductionOutputInterface {
         return ActualOutput.fromJson(Map<String, dynamic>.from(item.value));
       }).toList();
     } catch (e) {
-      print('Error getting actual outputs from Capella: $e');
+      talker.error('Error getting actual outputs from Capella: $e');
       return [];
     }
+  }
+
+  /// Sum of `actualQuantity` across the given docs, optionally substituting a
+  /// new value for one of them (used when an existing output is edited).
+  double _sumOutputs(
+    Iterable<dynamic> items, {
+    double seed = 0,
+    String? overrideId,
+    double? overrideQuantity,
+  }) {
+    return items.fold<double>(seed, (sum, item) {
+      final row = Map<String, dynamic>.from(item.value);
+      final id = (row['_id'] ?? row['id']) as String?;
+      if (overrideId != null && id == overrideId) {
+        return sum + (overrideQuantity ?? 0);
+      }
+      return sum + ((row['actualQuantity'] as num?)?.toDouble() ?? 0);
+    });
   }
 
   @override
@@ -241,53 +265,45 @@ mixin CapellaProductionOutputMixin implements ProductionOutputInterface {
     String? varianceReason,
     String? notes,
   }) async {
-    try {
-      final output = ActualOutput(
-        id: const Uuid().v4(),
-        workOrderId: workOrderId,
-        branchId: branchId,
-        actualQuantity: actualQuantity,
-        userId: userId,
-        varianceReason: varianceReason,
-        notes: notes,
-        lastTouched: DateTime.now().toUtc(),
+    final ditto = _dittoOrThrow('recordActualOutput');
+
+    final output = ActualOutput(
+      id: const Uuid().v4(),
+      workOrderId: workOrderId,
+      branchId: branchId,
+      actualQuantity: actualQuantity,
+      userId: userId,
+      varianceReason: varianceReason,
+      notes: notes,
+      lastTouched: DateTime.now().toUtc(),
+    );
+
+    // Sum what's already recorded and seed with the new quantity, so the
+    // rollup needs no read-back of the document we're about to write.
+    final existing = await ditto.store.execute(
+      'SELECT * FROM actual_outputs WHERE workOrderId = :workOrderId',
+      arguments: {'workOrderId': workOrderId},
+    );
+    final total = _sumOutputs(existing.items, seed: actualQuantity);
+
+    final doc = await ActualOutputDittoAdapter.instance.toDittoDocument(output);
+    final nowIso = DateTime.now().toUtc().toIso8601String();
+
+    // One transaction so the two observers can't fire out of step and render a
+    // frame where the variance breakdown moved but the total hasn't.
+    await ditto.store.transaction((txn) async {
+      await txn.execute(
+        'INSERT INTO actual_outputs DOCUMENTS (:doc) ON ID CONFLICT DO UPDATE',
+        arguments: {'doc': doc},
       );
-
-      // 1. Write to Brick
-      await repository.upsert<ActualOutput>(output);
-
-      // Recalculate total from all ActualOutput records to avoid race conditions
-      final actualOutputs = await repository.get<ActualOutput>(
-        query: Query(where: [Where('workOrderId').isExactly(workOrderId)]),
+      await txn.execute(
+        'UPDATE work_orders SET actualQuantity = :quantity, lastTouched = :lastTouched '
+        'WHERE _id = :id OR id = :id',
+        arguments: {'quantity': total, 'lastTouched': nowIso, 'id': workOrderId},
       );
+    });
 
-      final totalActualQuantity = actualOutputs.fold<double>(
-        0.0,
-        (sum, actualOutput) => sum + actualOutput.actualQuantity,
-      );
-
-      // Update WorkOrder in Brick with recalculated total
-      final workOrderList = await repository.get<WorkOrder>(
-        query: Query(where: [Where('id').isExactly(workOrderId)]),
-      );
-      if (workOrderList.isNotEmpty) {
-        final wo = workOrderList.first;
-        final updatedWo = wo.copyWith(
-          actualQuantity: totalActualQuantity,
-          lastTouched: DateTime.now().toUtc(),
-        );
-        await repository.upsert<WorkOrder>(updatedWo);
-
-        // Update WorkOrder in Ditto too - REMOVED, handled by repository.upsert
-      }
-
-      // 2. Write Output to Ditto - REMOVED, handled by repository.upsert
-
-      return output;
-    } catch (e) {
-      print('Error recording actual output in Capella: $e');
-      return null;
-    }
+    return output;
   }
 
   @override
@@ -297,55 +313,58 @@ mixin CapellaProductionOutputMixin implements ProductionOutputInterface {
     String? varianceReason,
     String? notes,
   }) async {
-    try {
-      // Brick Update
-      final list = await repository.get<ActualOutput>(
-        query: Query(where: [Where('id').isExactly(outputId)]),
+    final ditto = _dittoOrThrow('updateActualOutput');
+
+    final result = await ditto.store.execute(
+      'SELECT * FROM actual_outputs WHERE (_id = :id OR id = :id) LIMIT 1',
+      arguments: {'id': outputId},
+    );
+    if (result.items.isEmpty) return;
+    final current = ActualOutput.fromJson(
+      Map<String, dynamic>.from(result.items.first.value),
+    );
+
+    final updates = <String, dynamic>{};
+    if (actualQuantity != null) updates['actualQuantity'] = actualQuantity;
+    if (varianceReason != null) updates['varianceReason'] = varianceReason;
+    if (notes != null) updates['notes'] = notes;
+    if (updates.isEmpty) return;
+    final nowIso = DateTime.now().toUtc().toIso8601String();
+    updates['lastTouched'] = nowIso;
+
+    // Re-sum the siblings rather than applying a delta: deltas compound any
+    // drift, and both approaches need the same read.
+    double? newTotal;
+    if (actualQuantity != null && actualQuantity != current.actualQuantity) {
+      final siblings = await ditto.store.execute(
+        'SELECT * FROM actual_outputs WHERE workOrderId = :workOrderId',
+        arguments: {'workOrderId': current.workOrderId},
       );
-      if (list.isNotEmpty) {
-        final current = list.first;
-
-        // Calculate the delta if actualQuantity is changing
-        double delta = 0.0;
-        if (actualQuantity != null && current.actualQuantity != actualQuantity) {
-          delta = (actualQuantity - current.actualQuantity).toDouble();
-        }
-
-        var output = current.copyWith(
-          actualQuantity: actualQuantity,
-          varianceReason: varianceReason,
-          notes: notes,
-          lastTouched: DateTime.now().toUtc(),
-        );
-
-        // Only update the parent WorkOrder if there's a quantity change
-        if (delta != 0.0) {
-          // Fetch the parent WorkOrder
-          final workOrders = await repository.get<WorkOrder>(
-            query: Query(where: [Where('id').isExactly(current.workOrderId)]),
-          );
-
-          if (workOrders.isNotEmpty) {
-            final workOrder = workOrders.first;
-            // Add the delta to the current actualQuantity, handling nulls as 0
-            final newActualQuantity = (workOrder.actualQuantity ?? 0.0) + delta;
-
-            final updatedWorkOrder = workOrder.copyWith(
-              actualQuantity: newActualQuantity,
-              lastTouched: DateTime.now().toUtc(),
-            );
-
-            await repository.upsert<WorkOrder>(updatedWorkOrder);
-          }
-        }
-
-        await repository.upsert<ActualOutput>(output);
-      }
-
-      // Ditto Update - REMOVED, handled by repository.upsert
-    } catch (e) {
-      print("Error updating actual output: $e");
+      newTotal = _sumOutputs(
+        siblings.items,
+        overrideId: outputId,
+        overrideQuantity: actualQuantity,
+      );
     }
+
+    await ditto.store.transaction((txn) async {
+      await txn.execute(
+        'UPDATE actual_outputs SET ${_setClause(updates)} '
+        'WHERE _id = :id OR id = :id',
+        arguments: {...updates, 'id': outputId},
+      );
+      if (newTotal != null) {
+        await txn.execute(
+          'UPDATE work_orders SET actualQuantity = :quantity, lastTouched = :lastTouched '
+          'WHERE _id = :id OR id = :id',
+          arguments: {
+            'quantity': newTotal,
+            'lastTouched': nowIso,
+            'id': current.workOrderId,
+          },
+        );
+      }
+    });
   }
 
   @override
@@ -354,15 +373,9 @@ mixin CapellaProductionOutputMixin implements ProductionOutputInterface {
     DateTime? startDate,
     DateTime? endDate,
   }) {
-    // Return a stream from Ditto
-    final ditto = dittoService.dittoInstance;
-    if (ditto == null) return const Stream.empty();
-
-    // Construct query similar to getWorkOrders
     final List<String> whereClauses = ['branchId = :branchId'];
     final Map<String, dynamic> arguments = {'branchId': branchId};
 
-    // ... date logic ...
     if (startDate != null) {
       whereClauses.add('targetDate >= :startDate');
       arguments['startDate'] = startDate.toIso8601String();
@@ -372,31 +385,99 @@ mixin CapellaProductionOutputMixin implements ProductionOutputInterface {
       arguments['endDate'] = endDate.toIso8601String();
     }
 
-    final query =
-        "SELECT * FROM work_orders WHERE ${whereClauses.join(' AND ')}";
-
-    final preparedPoStream = prepareDqlSyncSubscription(query, arguments);
-    ditto.sync.registerSubscription(
-      preparedPoStream.dql,
-      arguments: preparedPoStream.arguments,
-    );
-
-    // Use registerObserver for reactive stream
-    StreamController<List<WorkOrder>> controller = StreamController();
-
-    final observer = ditto.store.registerObserver(
-      query,
+    return _observeDitto<WorkOrder>(
+      query: "SELECT * FROM work_orders WHERE ${whereClauses.join(' AND ')}",
       arguments: arguments,
-      onChange: (result) {
-        final items = result.items.map((item) {
-          return WorkOrder.fromJson(Map<String, dynamic>.from(item.value));
-        }).toList();
-        controller.add(items);
-      },
+      fromMap: WorkOrder.fromJson,
+      label: 'workOrdersStream',
     );
+  }
 
-    controller.onCancel = () {
-      observer.cancel();
+  @override
+  Stream<List<ActualOutput>> actualOutputsStream({
+    required String branchId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) {
+    final List<String> whereClauses = ['branchId = :branchId'];
+    final Map<String, dynamic> arguments = {'branchId': branchId};
+
+    if (startDate != null) {
+      whereClauses.add('recordedAt >= :startDate');
+      arguments['startDate'] = startDate.toIso8601String();
+    }
+    if (endDate != null) {
+      whereClauses.add('recordedAt <= :endDate');
+      arguments['endDate'] = endDate.toIso8601String();
+    }
+
+    return _observeDitto<ActualOutput>(
+      query: "SELECT * FROM actual_outputs WHERE ${whereClauses.join(' AND ')}",
+      arguments: arguments,
+      fromMap: ActualOutput.fromJson,
+      label: 'actualOutputsStream',
+    );
+  }
+
+  /// Live view of a Ditto query: subscribe for replication, observe for local
+  /// changes, and seed the first emission from a one-shot read.
+  ///
+  /// The seed matters because `registerObserver` may not deliver an initial
+  /// callback before the provider attaches its listener; without it a fresh
+  /// listener would sit in `loading` until the next mutation.
+  Stream<List<T>> _observeDitto<T>({
+    required String query,
+    required Map<String, dynamic> arguments,
+    required T Function(Map<String, dynamic>) fromMap,
+    required String label,
+  }) {
+    final ditto = dittoService.dittoInstance;
+    if (ditto == null) return Stream.value(<T>[]);
+
+    // Single-subscription on purpose: the observer and the seed both land
+    // after an await, and a broadcast controller would drop whichever fires
+    // before the provider attaches its listener.
+    final controller = StreamController<List<T>>();
+    dynamic observer;
+    var observed = false;
+
+    List<T> decode(Iterable<dynamic> items) => items
+        .map<T>((item) => fromMap(Map<String, dynamic>.from(item.value)))
+        .toList();
+
+    () async {
+      try {
+        final prepared = prepareDqlSyncSubscription(query, arguments);
+        await ditto.sync.registerSubscription(
+          prepared.dql,
+          arguments: prepared.arguments,
+        );
+
+        observer = ditto.store.registerObserver(
+          query,
+          arguments: arguments,
+          onChange: (result) {
+            if (controller.isClosed) return;
+            observed = true;
+            controller.add(decode(result.items));
+          },
+        );
+
+        if (!observed) {
+          final seed = await ditto.store.execute(query, arguments: arguments);
+          if (!observed && !controller.isClosed) {
+            controller.add(decode(seed.items));
+          }
+        }
+      } catch (e, st) {
+        talker.error('Capella $label failed: $e\n$st');
+        if (!controller.isClosed) controller.add(<T>[]);
+      }
+    }();
+
+    controller.onCancel = () async {
+      await observer?.cancel();
+      await controller.close();
     };
 
     return controller.stream;

--- a/packages/flipper_models/lib/sync/interfaces/production_output_interface.dart
+++ b/packages/flipper_models/lib/sync/interfaces/production_output_interface.dart
@@ -69,6 +69,17 @@ abstract class ProductionOutputInterface {
     DateTime? endDate,
   });
 
+  /// Stream of actual output records for real-time updates.
+  ///
+  /// The work-order stream already carries the rolled-up `actualQuantity`, so
+  /// this exists for anything that needs the individual records — notably the
+  /// variance-by-reason breakdown on the production dashboard.
+  Stream<List<dynamic>> actualOutputsStream({
+    required String branchId,
+    DateTime? startDate,
+    DateTime? endDate,
+  });
+
   /// Get variance summary for a period
   Future<Map<String, dynamic>> getVarianceSummary({
     required String branchId,

--- a/packages/flipper_models/lib/sync/mixins/production_output_mixin.dart
+++ b/packages/flipper_models/lib/sync/mixins/production_output_mixin.dart
@@ -1,17 +1,22 @@
-import 'dart:async';
 import 'package:flipper_models/sync/interfaces/production_output_interface.dart';
 import 'package:supabase_models/brick/models/work_order.model.dart';
 import 'package:supabase_models/brick/models/actual_output.model.dart';
-import 'package:supabase_models/brick/repository.dart';
 
-import 'package:uuid/uuid.dart';
-
-/// CoreSync implementation of ProductionOutputInterface
+/// CoreSync (Brick) side of [ProductionOutputInterface] — intentionally inert.
 ///
-/// Provides production output functionality using Brick (SQLite/Supabase).
-/// Used as the default strategy or when Capella is not active.
+/// Production output is **Ditto-only**: `CapellaProductionOutputMixin` owns
+/// every read and write, and `SyncStrategy.getStrategy()` returns Capella
+/// unconditionally, so nothing can reach these members today. They exist only
+/// so `CoreSync` keeps satisfying `DatabaseSyncInterface`.
+///
+/// They throw rather than silently writing to Brick: a work order that landed
+/// in Turso/Supabase without reaching Ditto would be invisible to the entire
+/// feature, which is exactly the bug the Ditto-only cutover removed.
 mixin ProductionOutputMixin implements ProductionOutputInterface {
-  Repository get repository;
+  Never _dittoOnly(String member) => throw UnimplementedError(
+        'Production output is Ditto-only; $member is served by '
+        'CapellaProductionOutputMixin.',
+      );
 
   @override
   Future<List<WorkOrder>> getWorkOrders({
@@ -19,41 +24,8 @@ mixin ProductionOutputMixin implements ProductionOutputInterface {
     DateTime? startDate,
     DateTime? endDate,
     String? status,
-  }) async {
-    try {
-      final queryConditions = [Where('branchId').isExactly(branchId)];
-
-      if (status != null) {
-        queryConditions.add(Where('status').isExactly(status));
-      }
-
-      // Brick query doesn't support complex date comparisons in 'where' easily for all providers
-      // Fetch and filter in memory if needed, or rely on provider capabilities.
-      // For OfflineFirstWithSupabase, simpler equality is safest, but we can try ranges if supported.
-      // We'll fetch by branch and filter in memory to be safe and consistent.
-
-      final workOrders = await repository.get<WorkOrder>(
-        query: Query(where: queryConditions),
-      );
-
-      var filtered = workOrders;
-      if (startDate != null) {
-        filtered = filtered
-            .where((wo) => !wo.targetDate.isBefore(startDate))
-            .toList();
-      }
-      if (endDate != null) {
-        filtered = filtered
-            .where((wo) => !wo.targetDate.isAfter(endDate))
-            .toList();
-      }
-
-      return filtered;
-    } catch (e) {
-      print('Error getting work orders (Brick): $e');
-      return [];
-    }
-  }
+  }) async =>
+      _dittoOnly('getWorkOrders');
 
   @override
   Future<WorkOrder?> createWorkOrder({
@@ -65,29 +37,8 @@ mixin ProductionOutputMixin implements ProductionOutputInterface {
     required DateTime targetDate,
     String? shiftId,
     String? notes,
-  }) async {
-    try {
-      final workOrder = WorkOrder(
-        id: const Uuid().v4(),
-        branchId: branchId,
-        businessId: businessId,
-        variantId: variantId,
-        variantName: variantName,
-        plannedQuantity: plannedQuantity,
-        targetDate: targetDate, // DateTime
-        shiftId: shiftId,
-        notes: notes,
-        status: 'planned',
-        lastTouched: DateTime.now().toUtc(),
-      );
-
-      await repository.upsert<WorkOrder>(workOrder);
-      return workOrder;
-    } catch (e) {
-      print('Error creating work order (Brick): $e');
-      return null;
-    }
-  }
+  }) async =>
+      _dittoOnly('createWorkOrder');
 
   @override
   Future<void> updateWorkOrder({
@@ -95,55 +46,12 @@ mixin ProductionOutputMixin implements ProductionOutputInterface {
     double? plannedQuantity,
     String? status,
     String? notes,
-  }) async {
-    try {
-      final workOrders = await repository.get<WorkOrder>(
-        query: Query(where: [Where('id').isExactly(workOrderId)]),
-      );
-
-      if (workOrders.isNotEmpty) {
-        final current = workOrders.first;
-        final now = DateTime.now().toUtc();
-
-        // Set timestamps based on status changes
-        DateTime? startedAt = current.startedAt;
-        DateTime? completedAt = current.completedAt;
-
-        if (status == 'in_progress' && current.status != 'in_progress') {
-          startedAt = now;
-        }
-        if (status == 'completed' && current.status != 'completed') {
-          completedAt = now;
-        }
-
-        final updated = current.copyWith(
-          plannedQuantity: plannedQuantity,
-          status: status,
-          notes: notes,
-          startedAt: startedAt,
-          completedAt: completedAt,
-          lastTouched: now,
-        );
-        await repository.upsert<WorkOrder>(updated);
-      }
-    } catch (e) {
-      print('Error updating work order (Brick): $e');
-    }
-  }
+  }) async =>
+      _dittoOnly('updateWorkOrder');
 
   @override
-  Future<void> deleteWorkOrder({required String workOrderId}) async {
-    try {
-      final workOrders = await repository.get<WorkOrder>(
-        query: Query(where: [Where('id').isExactly(workOrderId)]),
-      );
-      if (workOrders.isNotEmpty) {
-        await repository.delete<WorkOrder>(workOrders.first);
-      }
-    } catch (e) {
-      print('Error deleting work order (Brick): $e');
-    }
-  }
+  Future<void> deleteWorkOrder({required String workOrderId}) async =>
+      _dittoOnly('deleteWorkOrder');
 
   @override
   Future<List<ActualOutput>> getActualOutputs({
@@ -151,48 +59,8 @@ mixin ProductionOutputMixin implements ProductionOutputInterface {
     DateTime? startDate,
     DateTime? endDate,
     String? workOrderId,
-  }) async {
-    try {
-      final queryConditions = [Where('branchId').isExactly(branchId)];
-      if (workOrderId != null) {
-        queryConditions.add(Where('workOrderId').isExactly(workOrderId));
-      }
-
-      final outputs = await repository.get<ActualOutput>(
-        query: Query(where: queryConditions),
-      );
-
-      var filtered = outputs;
-      if (startDate != null) {
-        // Assuming recordedAt or using lastTouched as proxy if needed.
-        // ActualOutput should have a date field. Checking model...
-        // It has lastTouched. A 'createdAt' or 'recordedAt' would be better.
-        // Assuming the model has it or we filter by lastTouched.
-        // The interface implies we filter by date.
-        // Let's assume lastTouched for now or check model later.
-        filtered = filtered
-            .where(
-              (ao) =>
-                  ao.lastTouched != null &&
-                  !ao.lastTouched!.isBefore(startDate),
-            )
-            .toList();
-      }
-      if (endDate != null) {
-        filtered = filtered
-            .where(
-              (ao) =>
-                  ao.lastTouched != null && !ao.lastTouched!.isAfter(endDate),
-            )
-            .toList();
-      }
-
-      return filtered;
-    } catch (e) {
-      print('Error getting actual outputs (Brick): $e');
-      return [];
-    }
-  }
+  }) async =>
+      _dittoOnly('getActualOutputs');
 
   @override
   Future<ActualOutput?> recordActualOutput({
@@ -202,50 +70,8 @@ mixin ProductionOutputMixin implements ProductionOutputInterface {
     required String userId,
     String? varianceReason,
     String? notes,
-  }) async {
-    try {
-      final output = ActualOutput(
-        id: const Uuid().v4(),
-        workOrderId: workOrderId,
-        branchId: branchId,
-        actualQuantity: actualQuantity,
-        userId: userId,
-        varianceReason: varianceReason,
-        notes: notes,
-        lastTouched: DateTime.now().toUtc(),
-      );
-
-      await repository.upsert<ActualOutput>(output);
-
-      // Recalculate total from all ActualOutput records to avoid race conditions
-      final actualOutputs = await repository.get<ActualOutput>(
-        query: Query(where: [Where('workOrderId').isExactly(workOrderId)]),
-      );
-
-      final totalActualQuantity = actualOutputs.fold<double>(
-        0.0,
-        (sum, actualOutput) => sum + actualOutput.actualQuantity,
-      );
-
-      // Update work order total with recalculated value
-      final workOrders = await repository.get<WorkOrder>(
-        query: Query(where: [Where('id').isExactly(workOrderId)]),
-      );
-      if (workOrders.isNotEmpty) {
-        final wo = workOrders.first;
-        final updatedWo = wo.copyWith(
-          actualQuantity: totalActualQuantity,
-          lastTouched: DateTime.now().toUtc(),
-        );
-        await repository.upsert<WorkOrder>(updatedWo);
-      }
-
-      return output;
-    } catch (e) {
-      print('Error recording actual output (Brick): $e');
-      return null;
-    }
-  }
+  }) async =>
+      _dittoOnly('recordActualOutput');
 
   @override
   Future<void> updateActualOutput({
@@ -253,196 +79,30 @@ mixin ProductionOutputMixin implements ProductionOutputInterface {
     double? actualQuantity,
     String? varianceReason,
     String? notes,
-  }) async {
-    try {
-      final outputs = await repository.get<ActualOutput>(
-        query: Query(where: [Where('id').isExactly(outputId)]),
-      );
-
-      if (outputs.isNotEmpty) {
-        final current = outputs.first;
-
-        // Check if actualQuantity is changing
-        final actualQuantityChanged = actualQuantity != null &&
-            current.actualQuantity != actualQuantity;
-
-        final updated = current.copyWith(
-          actualQuantity: actualQuantity,
-          varianceReason: varianceReason,
-          notes: notes,
-          lastTouched: DateTime.now().toUtc(),
-        );
-        await repository.upsert<ActualOutput>(updated);
-
-        // If actualQuantity changed, recalculate the parent WorkOrder total
-        if (actualQuantityChanged) {
-          final workOrderId = current.workOrderId;
-
-          // Recalculate total from all ActualOutput records for this work order
-          final actualOutputs = await repository.get<ActualOutput>(
-            query: Query(where: [Where('workOrderId').isExactly(workOrderId)]),
-          );
-
-          final totalActualQuantity = actualOutputs.fold<double>(
-            0.0,
-            (sum, actualOutput) => sum + actualOutput.actualQuantity,
-          );
-
-          // Update work order total with recalculated value
-          final workOrders = await repository.get<WorkOrder>(
-            query: Query(where: [Where('id').isExactly(workOrderId)]),
-          );
-          if (workOrders.isNotEmpty) {
-            final wo = workOrders.first;
-            final updatedWo = wo.copyWith(
-              actualQuantity: totalActualQuantity,
-              lastTouched: DateTime.now().toUtc(),
-            );
-            await repository.upsert<WorkOrder>(updatedWo);
-          }
-        }
-      }
-    } catch (e) {
-      print('Error updating actual output (Brick): $e');
-    }
-  }
+  }) async =>
+      _dittoOnly('updateActualOutput');
 
   @override
   Stream<List<WorkOrder>> workOrdersStream({
     required String branchId,
     DateTime? startDate,
     DateTime? endDate,
-  }) {
-    // Create a broadcast stream controller to allow multiple listeners
-    final controller = StreamController<List<WorkOrder>>.broadcast();
+  }) =>
+      _dittoOnly('workOrdersStream');
 
-    Timer? _timer;
-
-    void startPolling() {
-      // Immediately fetch and add the initial results
-      getWorkOrders(
-        branchId: branchId,
-        startDate: startDate,
-        endDate: endDate,
-      ).then((workOrders) {
-        if (!controller.isClosed) {
-          controller.add(workOrders);
-        }
-      });
-
-      // Start periodic polling
-      _timer = Timer.periodic(const Duration(seconds: 5), (_) async {
-        if (!controller.isClosed) {
-          try {
-            final workOrders = await getWorkOrders(
-              branchId: branchId,
-              startDate: startDate,
-              endDate: endDate,
-            );
-            if (!controller.isClosed) {
-              controller.add(workOrders);
-            }
-          } catch (e) {
-            if (!controller.isClosed) {
-              controller.addError(e);
-            }
-          }
-        } else {
-          // If controller is closed, cancel the timer
-          _timer?.cancel();
-        }
-      });
-    }
-
-    // Start polling when the first listener subscribes
-    controller.onListen = startPolling;
-
-    // Handle cancellation to clean up resources when all listeners are gone
-    controller.onCancel = () {
-      _timer?.cancel();
-      _timer = null;
-    };
-
-    return controller.stream;
-  }
+  @override
+  Stream<List<ActualOutput>> actualOutputsStream({
+    required String branchId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) =>
+      _dittoOnly('actualOutputsStream');
 
   @override
   Future<Map<String, dynamic>> getVarianceSummary({
     required String branchId,
     required DateTime startDate,
     required DateTime endDate,
-  }) async {
-    // Same calculation logic as service/Capella, but using Brick fetch
-    try {
-      final workOrders = await getWorkOrders(
-        branchId: branchId,
-        startDate: startDate,
-        endDate: endDate,
-      );
-
-      final outputs = await getActualOutputs(
-        branchId: branchId,
-        startDate: startDate,
-        endDate: endDate,
-      );
-
-      double totalPlanned = 0;
-      double totalActual = 0;
-      int completedOrders = 0;
-      final totalOrders = workOrders.length;
-
-      for (final wo in workOrders) {
-        totalPlanned += wo.plannedQuantity;
-        totalActual += wo.actualQuantity;
-        if (wo.status == 'completed') completedOrders++;
-      }
-
-      final varianceByReason = <String, double>{
-        'machine': 0,
-        'material': 0,
-        'labor': 0,
-        'quality': 0,
-        'planning': 0,
-        'other': 0,
-      };
-
-      for (final output in outputs) {
-        if (output.varianceReason != null) {
-          final reason = output.varianceReason!.toLowerCase();
-          if (varianceByReason.containsKey(reason)) {
-            varianceByReason[reason] = varianceByReason[reason]! + 1;
-          } else {
-            varianceByReason['other'] = varianceByReason['other']! + 1;
-          }
-        }
-      }
-
-      final variance = totalActual - totalPlanned;
-      final variancePercentage = totalPlanned > 0
-          ? (variance / totalPlanned) * 100
-          : 0.0;
-      final efficiency = totalPlanned > 0
-          ? (totalActual / totalPlanned) * 100
-          : 0.0;
-
-      return {
-        'totalPlanned': totalPlanned,
-        'totalActual': totalActual,
-        'variance': variance,
-        'variancePercentage': variancePercentage,
-        'efficiency': efficiency,
-        'totalOrders': totalOrders,
-        'completedOrders': completedOrders,
-        'completionRate': totalOrders > 0
-            ? (completedOrders / totalOrders) * 100
-            : 0.0,
-        'varianceByReason': varianceByReason,
-        'startDate': startDate.toIso8601String(),
-        'endDate': endDate.toIso8601String(),
-      };
-    } catch (e) {
-      print('Error getting variance summary (Brick): $e');
-      return {};
-    }
-  }
+  }) async =>
+      _dittoOnly('getVarianceSummary');
 }

--- a/packages/supabase_models/lib/brick/repository/legacy_preferences_migration.dart
+++ b/packages/supabase_models/lib/brick/repository/legacy_preferences_migration.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:supabase_models/brick/repository/session_prefs_keys.dart';
 
 /// Copies / merges the most recent pre-rename `<baseName>_v<N>.json` file into
 /// [targetFileName] when the stable target is missing, empty, or incomplete.
@@ -16,10 +17,24 @@ import 'package:path/path.dart' as p;
 ///
 /// Incomplete targets (e.g. a file that only contains MFA keys after a bad
 /// write) are merged with the richest legacy file so session keys return.
+///
+/// **A logout is not an incomplete target.** `clearSessionKeys()` removes
+/// exactly the keys this migration used to treat as proof of health (`userId`,
+/// `businessId`, `bearerToken`), so on the next launch every signed-out device
+/// that still had a legacy `_v<N>.json` lying around got its previous session
+/// merged straight back in — and because nothing consumes the legacy file, it
+/// happened again on every launch, forever. [kSessionClearedAtKey] is the tell:
+/// when a clear was recorded *after* the legacy snapshot, the legacy file may
+/// still repair device-level prefs but must not carry [kSessionPrefKeys].
+///
+/// [siblingFileNames] are the other stable preference files in [directory]
+/// (main <-> backup). They are consulted for [kSessionClearedAtKey] so a logout
+/// is still honoured when the target file itself was lost.
 Future<void> migrateLegacyPreferencesFileIfNeeded({
   required String directory,
   required String baseName,
   required String targetFileName,
+  List<String> siblingFileNames = const [],
 }) async {
   final logger = Logger('LegacyPreferencesMigration');
   final targetPath = p.join(directory, targetFileName);
@@ -46,19 +61,8 @@ Future<void> migrateLegacyPreferencesFileIfNeeded({
     }
   }
 
-  Map<String, dynamic> readJson(File file) {
-    try {
-      final decoded = jsonDecode(file.readAsStringSync());
-      if (decoded is Map<String, dynamic>) return decoded;
-      if (decoded is Map) {
-        return decoded.map((k, v) => MapEntry(k.toString(), v));
-      }
-    } catch (_) {}
-    return <String, dynamic>{};
-  }
-
   final targetExists = targetFile.existsSync() && targetFile.lengthSync() > 0;
-  final targetMap = targetExists ? readJson(targetFile) : <String, dynamic>{};
+  final targetMap = targetExists ? _readJson(targetFile) : <String, dynamic>{};
   final targetLooksHealthy = targetMap.containsKey('userId') ||
       targetMap.containsKey('businessId') ||
       targetMap.containsKey('bearerToken');
@@ -71,16 +75,83 @@ Future<void> migrateLegacyPreferencesFileIfNeeded({
     return;
   }
 
-  final legacyMap = readJson(bestFile);
+  final legacyMap = _readJson(bestFile);
   if (legacyMap.isEmpty && targetMap.isEmpty) return;
 
-  // Legacy fills session keys; target wins on overlap (e.g. MFA keys).
-  final merged = <String, dynamic>{...legacyMap, ...targetMap};
+  // A logout recorded after the legacy snapshot outranks it: the missing
+  // session keys are the point, not damage to repair.
+  final clearedAt = _latestSessionClearedAt(
+    directory: directory,
+    targetMap: targetMap,
+    siblingFileNames: siblingFileNames,
+    targetFileName: targetFileName,
+  );
+  final sessionClearedAfterLegacy = clearedAt > _sessionClearedAt(legacyMap);
+
+  final donor = sessionClearedAfterLegacy
+      ? (Map<String, dynamic>.from(legacyMap)
+        ..removeWhere((key, _) => kSessionPrefKeys.contains(key)))
+      : legacyMap;
+
+  // Nothing the target is missing — leave the file (and its mtime) alone.
+  if (!donor.keys.any((key) => !targetMap.containsKey(key))) {
+    if (sessionClearedAfterLegacy) {
+      logger.info(
+        'Skipping preferences repair of $targetFileName from '
+        '${p.basename(bestFile.path)}: session was cleared at $clearedAt',
+      );
+    }
+    return;
+  }
+
+  // Legacy fills the gaps; target wins on overlap (e.g. MFA keys).
+  final merged = <String, dynamic>{...donor, ...targetMap};
   logger.warning(
     'Repairing preferences $targetFileName from legacy '
     '${p.basename(bestFile.path)} (targetHealthy=$targetLooksHealthy, '
+    'sessionClearedAfterLegacy=$sessionClearedAfterLegacy, '
     'legacyKeys=${legacyMap.length}, targetKeys=${targetMap.length}, '
     'mergedKeys=${merged.length})',
   );
   await targetFile.writeAsString(jsonEncode(merged), flush: true);
+}
+
+Map<String, dynamic> _readJson(File file) {
+  try {
+    final decoded = jsonDecode(file.readAsStringSync());
+    if (decoded is Map<String, dynamic>) return decoded;
+    if (decoded is Map) {
+      return decoded.map((k, v) => MapEntry(k.toString(), v));
+    }
+  } catch (_) {}
+  return <String, dynamic>{};
+}
+
+int _sessionClearedAt(Map<String, dynamic> map) {
+  final raw = map[kSessionClearedAtKey];
+  if (raw is num) return raw.toInt();
+  if (raw is String) return int.tryParse(raw) ?? 0;
+  return 0;
+}
+
+/// Newest logout timestamp across the target and its sibling stable files.
+///
+/// The main file and its backup are written together, but a logout that only
+/// survived in one of them must still win — otherwise repairing the other one
+/// hands the session back.
+int _latestSessionClearedAt({
+  required String directory,
+  required Map<String, dynamic> targetMap,
+  required List<String> siblingFileNames,
+  required String targetFileName,
+}) {
+  var newest = _sessionClearedAt(targetMap);
+  for (final name in siblingFileNames) {
+    if (name == targetFileName) continue;
+    final file = File(p.join(directory, name));
+    if (!file.existsSync() || file.lengthSync() == 0) continue;
+    final value = _sessionClearedAt(_readJson(file));
+    if (value > newest) newest = value;
+  }
+  return newest;
 }

--- a/packages/supabase_models/lib/brick/repository/local_storage.dart
+++ b/packages/supabase_models/lib/brick/repository/local_storage.dart
@@ -6,6 +6,7 @@ import 'package:flipper_web/services/ditto_service.dart';
 import 'package:path/path.dart' as path;
 import 'package:supabase_models/brick/databasePath.dart';
 import 'package:supabase_models/brick/repository/legacy_preferences_migration.dart';
+import 'package:supabase_models/brick/repository/session_prefs_keys.dart';
 import 'package:supabase_models/brick/repository/storage.dart';
 // ignore: depend_on_referenced_packages
 import 'package:shared_preferences/shared_preferences.dart';
@@ -223,76 +224,16 @@ class SharedPreferenceStorage implements LocalStorage {
     'userIdString',
   };
 
-  /// Millis timestamp of the last [clearSessionKeys]. Used to stop a stale Ditto
-  /// prefs payload from resurrecting a session that was logged out — see
-  /// [attachDittoPersistence].
-  static const String _kSessionClearedAtKey = 'sessionClearedAt';
+  /// Millis timestamp of the last [clearSessionKeys]. Used to stop a stale copy
+  /// of the preferences — the Ditto payload (see [attachDittoPersistence]) or a
+  /// pre-rename `_v<N>.json` file (see [migrateLegacyPreferencesFileIfNeeded]) —
+  /// from resurrecting a session that was logged out.
+  static const String _kSessionClearedAtKey = kSessionClearedAtKey;
 
-  /// Everything that belongs to "who is signed in and what were they doing".
-  ///
-  /// Deliberately excludes device-level prefs that must survive logout:
-  /// `encryptionKey`, `databaseFilename`, `queueFilename`, `dbVersion`,
-  /// `thisDeviceId`, `getServerUrl`, `defaultLanguage`, cached MFA secrets
-  /// (offline authenticator login) and EBM/tax config (`tin`, `bhfId`, `mrc`,
-  /// `vatEnabled`), which are only re-hydrated conditionally after login.
-  static const Set<String> _sessionKeys = {
-    // Identity
-    'userId',
-    'userIdString',
-    'userPhone',
-    'userName',
-    'uid',
-    'isAnonymous',
-    'yegoboxLoggedInUserPermission',
-    'commissionOnlySession',
-    // Tokens / auth state
-    'authComplete',
-    'bearerToken',
-    'token',
-    'UToken',
-    'otp',
-    'getIsTokenRegistered',
-    'pinLogin',
-    'from_login',
-    'freshSignup',
-    // Business / branch selection
-    'businessId',
-    'currentBusinessId',
-    'getBusinessServerId',
-    'branchId',
-    'branchIdString',
-    'currentBranchId',
-    'active_branch_id',
-    'getBranchServerId',
-    'branch_switched',
-    'branch_switching',
-    'last_branch_switch_timestamp',
-    // Landing app / mode
-    'defaultApp',
-    'getDefaultApp',
-    'isPosDefault',
-    'isOrdersDefault',
-    'isProformaMode',
-    'isTrainingMode',
-    // In-flight sale state
-    'transactionId',
-    'currentOrderId',
-    'transactionInProgress',
-    'transactionCompleting',
-    'customerName',
-    'customerTin',
-    'currentSaleCustomerPhoneNumber',
-    'pendingCustomerName',
-    'pendingCustomerTin',
-    'getCashReceived',
-    'getRefundReason',
-    'couponCode',
-    'discountRate',
-    'purchaseCode',
-    // Branch-scoped artifacts
-    'receiptLogoBase64',
-    'lastZReportDate',
-  };
+  /// Session-scoped preferences dropped on logout. Defined in
+  /// `session_prefs_keys.dart` because the legacy-file migration has to know
+  /// the same set to avoid merging a signed-out session back in.
+  static const Set<String> _sessionKeys = kSessionPrefKeys;
 
   @override
   Future<void> clearSessionKeys() async {
@@ -537,16 +478,24 @@ class SharedPreferenceStorage implements LocalStorage {
       _filePath = path.join(directory, '$_kPreferencesKey.json');
       _backupFilePath = path.join(directory, '$_kPreferencesBackupKey.json');
 
-      // One-time migration from the old `_v<dbVersion>.json` naming scheme.
+      // Migration from the old `_v<dbVersion>.json` naming scheme. Both stable
+      // files are passed as siblings so a logout recorded in either one blocks
+      // the legacy snapshot from restoring the session (see that function).
+      final stableFileNames = [
+        path.basename(_filePath),
+        path.basename(_backupFilePath),
+      ];
       await migrateLegacyPreferencesFileIfNeeded(
         directory: directory,
         baseName: _kPreferencesKey,
         targetFileName: path.basename(_filePath),
+        siblingFileNames: stableFileNames,
       );
       await migrateLegacyPreferencesFileIfNeeded(
         directory: directory,
         baseName: _kPreferencesBackupKey,
         targetFileName: path.basename(_backupFilePath),
+        siblingFileNames: stableFileNames,
       );
 
       // Load preferences from file

--- a/packages/supabase_models/lib/brick/repository/session_prefs_keys.dart
+++ b/packages/supabase_models/lib/brick/repository/session_prefs_keys.dart
@@ -1,0 +1,78 @@
+/// Preference keys that describe "who is signed in and what were they doing".
+///
+/// Shared by [SharedPreferenceStorage.clearSessionKeys] (which drops them on
+/// logout) and [migrateLegacyPreferencesFileIfNeeded] (which must never put
+/// them back), so the two can never drift apart — a key present in one list but
+/// not the other is exactly how a logged-out user gets signed back in.
+library;
+
+/// Millis timestamp of the last session clear (logout). Written by
+/// `clearSessionKeys()`; read by every code path that merges an older copy of
+/// the preferences back in, so a logout can outrank a stale snapshot.
+const String kSessionClearedAtKey = 'sessionClearedAt';
+
+/// Everything that belongs to "who is signed in and what were they doing".
+///
+/// Deliberately excludes device-level prefs that must survive logout:
+/// `encryptionKey`, `databaseFilename`, `queueFilename`, `dbVersion`,
+/// `thisDeviceId`, `getServerUrl`, `defaultLanguage`, cached MFA secrets
+/// (offline authenticator login) and EBM/tax config (`tin`, `bhfId`, `mrc`,
+/// `vatEnabled`), which are only re-hydrated conditionally after login.
+const Set<String> kSessionPrefKeys = {
+  // Identity
+  'userId',
+  'userIdString',
+  'userPhone',
+  'userName',
+  'uid',
+  'isAnonymous',
+  'yegoboxLoggedInUserPermission',
+  'commissionOnlySession',
+  // Tokens / auth state
+  'authComplete',
+  'bearerToken',
+  'token',
+  'UToken',
+  'otp',
+  'getIsTokenRegistered',
+  'pinLogin',
+  'from_login',
+  'freshSignup',
+  // Business / branch selection
+  'businessId',
+  'currentBusinessId',
+  'getBusinessServerId',
+  'branchId',
+  'branchIdString',
+  'currentBranchId',
+  'active_branch_id',
+  'getBranchServerId',
+  'branch_switched',
+  'branch_switching',
+  'last_branch_switch_timestamp',
+  // Landing app / mode
+  'defaultApp',
+  'getDefaultApp',
+  'isPosDefault',
+  'isOrdersDefault',
+  'isProformaMode',
+  'isTrainingMode',
+  // In-flight sale state
+  'transactionId',
+  'currentOrderId',
+  'transactionInProgress',
+  'transactionCompleting',
+  'customerName',
+  'customerTin',
+  'currentSaleCustomerPhoneNumber',
+  'pendingCustomerName',
+  'pendingCustomerTin',
+  'getCashReceived',
+  'getRefundReason',
+  'couponCode',
+  'discountRate',
+  'purchaseCode',
+  // Branch-scoped artifacts
+  'receiptLogoBase64',
+  'lastZReportDate',
+};

--- a/packages/supabase_models/test/legacy_preferences_migration_test.dart
+++ b/packages/supabase_models/test/legacy_preferences_migration_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -32,12 +33,12 @@ void main() {
     }
   });
 
-  test('skips migration when the target file already has data', () async {
+  test('skips migration when the target file already holds a session', () async {
     final directory =
         Directory.systemTemp.createTempSync('flipper_legacy_prefs_');
     try {
       final targetPath = p.join(directory.path, 'flipper_preferences.json');
-      await File(targetPath).writeAsString('{"current":true}');
+      await File(targetPath).writeAsString('{"userId":"current"}');
       await File(p.join(directory.path, 'flipper_preferences_v45.json'))
           .writeAsString('{"userId":"123"}');
 
@@ -47,7 +48,149 @@ void main() {
         targetFileName: 'flipper_preferences.json',
       );
 
-      expect(await File(targetPath).readAsString(), '{"current":true}');
+      expect(await File(targetPath).readAsString(), '{"userId":"current"}');
+    } finally {
+      directory.deleteSync(recursive: true);
+    }
+  });
+
+  test('gap-fills a target damaged by a bad write', () async {
+    // The case this migration exists for: prefs went missing without a logout,
+    // so the legacy snapshot is allowed to hand the session back.
+    final directory =
+        Directory.systemTemp.createTempSync('flipper_legacy_prefs_');
+    try {
+      final targetPath = p.join(directory.path, 'flipper_preferences.json');
+      await File(targetPath).writeAsString('{"mfa_totp_secret_123":"secret"}');
+      await File(p.join(directory.path, 'flipper_preferences_v45.json'))
+          .writeAsString('{"userId":"123","encryptionKey":"key-1"}');
+
+      await migrateLegacyPreferencesFileIfNeeded(
+        directory: directory.path,
+        baseName: 'flipper_preferences',
+        targetFileName: 'flipper_preferences.json',
+      );
+
+      final result = jsonDecode(await File(targetPath).readAsString())
+          as Map<String, dynamic>;
+      expect(result['userId'], '123');
+      expect(result['encryptionKey'], 'key-1');
+      expect(result['mfa_totp_secret_123'], 'secret');
+    } finally {
+      directory.deleteSync(recursive: true);
+    }
+  });
+
+  test('a logged-out target is not "repaired" back into a session', () async {
+    // clearSessionKeys() removes exactly userId/businessId/bearerToken, which
+    // used to be this migration's proof of health — so every launch after a
+    // logout merged the previous session back in from the leftover _v<N> file.
+    final directory =
+        Directory.systemTemp.createTempSync('flipper_legacy_prefs_');
+    try {
+      final targetPath = p.join(directory.path, 'flipper_preferences.json');
+      await File(targetPath).writeAsString(jsonEncode({
+        'sessionClearedAt': 2000,
+        'encryptionKey': 'key-1',
+        'thisDeviceId': 'device-1',
+      }));
+      await File(p.join(directory.path, 'flipper_preferences_v45.json'))
+          .writeAsString(jsonEncode({
+        'userId': '123',
+        'userIdString': '123',
+        'businessId': 'biz-1',
+        'branchId': 'branch-1',
+        'bearerToken': 'token-1',
+        'authComplete': true,
+        'encryptionKey': 'key-1',
+      }));
+
+      await migrateLegacyPreferencesFileIfNeeded(
+        directory: directory.path,
+        baseName: 'flipper_preferences',
+        targetFileName: 'flipper_preferences.json',
+        siblingFileNames: const [
+          'flipper_preferences.json',
+          'flipper_preferences_backup.json',
+        ],
+      );
+
+      final result =
+          jsonDecode(await File(targetPath).readAsString()) as Map<String, dynamic>;
+      expect(result['userId'], isNull);
+      expect(result['userIdString'], isNull);
+      expect(result['businessId'], isNull);
+      expect(result['branchId'], isNull);
+      expect(result['bearerToken'], isNull);
+      expect(result['authComplete'], isNull);
+      expect(result['encryptionKey'], 'key-1');
+    } finally {
+      directory.deleteSync(recursive: true);
+    }
+  });
+
+  test('honours a logout recorded only in the sibling backup file', () async {
+    final directory =
+        Directory.systemTemp.createTempSync('flipper_legacy_prefs_');
+    try {
+      final targetPath = p.join(directory.path, 'flipper_preferences.json');
+      await File(p.join(directory.path, 'flipper_preferences_backup.json'))
+          .writeAsString(jsonEncode({'sessionClearedAt': 2000}));
+      await File(p.join(directory.path, 'flipper_preferences_v45.json'))
+          .writeAsString(jsonEncode({
+        'userId': '123',
+        'encryptionKey': 'key-1',
+      }));
+
+      await migrateLegacyPreferencesFileIfNeeded(
+        directory: directory.path,
+        baseName: 'flipper_preferences',
+        targetFileName: 'flipper_preferences.json',
+        siblingFileNames: const [
+          'flipper_preferences.json',
+          'flipper_preferences_backup.json',
+        ],
+      );
+
+      final result =
+          jsonDecode(await File(targetPath).readAsString()) as Map<String, dynamic>;
+      expect(result['userId'], isNull);
+      expect(result['encryptionKey'], 'key-1');
+    } finally {
+      directory.deleteSync(recursive: true);
+    }
+  });
+
+  test('still restores the session when the legacy file is newer than the '
+      'last logout', () async {
+    // Logged out, then signed in again, then the dbVersion bump wiped prefs.
+    final directory =
+        Directory.systemTemp.createTempSync('flipper_legacy_prefs_');
+    try {
+      final targetPath = p.join(directory.path, 'flipper_preferences.json');
+      await File(targetPath).writeAsString(jsonEncode({
+        'sessionClearedAt': 1000,
+        'mfa_totp_secret_123': 'secret',
+      }));
+      await File(p.join(directory.path, 'flipper_preferences_v45.json'))
+          .writeAsString(jsonEncode({
+        'sessionClearedAt': 1000,
+        'userId': '123',
+        'businessId': 'biz-1',
+      }));
+
+      await migrateLegacyPreferencesFileIfNeeded(
+        directory: directory.path,
+        baseName: 'flipper_preferences',
+        targetFileName: 'flipper_preferences.json',
+        siblingFileNames: const ['flipper_preferences.json'],
+      );
+
+      final result =
+          jsonDecode(await File(targetPath).readAsString()) as Map<String, dynamic>;
+      expect(result['userId'], '123');
+      expect(result['businessId'], 'biz-1');
+      expect(result['mfa_totp_secret_123'], 'secret');
     } finally {
       directory.deleteSync(recursive: true);
     }


### PR DESCRIPTION
…ever offline

activeBranchProvider awaited CapellaBranchMixin.activeBranch() with no
timeout. When that Ditto local-store query hangs while offline, the
stream never yields and the Home tab body stays stuck on its loading
spinner indefinitely, even though the nav chrome renders fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live production output summaries, seven-day variance charts, and actual-output tracking.
  * Work-order data now refreshes automatically from live updates.
  * Added clearer work-order creation, empty, and error states.
* **Bug Fixes**
  * Improved handling of sign-out when a shift cannot be verified, allowing users to sign out after confirmation.
  * Prevented stale or duplicate branch-loading requests.
  * Prevented legacy preference migration from restoring sessions after logout.
* **Style**
  * Updated production output forms and tables with consistent visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->