### PR TITLE
fix(pos): keep the cart line cache honest on every path that changes …

### DIFF
--- a/Features/POS_PAY_PERFORMANCE_HANDOFF.md
+++ b/Features/POS_PAY_PERFORMANCE_HANDOFF.md
@@ -171,6 +171,34 @@ the display. See `project_pos_cart_display_truth` in memory.
    windowing, so the lines come back — but only online. Ditto has no subqueries
    (`reference_ditto_dql_limits`), so eviction cannot join items to open tickets.
 
+10. **A recovered settling session only drives the banner.** `settlingTillTicketProvider`
+   is in-memory, so a reload / restart / re-created scope between Collect and Pay
+   used to leave a resumed ticket rendering as a plain cart — PENDING on screen,
+   no settling banner, and therefore no "Back to new sale" (the user's report:
+   "sometimes a resumed ticket has the button and sometimes not"). Fixed by
+   deriving the session from the row instead: `resumeSaleTicketFast` leaves
+   `ticketName` and the park `createdAt` alone and only park ever writes
+   `ticketName`, so a PENDING row carrying one *is* a resumed ticket —
+   `recoverSettlingTillTicketFromResumedCart` (`pos_payment_role_provider.dart`)
+   rebuilds a session from it, and `effectiveSettlingTillTicketProvider`
+   (`pos_cart_display_provider.dart`) prefers the live session, falling back to
+   recovery off the pending-cart rows the checkout already observes (cache, then
+   stream, honouring the pin) so no extra Ditto observer lands on the POS hot
+   path. Suppressed ids and ordering mode return null, so the banner cannot flash
+   back after a re-park or a completed sale.
+
+   **Only the banner and its "Back to new sale" handler read the effective
+   provider.** The other four behaviours that the live session drives — Pay
+   binding (completion targets the ticket, not the collector's empty cart),
+   read-only cart, hidden Save-ticket, and mobile's `PopScope` auto-re-park — are
+   still keyed off `settlingTillTicketProvider` alone. So after a reload the
+   banner is back but the cart is editable again, and backing out of mobile
+   checkout will not auto-re-park. Deliberate: a wrong recovery is cosmetic in
+   the banner and charges the wrong transaction in Pay binding. Making recovery
+   feed all five is the follow-up; the race to test first is tapping "Back to new
+   sale" and re-adopting the ticket before Ditto reports it PARKED (the
+   suppressed-id guard is what stands in the way today).
+
 ## Diagnostics added this session
 
 Grep these first; they were built for exactly this problem.
@@ -218,6 +246,9 @@ switched … discarding them`, the fingerprint of a stolen cart.
   never swapped for an empty one; the completion hand-off always hands over.
 - `flipper_models/test/optimistic_cart_reconcile_test.dart` — idempotent
   reconciliation; the settle ledger, including a cancelled add still settling.
+- `flipper_models/test/settling_till_ticket_recovery_test.dart` — which rows count
+  as a resumed till ticket: PENDING + `ticketName` recovers, a plain pending cart
+  / a parked or completed row does not.
 
 Known-flaky under parallel load: `pos_cart_tap_sync_perf_test.dart` (timing
 budget) and occasionally a suite failing at "loading". Both pass in isolation.

--- a/Features/POS_PAY_PERFORMANCE_HANDOFF.md
+++ b/Features/POS_PAY_PERFORMANCE_HANDOFF.md
@@ -171,33 +171,57 @@ the display. See `project_pos_cart_display_truth` in memory.
    windowing, so the lines come back — but only online. Ditto has no subqueries
    (`reference_ditto_dql_limits`), so eviction cannot join items to open tickets.
 
-10. **A recovered settling session only drives the banner.** `settlingTillTicketProvider`
-   is in-memory, so a reload / restart / re-created scope between Collect and Pay
-   used to leave a resumed ticket rendering as a plain cart — PENDING on screen,
-   no settling banner, and therefore no "Back to new sale" (the user's report:
-   "sometimes a resumed ticket has the button and sometimes not"). Fixed by
-   deriving the session from the row instead: `resumeSaleTicketFast` leaves
-   `ticketName` and the park `createdAt` alone and only park ever writes
-   `ticketName`, so a PENDING row carrying one *is* a resumed ticket —
-   `recoverSettlingTillTicketFromResumedCart` (`pos_payment_role_provider.dart`)
-   rebuilds a session from it, and `effectiveSettlingTillTicketProvider`
-   (`pos_cart_display_provider.dart`) prefers the live session, falling back to
-   recovery off the pending-cart rows the checkout already observes (cache, then
-   stream, honouring the pin) so no extra Ditto observer lands on the POS hot
-   path. Suppressed ids and ordering mode return null, so the banner cannot flash
-   back after a re-park or a completed sale.
+10. **Settling mode is now recovered from the cart row, not just memory.**
+   `settlingTillTicketProvider` is in-memory, so a reload / restart / re-created
+   scope between Collect and Pay used to leave a resumed ticket rendering as a
+   plain cart — PENDING on screen, no settling banner, no "Back to new sale", an
+   editable cart, and Pay bound to whatever the pending stream emitted (the
+   user's report: "sometimes a resumed ticket has the button and sometimes
+   not"). Fixed by deriving the session from the row: `resumeSaleTicketFast`
+   leaves `ticketName` and the park `createdAt` alone and only park ever writes
+   `ticketName`, so a PENDING row carrying one *is* a resumed ticket.
 
-   **Only the banner and its "Back to new sale" handler read the effective
-   provider.** The other four behaviours that the live session drives — Pay
-   binding (completion targets the ticket, not the collector's empty cart),
-   read-only cart, hidden Save-ticket, and mobile's `PopScope` auto-re-park — are
-   still keyed off `settlingTillTicketProvider` alone. So after a reload the
-   banner is back but the cart is editable again, and backing out of mobile
-   checkout will not auto-re-park. Deliberate: a wrong recovery is cosmetic in
-   the banner and charges the wrong transaction in Pay binding. Making recovery
-   feed all five is the follow-up; the race to test first is tapping "Back to new
-   sale" and re-adopting the ticket before Ditto reports it PARKED (the
-   suppressed-id guard is what stands in the way today).
+   - `recoverSettlingTillTicketFromResumedCart` + `settlingRecoveryCartRow`
+     (`pos_payment_role_provider.dart`) — pure, tested: the status/ticketName
+     rule, and the pin > cache > stream precedence with the suppression guard.
+   - `effectiveSettlingTillTicketProvider` (`pos_cart_display_provider.dart`) —
+     live session first, else recovery off the rows the checkout already
+     observes. It only reaches for `transactionByIdProvider` when a *pinned* sale
+     is held by neither the cache nor the stream, so the common POS path opens no
+     extra Ditto observer.
+
+   **Everything that asks "am I collecting a ticket?" reads the effective
+   provider** — banner, "Back to new sale", Pay binding (`_activeCheckoutTransaction`
+   in both checkouts, the completion redirect in `previewCart.dart`), read-only
+   cart, Save-ticket gating, customer-capture suppression, mobile's `PopScope`
+   re-park and its dispose re-park, and the "another ticket is mid-settle"
+   re-park in `tickets_list.dart`. **Only the hand-off paths read/write the live
+   provider**: Collect/Resume set it, completion / re-park / park clear it, and
+   QuickSellingView's two `ref.listen`s stay live on purpose (a recovered
+   session's ticket *is* the pending row, so the pending-cart listener is the one
+   that should prefill its customer, and the settling listener never fires for a
+   session that was rebuilt rather than handed over).
+
+   Two invariants hold this together, and a change to either needs re-testing:
+
+   - **Suppression before status.** Every completion / re-park / park path sets
+     `suppressedCartTransactionIdProvider` to the ticket id *before* its row
+     leaves PENDING; recovery returns null for a suppressed id. Without that, the
+     banner flashes back over the next sale — or worse, the unattended mobile
+     dispose re-park resurrects a completed sale as a ticket.
+   - **A recovered snapshot is not trusted for parking.** Collect forces
+     `ticketSnapshot.status = PENDING` at hand-off; a recovered snapshot is only
+     as fresh as the row it came from. Every re-park path (`SettlingTillTicket.recovered`
+     is the flag) re-reads the row before parking on it.
+
+   `posCartDisplayItemsProvider` is deliberately still keyed on the live session:
+   for a recovered session the ticket *is* the pending cart, so the normal merge
+   path already renders exactly those lines, and the hot cart provider keeps its
+   dependency graph unchanged.
+
+   Left open: recovery cannot name the sender (resume overwrites `agentId` with
+   the collector), so a recovered banner reads "sent by Staff". Storing the
+   sender on the row at park time would fix it.
 
 ## Diagnostics added this session
 
@@ -247,8 +271,9 @@ switched … discarding them`, the fingerprint of a stolen cart.
 - `flipper_models/test/optimistic_cart_reconcile_test.dart` — idempotent
   reconciliation; the settle ledger, including a cancelled add still settling.
 - `flipper_models/test/settling_till_ticket_recovery_test.dart` — which rows count
-  as a resumed till ticket: PENDING + `ticketName` recovers, a plain pending cart
-  / a parked or completed row does not.
+  as a resumed till ticket (PENDING + `ticketName` recovers; a plain pending cart
+  / a parked or completed row does not), and which row a session is rebuilt from
+  (pin > cache > stream, never a different cart, never a suppressed id).
 
 Known-flaky under parallel load: `pos_cart_tap_sync_perf_test.dart` (timing
 budget) and occasionally a suite failing at "loading". Both pass in isolation.

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.399.0+1756529886
+version: 1.400.0+1756529887
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.403.0.0
+  msix_version: 1.404.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.394.0+1756529881
+version: 1.395.0+1756529882
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.398.0.0
+  msix_version: 1.399.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.395.0+1756529882
+version: 1.396.0+1756529883
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.399.0.0
+  msix_version: 1.400.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.400.0+1756529887
+version: 1.401.0+1756529888
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.404.0.0
+  msix_version: 1.405.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.396.0+1756529883
+version: 1.397.0+1756529884
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.400.0.0
+  msix_version: 1.401.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.398.0+1756529885
+version: 1.399.0+1756529886
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.402.0.0
+  msix_version: 1.403.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/apps/flipper/pubspec.yaml
+++ b/apps/flipper/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 #  ios : 1.184
 # macos : 1.181
 
-version: 1.397.0+1756529884
+version: 1.398.0+1756529885
 
 
 
@@ -217,7 +217,7 @@ msix_config:
   identity_name: yegobox.yegoboxflipper
   # identity_name: yegobox.yegoboxflipper_6y224vs1dg1rr
   # Store package identity — pre-commit bumps Minor each time (1.185.0.0 → 1.186.0.0).
-  msix_version: 1.401.0.0
+  msix_version: 1.402.0.0
 
   publisher: CN=B0F98A1E-8AE8-4B2B-BD1B-F494D4F791AE
   # publisher: CN=B0F334A1E-8AET-4B2C-BD1B-F239D4F791AE

--- a/packages/flipper_dashboard/lib/PurchaseCodeForm.dart
+++ b/packages/flipper_dashboard/lib/PurchaseCodeForm.dart
@@ -26,6 +26,9 @@ class PurchaseCodeFormBloc extends FormBloc<String, String>
   final Future<bool>? sendDigitalReceiptFuture;
   final Customer? customer;
 
+  /// The CREDIT slice of [amount] — owed, not collected. See [finalizePayment].
+  final double creditTenderAmount;
+
   PurchaseCodeFormBloc({
     required this.customerNameController,
     required this.countryCodeController,
@@ -39,6 +42,7 @@ class PurchaseCodeFormBloc extends FormBloc<String, String>
     this.skipTransactionPersist = false,
     this.sendDigitalReceiptFuture,
     this.customer,
+    this.creditTenderAmount = 0.0,
   }) {
     addFieldBlocs(fieldBlocs: [purchaseCode]);
   }
@@ -64,6 +68,7 @@ class PurchaseCodeFormBloc extends FormBloc<String, String>
         deferPersistTaxReceiptFields: skipTransactionPersist,
         sendDigitalReceipt: sendDigitalReceipt,
         customer: customer,
+        creditTenderAmount: creditTenderAmount,
       );
 
       if (response.resultCd == "000") {

--- a/packages/flipper_dashboard/lib/QuickSellingView.dart
+++ b/packages/flipper_dashboard/lib/QuickSellingView.dart
@@ -271,7 +271,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
   /// its row has loaded), else the pending cart that owns the on-screen lines.
   ITransaction? _activeCheckoutTransaction() {
     final isExpense = ProxyService.box.isOrdering() ?? false;
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     if (settling != null && settling.transactionId.isNotEmpty) {
       final ticket =
           ref.read(transactionByIdProvider(settling.transactionId)).value ??
@@ -498,7 +498,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     final isExpense = ProxyService.box.isOrdering() ?? false;
     // Prefer the till ticket being settled so the header matches the settling
     // banner; otherwise show the operator's own pending cart.
-    final settling = ref.watch(settlingTillTicketProvider);
+    final settling = ref.watch(effectiveSettlingTillTicketProvider);
     final cachedPending =
         ref.watch(cachedPendingCartTransactionProvider(isExpense));
     final streamedPending = ref
@@ -558,7 +558,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
 
     final showSaveTicket =
         transaction != null &&
-        ref.watch(settlingTillTicketProvider) == null &&
+        ref.watch(effectiveSettlingTillTicketProvider) == null &&
         ref.watch(posCartDisplayItemsProvider.select((l) => l.isNotEmpty));
 
     return Padding(
@@ -842,7 +842,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
 
     // Customer details come from the queued ticket while settling; don't pop the
     // operator's own capture panel open in that case.
-    final settling = ref.read(settlingTillTicketProvider) != null;
+    final settling = ref.read(effectiveSettlingTillTicketProvider) != null;
     if (!settling && !_customerFieldsExpanded && mounted) {
       setState(() => _customerFieldsExpanded = true);
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1091,7 +1091,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     final endTime = DateTime.now().toUtc();
     final duration = endTime.difference(startTime).inSeconds;
 
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     // Prefer the settling ticket id when present — Pay may have been bound to a
     // stale pending-cart closure before ticketSnapshot loaded.
     final soldId =
@@ -1393,7 +1393,10 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
         );
         // While settling a till ticket, customer fields come from that ticket
         // (see settlingTillTicketProvider listen below) — not the collector's
-        // own pending cart.
+        // own pending cart. Live session only: a *recovered* session's ticket
+        // IS this pending row, so prefilling from it is both correct and the
+        // only prefill that will run (the listen below never fires for a
+        // session that was rebuilt rather than handed over).
         if (ref.read(settlingTillTicketProvider) != null) return;
         // After park/invalidate, Riverpod emits AsyncLoading that still carries
         // the previous parked row. Prefilling from that re-injects the handed-off
@@ -1504,7 +1507,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     // payment init, and — critically — completion) from that ticket rather than
     // the collector's own pending cart. Prefer the live row, else the snapshot
     // captured at Collect so Pay never binds to an empty pending twin.
-    final settlingTicket = ref.watch(settlingTillTicketProvider);
+    final settlingTicket = ref.watch(effectiveSettlingTillTicketProvider);
     final settlingTxn = settlingTicket == null
         ? null
         : (ref.watch(transactionByIdProvider(settlingTicket.transactionId)).value ??
@@ -2762,7 +2765,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     required bool isTransferMode,
     bool includePinnedHeader = true,
   }) {
-    final settling = ref.watch(settlingTillTicketProvider);
+    final settling = ref.watch(effectiveSettlingTillTicketProvider);
     final isSettling = settling != null;
     // View-only staff get a read-only cart table (no price/qty/delete controls).
     final readOnlyCart = isSettling || !ref.watch(canSellProvider);
@@ -3011,7 +3014,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     // it as a fixed sibling below QuickSellingView, so it is never literally
     // missing — just painted over). Force the scrollable fallback here so the
     // whole pane scrolls instead of overflowing.
-    final isSettling = ref.watch(settlingTillTicketProvider) != null;
+    final isSettling = ref.watch(effectiveSettlingTillTicketProvider) != null;
 
     final pinnedBottomColumn = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -3853,7 +3856,7 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     // cleared locally. parkSaleTicketFast mints the replacement pending cart
     // unawaited, so waiting on the pending stream leaves the parked ticket
     // rendered as the cart for as long as Ditto takes to reconcile.
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     if (settling != null) {
       // A settling session scopes posCartDisplayItemsProvider straight to the
       // ticket's item stream, which outranks every clear below.
@@ -3998,7 +4001,10 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     setState(() => _backToNewSaleBusy = true);
     final branchId = ProxyService.box.getBranchId() ?? '';
     try {
-      ITransaction? txn = settling.ticketSnapshot;
+      // Collect forces its snapshot to PENDING at hand-off; a recovered
+      // snapshot is only as fresh as the cart row it came from, so re-read the
+      // row before parking on it.
+      ITransaction? txn = settling.recovered ? null : settling.ticketSnapshot;
       try {
         txn ??= await ProxyService.getStrategy(Strategy.capella).getTransaction(
           id: settling.transactionId,

--- a/packages/flipper_dashboard/lib/QuickSellingView.dart
+++ b/packages/flipper_dashboard/lib/QuickSellingView.dart
@@ -2730,7 +2730,9 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
     required AsyncValue<ITransaction> transactionAsyncValue,
     required CoreViewModel model,
   }) {
-    final settling = ref.watch(settlingTillTicketProvider);
+    // Effective, not live: a resumed ticket whose in-memory settling session was
+    // dropped (reload / restart) must still show the banner and its way back.
+    final settling = ref.watch(effectiveSettlingTillTicketProvider);
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -3988,7 +3990,9 @@ class _QuickSellingViewState extends ConsumerState<QuickSellingView>
 
   Future<void> _backToNewSaleFromSettling() async {
     if (_backToNewSaleBusy) return;
-    final settling = ref.read(settlingTillTicketProvider);
+    // Matches the banner: works for a session rebuilt from the resumed ticket
+    // as well as a live Collect hand-off.
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     if (settling == null) return;
 
     setState(() => _backToNewSaleBusy = true);

--- a/packages/flipper_dashboard/lib/checkout.dart
+++ b/packages/flipper_dashboard/lib/checkout.dart
@@ -234,7 +234,7 @@ class CheckOutState extends ConsumerState<CheckOut>
   /// Prefer the till ticket being collected over the operator's pending cart
   /// so [PosDefaultView]'s Pay bar is wired to the same txn as the cart UI.
   ITransaction? _activeCheckoutTransaction(ITransaction? pending) {
-    final settling = ref.watch(settlingTillTicketProvider);
+    final settling = ref.watch(effectiveSettlingTillTicketProvider);
     if (settling != null && settling.transactionId.isNotEmpty) {
       final ticket =
           ref.watch(transactionByIdProvider(settling.transactionId)).value;
@@ -269,7 +269,7 @@ class CheckOutState extends ConsumerState<CheckOut>
   /// Action-path variant (Pay / ticket navigation): logs the redirect once per
   /// tap instead of on every rebuild.
   ITransaction? _resolveActiveCheckoutTransaction(ITransaction? pending) {
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     if (settling != null && settling.transactionId.isNotEmpty) {
       final ticket =
           ref.read(transactionByIdProvider(settling.transactionId)).value;
@@ -428,7 +428,7 @@ class CheckOutState extends ConsumerState<CheckOut>
 
     // Capture the settling ticket before clearing so we can also unwind the
     // resume pin/cache below.
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     // End any till-settling session so the operator's next cart is no longer
     // scoped to the collected ticket (posCartDisplayItemsProvider keys off it).
     ref.read(settlingTillTicketProvider.notifier).state = null;
@@ -511,7 +511,7 @@ class CheckOutState extends ConsumerState<CheckOut>
     // startCompleteTransactionFlow), not the operator's own pending cart passed
     // here. Validate the ticket's customer; if its row has not resolved yet,
     // defer to the flow rather than risk a false block.
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     final ITransaction target;
     if (settling != null && settling.transactionId.isNotEmpty) {
       final ticket =

--- a/packages/flipper_dashboard/lib/checkout.dart
+++ b/packages/flipper_dashboard/lib/checkout.dart
@@ -236,8 +236,13 @@ class CheckOutState extends ConsumerState<CheckOut>
   ITransaction? _activeCheckoutTransaction(ITransaction? pending) {
     final settling = ref.watch(effectiveSettlingTillTicketProvider);
     if (settling != null && settling.transactionId.isNotEmpty) {
+      // Snapshot fallback, like QuickSellingView: while the row provider is
+      // still loading, falling through would bind the Pay bar to the
+      // collector's own (usually empty) pending cart instead of the ticket.
+      // Identity is all this needs — completion re-reads the row by id.
       final ticket =
-          ref.watch(transactionByIdProvider(settling.transactionId)).value;
+          ref.watch(transactionByIdProvider(settling.transactionId)).value ??
+          settling.ticketSnapshot;
       if (ticket != null) return ticket;
     }
     return _cartDisplayOwnerTransaction(pending, listen: true) ?? pending;
@@ -272,7 +277,8 @@ class CheckOutState extends ConsumerState<CheckOut>
     final settling = ref.read(effectiveSettlingTillTicketProvider);
     if (settling != null && settling.transactionId.isNotEmpty) {
       final ticket =
-          ref.read(transactionByIdProvider(settling.transactionId)).value;
+          ref.read(transactionByIdProvider(settling.transactionId)).value ??
+          settling.ticketSnapshot;
       if (ticket != null) return ticket;
     }
     final owner = _cartDisplayOwnerTransaction(

--- a/packages/flipper_dashboard/lib/features/tickets/widgets/tickets_list.dart
+++ b/packages/flipper_dashboard/lib/features/tickets/widgets/tickets_list.dart
@@ -928,8 +928,11 @@ mixin TicketsListMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> {
       );
     }
 
-    // Already settling this ticket — just return to checkout.
-    final currentSettling = ref.read(settlingTillTicketProvider);
+    // Already settling this ticket — just return to checkout. Effective, not
+    // live: a session rebuilt from the cart (its in-memory hand-off was lost)
+    // still owns a PENDING ticket, and collecting a second one without
+    // re-parking it first would strand it off the till queue.
+    final currentSettling = ref.read(effectiveSettlingTillTicketProvider);
     if (currentSettling != null &&
         currentSettling.transactionId == ticket.id) {
       logHandoff('already-settling-close');
@@ -1046,7 +1049,10 @@ mixin TicketsListMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> {
     try {
       final branchId =
           settling.branchId ?? ProxyService.box.getBranchId() ?? '';
-      final txn = settling.ticketSnapshot ??
+      // Collect forces its snapshot to PENDING at hand-off, so it can be
+      // trusted; a recovered snapshot is only as fresh as the cart row it came
+      // from, so re-read before parking on it.
+      final txn = (settling.recovered ? null : settling.ticketSnapshot) ??
           await ProxyService.getStrategy(Strategy.capella).getTransaction(
             id: settling.transactionId,
             branchId: branchId,

--- a/packages/flipper_dashboard/lib/features/tickets/widgets/tickets_list.dart
+++ b/packages/flipper_dashboard/lib/features/tickets/widgets/tickets_list.dart
@@ -1052,13 +1052,41 @@ mixin TicketsListMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> {
       // Collect forces its snapshot to PENDING at hand-off, so it can be
       // trusted; a recovered snapshot is only as fresh as the cart row it came
       // from, so re-read before parking on it.
-      final txn = (settling.recovered ? null : settling.ticketSnapshot) ??
+      var txn = (settling.recovered ? null : settling.ticketSnapshot) ??
           await ProxyService.getStrategy(Strategy.capella).getTransaction(
             id: settling.transactionId,
             branchId: branchId,
           );
-      if (txn != null &&
-          (txn.status ?? '').toLowerCase() == PENDING.toLowerCase()) {
+      // Nothing locally: ask the server once before concluding anything. A
+      // ticket collected on another device may not have replicated here yet,
+      // and this hand-off now refuses to proceed on an unresolved row — so
+      // reading "not synced" as "not there" would block Collect outright.
+      txn ??= await ProxyService.getStrategy(Strategy.capella).getTransaction(
+        id: settling.transactionId,
+        branchId: branchId,
+        awaitRemote: true,
+      );
+      if (txn == null) {
+        // Unresolved is not the same as gone: this lookup is branch-scoped and
+        // local, and the re-read above means recovered sessions always reach
+        // it. Reporting success here would clear the session and let the caller
+        // collect the next ticket while this one stays PENDING and off the
+        // list — the exact orphan this method exists to prevent. Fail like the
+        // catch below so the hand-off aborts and the session survives.
+        talker.warning(
+          'Re-park previous settling ticket: ${settling.transactionId} did not '
+          'resolve — settling kept, hand-off aborted.',
+        );
+        if (mounted) {
+          showCustomSnackBarUtil(
+            context,
+            'Could not return the current ticket to the till. Try again.',
+            backgroundColor: Colors.red,
+          );
+        }
+        return false;
+      }
+      if ((txn.status ?? '').toLowerCase() == PENDING.toLowerCase()) {
         await ref.read(parkTransactionProvider.notifier).park(
               ticketName: pendingSaleCartReparkTicketName(
                 id: settling.transactionId,
@@ -1072,6 +1100,7 @@ mixin TicketsListMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> {
               customerId: txn.customerId,
             );
       }
+      // Parked, or confirmed to have left PENDING already: session finished.
       ref.read(settlingTillTicketProvider.notifier).state = null;
       clearPinnedPosCartTransactionIfWidget(
         ref,

--- a/packages/flipper_dashboard/lib/mixins/previewCart.dart
+++ b/packages/flipper_dashboard/lib/mixins/previewCart.dart
@@ -309,6 +309,14 @@ List<PaymentLineForSaleCompletion> paymentLinesForSaleCompletion(
       .toList();
 }
 
+/// The CREDIT slice of the tender — what the customer is taking on account.
+double sumCreditTenderFromPaymentMethods(List<Payment> paymentMethods) {
+  final sum = paymentLinesForSaleCompletion(paymentMethods)
+      .where((p) => p.method.toUpperCase() == 'CREDIT')
+      .fold<double>(0, (s, p) => s + p.amount);
+  return sum > _tenderEpsilon ? sum : 0.0;
+}
+
 double sumTenderFromPaymentMethods(List<Payment> paymentMethods) {
   final sum = paymentLinesForSaleCompletion(paymentMethods)
       .fold<double>(0, (s, p) => s + p.amount);
@@ -1880,6 +1888,12 @@ mixin PreviewCartMixin<T extends ConsumerStatefulWidget>
         return false;
       }
 
+      // A CREDIT line is not money in the drawer: it parks the sale as a loan,
+      // and [finalizePayment] must not read it as payment received.
+      final creditTenderAmount = sumCreditTenderFromPaymentMethods(
+        paymentMethods,
+      );
+
       // Prefer live customer TIN over a stale denormalized ticket field so
       // clearing TIN on the customer no longer forces a purchase-code dialog.
       Customer? liveCustomer = customer;
@@ -1921,6 +1935,7 @@ mixin PreviewCartMixin<T extends ConsumerStatefulWidget>
               transaction: transaction,
               context: context,
               customer: liveCustomer,
+              creditTenderAmount: creditTenderAmount,
             );
 
         // If user cancelled or dialog didn't complete, propagate false
@@ -1964,6 +1979,7 @@ mixin PreviewCartMixin<T extends ConsumerStatefulWidget>
           deferPersistTaxReceiptFields: true,
           sendDigitalReceipt: sendDigitalReceipt,
           customer: liveCustomer,
+          creditTenderAmount: creditTenderAmount,
           onSuccess: () {
             ref.read(payButtonStateProvider.notifier).stopLoading();
           },
@@ -2046,6 +2062,7 @@ mixin PreviewCartMixin<T extends ConsumerStatefulWidget>
     required Function onComplete,
     required BuildContext context,
     Customer? customer,
+    double creditTenderAmount = 0.0,
   }) async {
     if (transaction.customerTin != null &&
         transaction.customerTin!.isNotEmpty) {
@@ -2074,6 +2091,7 @@ mixin PreviewCartMixin<T extends ConsumerStatefulWidget>
               skipTransactionPersist: true,
               sendDigitalReceiptFuture: sendDigitalReceiptFuture,
               customer: customer,
+              creditTenderAmount: creditTenderAmount,
             ),
             child: Builder(
               builder: (context) {

--- a/packages/flipper_dashboard/lib/mixins/previewCart.dart
+++ b/packages/flipper_dashboard/lib/mixins/previewCart.dart
@@ -611,7 +611,7 @@ mixin PreviewCartMixin<T extends ConsumerStatefulWidget>
       // own pending cart. The desktop checkout is bound to
       // [pendingTransactionStreamProvider], which can hand completion the
       // operator's empty pending-cart id during the settling hand-off.
-      final settlingTicket = ref.read(settlingTillTicketProvider);
+      final settlingTicket = ref.read(effectiveSettlingTillTicketProvider);
       if (settlingTicket != null &&
           settlingTicket.transactionId.isNotEmpty &&
           settlingTicket.transactionId != transactionId) {

--- a/packages/flipper_dashboard/lib/mobile_checkout_screen.dart
+++ b/packages/flipper_dashboard/lib/mobile_checkout_screen.dart
@@ -327,9 +327,22 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
     }
   }
 
+  /// Live settling session, else one rebuilt from the resumed ticket itself.
+  ///
+  /// [settlingTillTicketProvider] is in-memory only, so a reload / restart
+  /// between Collect and Pay left this screen showing a resumed ticket with no
+  /// settling banner — and therefore no way back to a new sale.
+  SettlingTillTicket? _effectiveSettling(ITransaction txn) {
+    return ref.read(settlingTillTicketProvider) ??
+        recoverSettlingTillTicketFromResumedCart(txn);
+  }
+
   Future<void> _backToNewSaleFromSettling() async {
     if (_backToNewSaleBusy) return;
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = _effectiveSettling(
+      ref.read(transactionByIdProvider(_transactionId)).value ??
+          widget.transaction,
+    );
     if (settling == null) return;
 
     setState(() => _backToNewSaleBusy = true);
@@ -1150,6 +1163,10 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
                 .fold<double>(0, (s, i) => s + _displayQtyFor(i))
                 .round();
 
+            // The banner (and its "Back to new sale") stays put even when the
+            // in-memory settling session was lost — see [_effectiveSettling].
+            final bannerSettling = settling ?? _effectiveSettling(txn);
+
             var footerPrimaryLabel = !canCollect
                 ? 'Send to Till →'
                 : digitalEnabled && items.isNotEmpty
@@ -1183,7 +1200,8 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
                       Navigator.of(context).pop();
                     },
                   ),
-                  if (settling != null) _buildSettlingBanner(settling),
+                  if (bannerSettling != null)
+                    _buildSettlingBanner(bannerSettling),
                   Expanded(
                     child: ListView(
                       padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),

--- a/packages/flipper_dashboard/lib/mobile_checkout_screen.dart
+++ b/packages/flipper_dashboard/lib/mobile_checkout_screen.dart
@@ -120,14 +120,18 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
   void dispose() {
     final container = _container;
     if (container != null) {
-      clearPinnedPosCartTransactionContainer(container);
       // Never clear settling without re-parking — that left a PENDING till
       // ticket invisible on the Tickets list after a system back / swipe-away.
       // Effective, not live: read off the container's pending-cart providers
       // (never the route's own stale [widget.transaction]) so a completed sale
       // — which suppresses its id and drops the cache — cannot look like a
       // ticket that still needs parking.
+      //
+      // Read *before* dropping the pin: a recovered session resolves through
+      // [pinnedPosCartTransactionIdProvider], which is how this route holds its
+      // ticket, so clearing first can leave nothing to re-park.
       final settling = container.read(effectiveSettlingTillTicketProvider);
+      clearPinnedPosCartTransactionContainer(container);
       if (settling != null && !_settlingLeaveHandled) {
         unawaited(_reparkSettlingViaContainer(container, settling));
       }

--- a/packages/flipper_dashboard/lib/mobile_checkout_screen.dart
+++ b/packages/flipper_dashboard/lib/mobile_checkout_screen.dart
@@ -123,7 +123,11 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
       clearPinnedPosCartTransactionContainer(container);
       // Never clear settling without re-parking — that left a PENDING till
       // ticket invisible on the Tickets list after a system back / swipe-away.
-      final settling = container.read(settlingTillTicketProvider);
+      // Effective, not live: read off the container's pending-cart providers
+      // (never the route's own stale [widget.transaction]) so a completed sale
+      // — which suppresses its id and drops the cache — cannot look like a
+      // ticket that still needs parking.
+      final settling = container.read(effectiveSettlingTillTicketProvider);
       if (settling != null && !_settlingLeaveHandled) {
         unawaited(_reparkSettlingViaContainer(container, settling));
       }
@@ -138,7 +142,11 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
   ) async {
     try {
       final branchId = settling.branchId ?? _branchId;
-      final txn = settling.ticketSnapshot ??
+      // A recovered snapshot is only as fresh as the pending row it came from,
+      // and this path runs unattended (system back / swipe-away) — re-read the
+      // row so a sale that has since completed is never parked back into the
+      // till queue. Collect's own snapshot is forced PENDING at hand-off.
+      final txn = (settling.recovered ? null : settling.ticketSnapshot) ??
           await ProxyService.getStrategy(Strategy.capella).getTransaction(
             id: settling.transactionId,
             branchId: branchId,
@@ -195,7 +203,7 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
     // Bind the on-screen sale — settling snapshot first, else the same id as
     // this checkout route. Unconditionally reading the pending stream parked
     // the collector's empty twin while settling (desktop had the same bug).
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     final streamedPending =
         ref.read(pendingTransactionStreamProvider(isExpense: false)).value;
     final ITransaction txn;
@@ -327,22 +335,9 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
     }
   }
 
-  /// Live settling session, else one rebuilt from the resumed ticket itself.
-  ///
-  /// [settlingTillTicketProvider] is in-memory only, so a reload / restart
-  /// between Collect and Pay left this screen showing a resumed ticket with no
-  /// settling banner — and therefore no way back to a new sale.
-  SettlingTillTicket? _effectiveSettling(ITransaction txn) {
-    return ref.read(settlingTillTicketProvider) ??
-        recoverSettlingTillTicketFromResumedCart(txn);
-  }
-
   Future<void> _backToNewSaleFromSettling() async {
     if (_backToNewSaleBusy) return;
-    final settling = _effectiveSettling(
-      ref.read(transactionByIdProvider(_transactionId)).value ??
-          widget.transaction,
-    );
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     if (settling == null) return;
 
     setState(() => _backToNewSaleBusy = true);
@@ -634,7 +629,7 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
   }
 
   Future<void> _navigateToSuccessScreen({required double total}) async {
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     final wasSettling = settling != null;
     final items = await ref.read(
       transactionItemsStreamProvider(
@@ -842,7 +837,7 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
     String? providerPhone,
     Customer? attached,
   }) {
-    final settling = ref.read(settlingTillTicketProvider);
+    final settling = ref.read(effectiveSettlingTillTicketProvider);
     final settlingThisTicket =
         settling != null && settling.transactionId == txn.id;
     final candidates = settlingThisTicket
@@ -1015,7 +1010,7 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
       });
 
     final transactionAsync = ref.watch(transactionByIdProvider(_transactionId));
-    final settling = ref.watch(settlingTillTicketProvider);
+    final settling = ref.watch(effectiveSettlingTillTicketProvider);
     final customerPhone = ref.watch(customerPhoneNumberProvider);
     final digitalEnabled =
         ref.watch(isDigitalPaymentEnabledProvider).asData?.value ?? false;
@@ -1163,9 +1158,6 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
                 .fold<double>(0, (s, i) => s + _displayQtyFor(i))
                 .round();
 
-            // The banner (and its "Back to new sale") stays put even when the
-            // in-memory settling session was lost — see [_effectiveSettling].
-            final bannerSettling = settling ?? _effectiveSettling(txn);
 
             var footerPrimaryLabel = !canCollect
                 ? 'Send to Till →'
@@ -1200,8 +1192,7 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
                       Navigator.of(context).pop();
                     },
                   ),
-                  if (bannerSettling != null)
-                    _buildSettlingBanner(bannerSettling),
+                  if (settling != null) _buildSettlingBanner(settling),
                   Expanded(
                     child: ListView(
                       padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),

--- a/packages/flipper_dashboard/lib/mobile_checkout_screen.dart
+++ b/packages/flipper_dashboard/lib/mobile_checkout_screen.dart
@@ -151,8 +151,19 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
             id: settling.transactionId,
             branchId: branchId,
           );
-      if (txn != null &&
-          (txn.status ?? '').toLowerCase() == PENDING.toLowerCase()) {
+      if (txn == null) {
+        // Unresolved is not the same as gone. This lookup is branch-scoped and
+        // local, so it can miss a row that is still PENDING — and the re-read
+        // above means recovered sessions always reach it. Clearing here would
+        // strand the ticket: PENDING, off the till queue, on nobody's cart.
+        // Keep the session so the next POS surface can finish the re-park.
+        tv_talk.talker.warning(
+          'Mobile checkout dispose re-park: ticket ${settling.transactionId} '
+          'did not resolve — settling kept, not cleared.',
+        );
+        return;
+      }
+      if ((txn.status ?? '').toLowerCase() == PENDING.toLowerCase()) {
         await ParkTransactionService.park(
           ticketName: pendingSaleCartReparkTicketName(
             id: settling.transactionId,
@@ -166,6 +177,8 @@ class _MobileCheckoutScreenState extends ConsumerState<MobileCheckoutScreen>
           customerId: txn.customerId,
         );
       }
+      // Parked, or confirmed to have left PENDING already (completed, sent for
+      // review): either way this session is finished.
       container.read(settlingTillTicketProvider.notifier).state = null;
       _settlingLeaveHandled = true;
     } catch (e, st) {

--- a/packages/flipper_models/lib/helperModels/sale_completion_helpers.dart
+++ b/packages/flipper_models/lib/helperModels/sale_completion_helpers.dart
@@ -226,6 +226,62 @@ DerivedSaleCompletionState deriveSaleCompletionState({
   );
 }
 
+/// Receipt + park outcome for a single tender against a sale.
+class SalePaymentReceiptDecision {
+  const SalePaymentReceiptDecision({
+    required this.isFullyPaid,
+    required this.parksAsLoan,
+    required this.issueReceiptNow,
+  });
+
+  /// True when the sale total is covered by money actually collected (credit
+  /// never counts — it is still owed).
+  final bool isFullyPaid;
+
+  /// True when this tender leaves the ticket parked as a loan, either because
+  /// part of the sale went on CREDIT or because the customer underpaid.
+  final bool parksAsLoan;
+
+  /// True when this payment should produce the sale's receipt.
+  final bool issueReceiptNow;
+}
+
+/// Decides whether a tender issues the sale's receipt, and whether it parks the
+/// ticket as a loan.
+///
+/// A sale is receipted **once**, when it first leaves the till: the goods are
+/// handed over at that moment whether the customer paid in full, paid only part
+/// of it, or took the whole thing on credit — and stock leaves then too. So
+/// [SalePaymentReceiptDecision.issueReceiptNow] is true for every first
+/// completion, and false only for a later installment on a ticket that is
+/// already a loan ([transactionAlreadyLoan]): that sale was receipted when it
+/// happened, and the receipt can be reprinted from the transaction list.
+///
+/// [creditTenderAmount] is the CREDIT slice of [tenderAmount] — money the
+/// customer still owes, so it never counts toward
+/// [SalePaymentReceiptDecision.isFullyPaid]. [priorNonCreditPaid] is what the
+/// ticket already collected before this tender (a resumed loan's earlier
+/// installments); pass 0 for a fresh sale.
+SalePaymentReceiptDecision decideSalePaymentReceipt({
+  required bool transactionAlreadyLoan,
+  required double priorNonCreditPaid,
+  required double tenderAmount,
+  required double creditTenderAmount,
+  required double saleTotal,
+}) {
+  final credit = creditTenderAmount < 0 ? 0.0 : creditTenderAmount;
+  final nonCreditTenderRaw = tenderAmount - credit;
+  final nonCreditTender = nonCreditTenderRaw < 0 ? 0.0 : nonCreditTenderRaw;
+  final isFullyPaid =
+      (priorNonCreditPaid + nonCreditTender + _paymentEpsilon) >= saleTotal;
+  final parksAsLoan = credit > _paymentEpsilon || !isFullyPaid;
+  return SalePaymentReceiptDecision(
+    isFullyPaid: isFullyPaid,
+    parksAsLoan: parksAsLoan,
+    issueReceiptNow: !transactionAlreadyLoan,
+  );
+}
+
 /// Scales non-CREDIT rows so their sum does not exceed [saleTotal] (matches PreviewCartMixin).
 List<PaymentLineForSaleCompletion> normalizePaymentLinesToSaleTotal({
   required List<PaymentLineForSaleCompletion> paymentMethods,

--- a/packages/flipper_models/lib/mixins/TaxController.dart
+++ b/packages/flipper_models/lib/mixins/TaxController.dart
@@ -619,7 +619,9 @@ class TaxController<OBJ> {
           : 0.toStringAsFixed(2),
       items: transactionItems,
       cash: transaction.subTotal!,
-      received: transaction.cashReceived!,
+      // A credit / part-paid sale is receipted for the full amount, and its
+      // cashReceived can still be null at signing time — never bang it.
+      received: transaction.cashReceived ?? 0,
       payMode: paymentTypes.isEmpty
           ? "CASH".toPaymentType()
           : paymentTypes.last.paymentMethod?.toPaymentType() ?? "CASH",

--- a/packages/flipper_models/lib/providers/pos_cart_display_provider.dart
+++ b/packages/flipper_models/lib/providers/pos_cart_display_provider.dart
@@ -69,14 +69,21 @@ final posCartPendingTransactionIdProvider = Provider.family<String?, bool>((
 ///
 /// [settlingTillTicketProvider] lives only in memory, so anything that drops it
 /// mid-collection (a web reload, an app restart, a re-created provider scope)
-/// left the resumed ticket rendering as a plain cart — no settling banner and,
-/// with it, no "Back to new sale". Read this wherever the banner / return action
-/// is shown so both are always available for a resumed ticket; Pay binding and
-/// cart scoping still key off the live session only.
+/// left the resumed ticket rendering as a plain cart: no settling banner, no
+/// "Back to new sale", an editable cart, and Pay bound to whatever the pending
+/// stream happened to emit. Everything that asks "am I collecting a ticket?"
+/// reads this; only the hand-off paths themselves (Collect / Resume / re-park /
+/// completion) read and write [settlingTillTicketProvider] directly.
 ///
-/// Reads the pending-cart rows the checkout already observes (cache, then
-/// stream) rather than opening another [transactionByIdProvider] observer on
-/// the POS hot path.
+/// Resolution order mirrors [posCartPendingTransactionIdProvider]: a pin wins
+/// (mobile checkout and ticket resume pin their sale), then the cache, then the
+/// pending stream. The pinned row is looked up through [transactionByIdProvider]
+/// only when neither of those already holds it, so the common POS path opens no
+/// extra Ditto observer.
+///
+/// Returns null for a suppressed id — a just-completed or just-re-parked ticket
+/// is suppressed before its row leaves PENDING, and recovering from it would
+/// flash the banner back on (or, worse, re-park a sale that just completed).
 final effectiveSettlingTillTicketProvider = Provider<SettlingTillTicket?>((ref) {
   final live = ref.watch(settlingTillTicketProvider);
   if (live != null) return live;
@@ -84,25 +91,31 @@ final effectiveSettlingTillTicketProvider = Provider<SettlingTillTicket?>((ref) 
   // Purchases (ordering mode) never go through the till queue.
   if (_posCartIsExpense()) return null;
 
+  final cached = ref.watch(cachedPendingCartTransactionProvider(false));
+  final streamed = ref
+      .watch(pendingTransactionStreamProvider(isExpense: false))
+      .asData
+      ?.value;
   final pinnedId = ref.watch(pinnedPosCartTransactionIdProvider);
-  final candidates = <ITransaction?>[
-    ref.watch(cachedPendingCartTransactionProvider(false)),
-    ref.watch(pendingTransactionStreamProvider(isExpense: false)).asData?.value,
-  ];
-  final row = candidates.firstWhere(
-    (t) =>
-        t != null &&
-        t.id.isNotEmpty &&
-        (pinnedId == null || pinnedId.isEmpty || t.id == pinnedId),
-    orElse: () => null,
+
+  // Only when the pinned sale is held by neither of the rows the checkout is
+  // already observing — so the common POS path opens no extra Ditto observer.
+  final needsLookup = pinnedId != null &&
+      pinnedId.isNotEmpty &&
+      cached?.id != pinnedId &&
+      streamed?.id != pinnedId;
+
+  return recoverSettlingTillTicketFromResumedCart(
+    settlingRecoveryCartRow(
+      cached: cached,
+      streamed: streamed,
+      pinnedRow: needsLookup
+          ? ref.watch(transactionByIdProvider(pinnedId)).asData?.value
+          : null,
+      pinnedId: pinnedId,
+      suppressedId: ref.watch(suppressedCartTransactionIdProvider),
+    ),
   );
-  if (row == null) return null;
-
-  // A just-settled / just-re-parked ticket is suppressed before its row leaves
-  // PENDING; recovering from it would flash the banner back on.
-  if (ref.watch(suppressedCartTransactionIdProvider) == row.id) return null;
-
-  return recoverSettlingTillTicketFromResumedCart(row);
 });
 
 /// Transaction id used to merge Ditto line items with optimistic ghosts.

--- a/packages/flipper_models/lib/providers/pos_cart_display_provider.dart
+++ b/packages/flipper_models/lib/providers/pos_cart_display_provider.dart
@@ -64,6 +64,47 @@ final posCartPendingTransactionIdProvider = Provider.family<String?, bool>((
   return optId;
 });
 
+/// Settling session for the cart on screen: the live hand-off when one is set,
+/// else one rebuilt from the resumed ticket itself.
+///
+/// [settlingTillTicketProvider] lives only in memory, so anything that drops it
+/// mid-collection (a web reload, an app restart, a re-created provider scope)
+/// left the resumed ticket rendering as a plain cart — no settling banner and,
+/// with it, no "Back to new sale". Read this wherever the banner / return action
+/// is shown so both are always available for a resumed ticket; Pay binding and
+/// cart scoping still key off the live session only.
+///
+/// Reads the pending-cart rows the checkout already observes (cache, then
+/// stream) rather than opening another [transactionByIdProvider] observer on
+/// the POS hot path.
+final effectiveSettlingTillTicketProvider = Provider<SettlingTillTicket?>((ref) {
+  final live = ref.watch(settlingTillTicketProvider);
+  if (live != null) return live;
+
+  // Purchases (ordering mode) never go through the till queue.
+  if (_posCartIsExpense()) return null;
+
+  final pinnedId = ref.watch(pinnedPosCartTransactionIdProvider);
+  final candidates = <ITransaction?>[
+    ref.watch(cachedPendingCartTransactionProvider(false)),
+    ref.watch(pendingTransactionStreamProvider(isExpense: false)).asData?.value,
+  ];
+  final row = candidates.firstWhere(
+    (t) =>
+        t != null &&
+        t.id.isNotEmpty &&
+        (pinnedId == null || pinnedId.isEmpty || t.id == pinnedId),
+    orElse: () => null,
+  );
+  if (row == null) return null;
+
+  // A just-settled / just-re-parked ticket is suppressed before its row leaves
+  // PENDING; recovering from it would flash the banner back on.
+  if (ref.watch(suppressedCartTransactionIdProvider) == row.id) return null;
+
+  return recoverSettlingTillTicketFromResumedCart(row);
+});
+
 /// Transaction id used to merge Ditto line items with optimistic ghosts.
 final posCartMergeTxnIdProvider = Provider.family<String, bool>((ref, isExpense) {
   final pendingId = ref.watch(posCartPendingTransactionIdProvider(isExpense));

--- a/packages/flipper_models/lib/providers/pos_payment_role_provider.dart
+++ b/packages/flipper_models/lib/providers/pos_payment_role_provider.dart
@@ -165,6 +165,50 @@ class SettlingTillTicket {
   final ITransaction? ticketSnapshot;
 }
 
+/// Short human reference for a ticket — `reference` when set, else a truncated
+/// transaction id. Mirrors what the tickets list and the settling banner show.
+String settlingTicketDisplayRef(ITransaction ticket) {
+  final reference = ticket.reference?.trim();
+  if (reference != null && reference.isNotEmpty) return reference.toUpperCase();
+  final id = ticket.id;
+  if (id.length >= 6) return id.substring(0, 6).toUpperCase();
+  return id.toUpperCase();
+}
+
+/// Rebuilds a settling session from a resumed till ticket still sitting in the
+/// cart.
+///
+/// [settlingTillTicketProvider] is in-memory only, so a reload / restart / route
+/// rebuild between Collect and Pay dropped it while the ticket stayed PENDING on
+/// screen — the checkout then rendered the ticket's lines with no settling
+/// banner and no way back to a new sale. Resume keeps `ticketName` (only park
+/// writes it, and a freshly minted pending cart never has one), so a PENDING row
+/// carrying one is a resumed ticket and can seed a session again.
+///
+/// `createdAt` is the park stamp ([parkSaleTicketFast] writes it, resume leaves
+/// it alone), so the banner's elapsed time stays honest.
+SettlingTillTicket? recoverSettlingTillTicketFromResumedCart(
+  ITransaction? ticket,
+) {
+  if (ticket == null || ticket.id.isEmpty) return null;
+  if ((ticket.status ?? '').toLowerCase() != PENDING.toLowerCase()) return null;
+  final ticketName = ticket.ticketName?.trim() ?? '';
+  if (ticketName.isEmpty) return null;
+
+  return SettlingTillTicket(
+    transactionId: ticket.id,
+    displayRef: settlingTicketDisplayRef(ticket),
+    // The sender is not recoverable from the row — resume overwrites `agentId`
+    // with the collector — so fall back to the same generic name Collect uses.
+    creatorName: 'Staff',
+    createdAt: ticket.createdAt ?? ticket.lastTouched ?? DateTime.now(),
+    branchId: ticket.branchId,
+    ticketName: ticketName,
+    ticketNote: ticket.note,
+    ticketSnapshot: ticket,
+  );
+}
+
 /// Non-null while a Manager/Admin is settling a queued till ticket in the cart.
 final settlingTillTicketProvider =
     StateProvider<SettlingTillTicket?>((ref) => null);

--- a/packages/flipper_models/lib/providers/pos_payment_role_provider.dart
+++ b/packages/flipper_models/lib/providers/pos_payment_role_provider.dart
@@ -138,6 +138,7 @@ class SettlingTillTicket {
     this.ticketNote,
     this.seedItems = const <TransactionItem>[],
     this.ticketSnapshot,
+    this.recovered = false,
   });
 
   final String transactionId;
@@ -163,6 +164,16 @@ class SettlingTillTicket {
   /// this sale before [transactionByIdProvider] resolves (avoids completing
   /// the collector's empty pending cart).
   final ITransaction? ticketSnapshot;
+
+  /// True when this session was rebuilt from the cart row itself
+  /// ([recoverSettlingTillTicketFromResumedCart]) instead of being handed over
+  /// by Collect/Resume.
+  ///
+  /// Collect forces `ticketSnapshot.status = PENDING` at hand-off, so re-park
+  /// paths can trust it; a recovered snapshot is only as fresh as the pending
+  /// row it came from, so **re-read the row before parking on it** — parking a
+  /// sale that has since completed would resurrect it as a ticket.
+  final bool recovered;
 }
 
 /// Short human reference for a ticket — `reference` when set, else a truncated
@@ -206,7 +217,41 @@ SettlingTillTicket? recoverSettlingTillTicketFromResumedCart(
     ticketName: ticketName,
     ticketNote: ticket.note,
     ticketSnapshot: ticket,
+    recovered: true,
   );
+}
+
+/// The cart row a settling session may be rebuilt from, or null.
+///
+/// Pure so the precedence and the suppression guard can be tested without Ditto.
+/// Mirrors [posCartPendingTransactionIdProvider]: a pin wins outright (mobile
+/// checkout and ticket resume pin their sale, and while a pin is held the cache
+/// / stream may still be pointing at the operator's other cart), otherwise the
+/// cache is preferred over the stream. [pinnedRow] is the pinned id looked up
+/// directly — only needed when neither [cached] nor [streamed] holds it.
+///
+/// A suppressed id yields null: a just-completed or just-re-parked ticket is
+/// suppressed *before* its row leaves PENDING, and rebuilding a session from it
+/// would re-show the banner over the next sale, or re-park a completed one.
+ITransaction? settlingRecoveryCartRow({
+  ITransaction? cached,
+  ITransaction? streamed,
+  ITransaction? pinnedRow,
+  String? pinnedId,
+  String? suppressedId,
+}) {
+  if (pinnedId != null && pinnedId.isNotEmpty) {
+    if (suppressedId == pinnedId) return null;
+    for (final candidate in [cached, streamed, pinnedRow]) {
+      if (candidate != null && candidate.id == pinnedId) return candidate;
+    }
+    return null;
+  }
+
+  final row = (cached != null && cached.id.isNotEmpty) ? cached : streamed;
+  if (row == null || row.id.isEmpty) return null;
+  if (suppressedId != null && suppressedId == row.id) return null;
+  return row;
 }
 
 /// Non-null while a Manager/Admin is settling a queued till ticket in the cart.

--- a/packages/flipper_models/lib/sync/capella/mixins/bar_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/bar_mixin.dart
@@ -1,3 +1,4 @@
+import 'package:flipper_models/sync/utils/cart_line_doc_cache.dart';
 import 'dart:async';
 
 import 'package:flipper_models/SyncStrategy.dart';
@@ -574,6 +575,7 @@ mixin CapellaBarMixin implements BarInterface {
       'INSERT INTO transaction_items DOCUMENTS (:doc)',
       arguments: {'doc': doc},
     );
+    cartLineDocCache.forget(transactionId);
     await _adjustSubtotal(
       transactionId,
       line.price.toDouble() * line.qty.toDouble(),
@@ -613,6 +615,7 @@ mixin CapellaBarMixin implements BarInterface {
         'lastTouched': nowIso,
       },
     );
+    cartLineDocCache.forget(transactionId);
     final newTotal = line.price.toDouble() * clamped.toDouble();
     await _adjustSubtotal(transactionId, newTotal - oldTotal);
   }
@@ -663,6 +666,7 @@ mixin CapellaBarMixin implements BarInterface {
       'DELETE FROM transaction_items WHERE _id = :id OR id = :id',
       arguments: {'id': lineId},
     );
+    cartLineDocCache.forget(transactionId);
     await _adjustSubtotal(transactionId, -lineTotal);
   }
 

--- a/packages/flipper_models/lib/sync/capella/mixins/delete_operations_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/delete_operations_mixin.dart
@@ -1,3 +1,4 @@
+import 'package:flipper_models/sync/utils/cart_line_doc_cache.dart';
 import 'package:flipper_services/proxy.dart';
 import 'package:flipper_models/sync/interfaces/delete_operations_interface.dart';
 import 'package:flipper_models/db_model_export.dart';
@@ -73,6 +74,10 @@ mixin CapellaDeleteOperationsMixin implements DeleteOperationsInterface {
       talker.info('Deleted transaction item $id from Ditto');
 
       final txnId = transactionId ?? transactionItemId.transactionId;
+      // The add path caches this cart's lines; a deleted row left cached makes
+      // the next tap on that product update a document that no longer exists,
+      // so the line never comes back.
+      cartLineDocCache.forget(txnId ?? '');
       if (txnId != null) {
         final contrib =
             transactionItemId.price.toDouble() * transactionItemId.qty.toDouble();

--- a/packages/flipper_models/lib/sync/capella/mixins/transaction_item_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/transaction_item_mixin.dart
@@ -671,6 +671,13 @@ mixin CapellaTransactionItemMixin implements TransactionItemInterface {
         // add path's cache honest whatever changed the rows — a delete, a qty
         // edit, bar mode, or another device — instead of relying on every
         // mutation site remembering to invalidate.
+        //
+        // This query is filtered (active / doneWithTransaction / branchId), so
+        // what it reports is not always the whole cart, and [seed] replaces the
+        // entry wholesale. The add path therefore treats a cache *miss* as
+        // unproven and confirms it against the store before inserting — see
+        // saveTransactionItem — so an omitted row can no longer become a
+        // duplicate line for the same variant.
         if (transactionId != null && transactionId.isNotEmpty) {
           cartLineDocCache.seed(
             transactionId: transactionId,

--- a/packages/flipper_models/lib/sync/capella/mixins/transaction_item_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/transaction_item_mixin.dart
@@ -1,3 +1,4 @@
+import 'package:flipper_models/sync/utils/cart_line_doc_cache.dart';
 import 'dart:async';
 
 import 'package:flipper_models/SyncStrategy.dart';
@@ -68,6 +69,7 @@ mixin CapellaTransactionItemMixin implements TransactionItemInterface {
         "INSERT INTO transaction_items DOCUMENTS (:doc)",
         arguments: {'doc': docMap},
       );
+      cartLineDocCache.forget(item.transactionId ?? '');
       final lineTotal =
           item.totAmt?.toDouble() ??
           (item.price.toDouble() * item.qty.toDouble());
@@ -665,6 +667,18 @@ mixin CapellaTransactionItemMixin implements TransactionItemInterface {
             talker.error('Error converting transaction item: $e');
           }
         }
+        // Ditto has just told us what this cart holds. Adopting it keeps the
+        // add path's cache honest whatever changed the rows — a delete, a qty
+        // edit, bar mode, or another device — instead of relying on every
+        // mutation site remembering to invalidate.
+        if (transactionId != null && transactionId.isNotEmpty) {
+          cartLineDocCache.seed(
+            transactionId: transactionId,
+            rows: queryResult.items.map(
+              (doc) => Map<String, dynamic>.from(doc.value),
+            ),
+          );
+        }
         talker.debug(
           'transactionItemsStreams onChange txn=${transactionId ?? '-'}: '
           '${_summarizeItems(items)}',
@@ -770,6 +784,9 @@ mixin CapellaTransactionItemMixin implements TransactionItemInterface {
           )
           .join(', ');
 
+      // The add path caches this cart's lines by variant; a row changed here
+      // (qty stepper, discount, refund flag) must not stay cached as it was.
+      cartLineDocCache.forgetAll();
       final query =
           'UPDATE transaction_items SET $setClause WHERE _id = :id OR id = :id';
       final arguments = Map<String, dynamic>.from(updates);

--- a/packages/flipper_models/lib/sync/capella/mixins/transaction_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/transaction_mixin.dart
@@ -86,7 +86,6 @@ const int _pendingCartEmptySettleMs = 750;
 /// Per-cart `itemSeq` high-water marks, so adding a line is O(1) instead of
 /// asking the store how many lines the cart already has.
 final CartLineSeqCache _cartLineSeqCache = CartLineSeqCache();
-final CartLineDocCache _cartLineDocCache = CartLineDocCache();
 
 mixin CapellaTransactionMixin implements TransactionInterface {
   Repository get repository;
@@ -1590,19 +1589,19 @@ mixin CapellaTransactionMixin implements TransactionInterface {
       // all N rows after it, and replication were all queued on the same store.
       // The cart's own lines are ours: seed once, then answer from memory.
       final lookupSw = Stopwatch()..start();
-      if (!_cartLineDocCache.isSeeded(pendingTransaction.id)) {
+      if (!cartLineDocCache.isSeeded(pendingTransaction.id)) {
         final seed = await ditto.store.execute(
           'SELECT _id, id, qty, variantId, remainingStock, supplyPriceAtSale, '
           'supplyPrice, dcRt, taxTyCd, taxPercentage '
           'FROM transaction_items WHERE transactionId = :transactionId',
           arguments: {'transactionId': pendingTransaction.id},
         );
-        _cartLineDocCache.seed(
+        cartLineDocCache.seed(
           transactionId: pendingTransaction.id,
           rows: seed.items.map((d) => Map<String, dynamic>.from(d.value)),
         );
       }
-      final existingLine = _cartLineDocCache.lineFor(
+      final existingLine = cartLineDocCache.lineFor(
         transactionId: pendingTransaction.id,
         variantId: variation.id,
       );
@@ -1678,7 +1677,7 @@ mixin CapellaTransactionMixin implements TransactionInterface {
         );
 
         upsertMs = upsertSw.elapsedMilliseconds;
-        _cartLineDocCache.record(
+        cartLineDocCache.record(
           transactionId: pendingTransaction.id,
           variantId: variation.id,
           row: {
@@ -1797,7 +1796,7 @@ mixin CapellaTransactionMixin implements TransactionInterface {
           arguments: {'doc': docMap},
         );
         upsertMs = insertSw.elapsedMilliseconds;
-        _cartLineDocCache.record(
+        cartLineDocCache.record(
           transactionId: pendingTransaction.id,
           variantId: variation.id,
           row: {
@@ -1915,7 +1914,7 @@ mixin CapellaTransactionMixin implements TransactionInterface {
 
       // This writes a line behind the add path's cache; leaving the cached copy
       // in place would let the next tap compute a qty from a stale row.
-      _cartLineDocCache.forget(d['transactionId']?.toString() ?? '');
+      cartLineDocCache.forget(d['transactionId']?.toString() ?? '');
 
       final double oldQtyFromDb = (d['qty'] as num).toDouble();
       // incrementQty with null qty means +1 (see TransactionItemTable / brick mixin).
@@ -2359,7 +2358,7 @@ mixin CapellaTransactionMixin implements TransactionInterface {
       // An absolute subtotal supersedes any gathered cart delta; applying the
       // delta afterwards would add cart lines twice to a finished total.
       _discardPendingSubtotalDelta(targetId);
-      _cartLineDocCache.forget(targetId);
+      cartLineDocCache.forget(targetId);
     }
     addUpdate('subTotal', resolvedSubTotal);
     addUpdate('taxAmount', transaction?.taxAmount);
@@ -2694,7 +2693,7 @@ mixin CapellaTransactionMixin implements TransactionInterface {
           arguments: {'ids': chunk},
         );
         for (final id in chunk) {
-          _cartLineDocCache.forget(id.toString());
+          cartLineDocCache.forget(id.toString());
         }
         await txn.execute(
           'DELETE FROM transactions WHERE id IN (:ids)',
@@ -2956,7 +2955,7 @@ mixin CapellaTransactionMixin implements TransactionInterface {
     // Past the guard: this park is writing an absolute subtotal, so a gathered
     // cart delta must not land on top of it afterwards.
     _discardPendingSubtotalDelta(targetId);
-    _cartLineDocCache.forget(targetId);
+    cartLineDocCache.forget(targetId);
 
     // POS tickets list filters `isOriginalTransaction = true`; ensure park
     // always lands in that set (kitchen already skips this check).
@@ -3152,7 +3151,7 @@ mixin CapellaTransactionMixin implements TransactionInterface {
         'DELETE FROM transaction_items WHERE transactionId = :id',
         arguments: {'id': transaction.id},
       );
-      _cartLineDocCache.forget(transaction.id);
+      cartLineDocCache.forget(transaction.id);
 
       talker.info(
         'Successfully deleted transaction and items: ${transaction.id}',
@@ -3860,6 +3859,10 @@ mixin CapellaTransactionMixin implements TransactionInterface {
         'UPDATE transaction_items SET transactionId = :toId WHERE transactionId = :fromId',
         arguments: {'toId': to.id, 'fromId': from.id},
       );
+      // Lines just moved carts: both the cart that lost them and the one that
+      // gained them are stale in the add path's cache.
+      cartLineDocCache.forget(from.id);
+      cartLineDocCache.forget(to.id);
 
       // Move payment records
       await ditto.store.execute(

--- a/packages/flipper_models/lib/sync/capella/mixins/transaction_mixin.dart
+++ b/packages/flipper_models/lib/sync/capella/mixins/transaction_mixin.dart
@@ -1601,10 +1601,44 @@ mixin CapellaTransactionMixin implements TransactionInterface {
           rows: seed.items.map((d) => Map<String, dynamic>.from(d.value)),
         );
       }
-      final existingLine = cartLineDocCache.lineFor(
+      var existingLine = cartLineDocCache.lineFor(
         transactionId: pendingTransaction.id,
         variantId: variation.id,
       );
+      // A miss is not proof the line is absent. The cart's own observer also
+      // seeds this cache (`transactionItemsStreams`), and that query is
+      // *filtered* — active, doneWithTransaction and branchId — so a line the
+      // filter excludes is dropped from a cache that claims to be complete. A
+      // line another device just added to the same cart is missing for the same
+      // reason. Inserting on a false miss writes a second row for the variant.
+      // One indexed read, only when the variant is not cached — never on the
+      // repeat tap this cache exists for. Unfiltered, to match the seed above.
+      if (existingLine == null) {
+        final confirm = await ditto.store.execute(
+          'SELECT _id, id, qty, variantId, remainingStock, supplyPriceAtSale, '
+          'supplyPrice, dcRt, taxTyCd, taxPercentage '
+          'FROM transaction_items '
+          'WHERE transactionId = :transactionId AND variantId = :variantId '
+          'LIMIT 1',
+          arguments: {
+            'transactionId': pendingTransaction.id,
+            'variantId': variation.id,
+          },
+        );
+        if (confirm.items.isNotEmpty) {
+          existingLine = Map<String, dynamic>.from(confirm.items.first.value);
+          talker.warning(
+            'cartLineDocCache miss for variant ${variation.id} on cart '
+            '${pendingTransaction.id} was wrong — the store has the line; '
+            'updating it instead of inserting a duplicate.',
+          );
+          cartLineDocCache.record(
+            transactionId: pendingTransaction.id,
+            variantId: variation.id,
+            row: existingLine,
+          );
+        }
+      }
       final lookupMs = lookupSw.elapsedMilliseconds;
       var seqMs = 0;
       var upsertMs = 0;

--- a/packages/flipper_models/lib/sync/utils/cart_line_doc_cache.dart
+++ b/packages/flipper_models/lib/sync/utils/cart_line_doc_cache.dart
@@ -18,6 +18,15 @@
 /// than raising its qty. Completion reads the persisted lines back and
 /// reconciles, and money is computed from those rows, so the exposure is a
 /// duplicated display line — the same class of exposure the seq cache accepts.
+/// The cache the cart add path reads and every cart mutation must keep honest.
+///
+/// Shared, because the paths that change a cart line live in five different
+/// mixins: the add path here, the qty stepper, bar-mode tabs, line deletes and
+/// the move-lines-between-carts path. A private instance meant a delete could
+/// leave a row cached that no longer exists — the next tap on that product then
+/// updated a deleted document and the line never came back.
+final CartLineDocCache cartLineDocCache = CartLineDocCache();
+
 class CartLineDocCache {
   CartLineDocCache({this.maxTrackedCarts = 8}) : assert(maxTrackedCarts > 0);
 

--- a/packages/flipper_models/lib/view_models/mixins/_transaction.dart
+++ b/packages/flipper_models/lib/view_models/mixins/_transaction.dart
@@ -76,6 +76,10 @@ mixin TransactionMixinOld {
 
     /// When set (e.g. POS checkout), skips [resolveCustomerForReceipt] DB lookup.
     Customer? customer,
+
+    /// The CREDIT slice of [amount] — money the customer still owes. It parks
+    /// the sale as a loan and never counts as payment received.
+    double creditTenderAmount = 0.0,
   }) async {
     try {
       final businessId = ProxyService.box.getBusinessId();
@@ -99,28 +103,42 @@ mixin TransactionMixinOld {
         extra: 'tax_enabled=$taxEnabled has_ebm=${ebm != null}',
       );
 
+      // A sale is receipted once, when it first leaves the till: the goods go
+      // out and stock is deducted then, whether the customer paid in full,
+      // underpaid, or took the lot on CREDIT. Both of those last two park the
+      // ticket as a loan, and both still get the receipt for the FULL sale.
+      // Only a later installment on an already-parked loan skips it — that sale
+      // was receipted when it happened (reprint it from the transaction list).
       final isLoan = transaction.isLoan == true;
-      final isFullyPaid =
-          ((transaction.cashReceived ?? 0) + amount) >=
-          (transaction.subTotal ?? 0);
-      final shouldComplete = !isLoan || isFullyPaid;
+      final receiptDecision = decideSalePaymentReceipt(
+        transactionAlreadyLoan: isLoan,
+        priorNonCreditPaid: transaction.cashReceived ?? 0,
+        tenderAmount: amount,
+        creditTenderAmount: creditTenderAmount,
+        saleTotal: transaction.subTotal ?? 0,
+      );
+      final isFullyPaid = receiptDecision.isFullyPaid;
+      final parksAsLoan = receiptDecision.parksAsLoan;
+      final issueReceiptNow = receiptDecision.issueReceiptNow;
 
       // Ticket Review + Handover workflow (opt-in per business): when enabled, a
       // fully-paid sale is only FLAGGED paid at Pay — payment is recorded and the
       // caller's onComplete persists status `pendingReview`. Tax signing, RRA
       // receipt, fiscal counters and stock deduction are ALL deferred to the
       // Stock Manager's handover step (see [finalizeSaleForHandover] + the
-      // handover action). Loan / partial / parked sales are never deferred and
-      // behave exactly as today. When the setting is OFF this branch is skipped
-      // and completion is byte-identical to before.
+      // handover action). A sale that parks as a loan — underpaid, or any part
+      // of it on CREDIT — is never deferred: it is signed, receipted and its
+      // stock deducted right here, at the till. When the setting is OFF this
+      // branch is skipped entirely.
       final ticketReviewWorkflowEnabled =
           ProxyService.settings.enableTicketReviewWorkflow;
       final deferForReview =
-          ticketReviewWorkflowEnabled && !isLoan && shouldComplete && isFullyPaid;
+          ticketReviewWorkflowEnabled && !isLoan && !parksAsLoan;
       talker.debug(
         '[ticket_review_workflow] finalizePayment: '
         'ticketReviewWorkflowEnabled=$ticketReviewWorkflowEnabled '
-        'isLoan=$isLoan isFullyPaid=$isFullyPaid deferForReview=$deferForReview '
+        'isLoan=$isLoan isFullyPaid=$isFullyPaid parksAsLoan=$parksAsLoan '
+        'deferForReview=$deferForReview '
         'transactionId=${transaction.id}',
       );
       if (deferForReview) {
@@ -191,15 +209,14 @@ mixin TransactionMixinOld {
         );
       }
 
-      // Skip receipt generation entirely for loan tickets — additional payments
-      // on resumed loans should never trigger a receipt.
+      // Sign and print for every first completion, including one that parks as
+      // a loan — the supply happened now, so it is fiscalised now. Additional
+      // payments on a resumed loan re-sign nothing.
       if (taxEnabled &&
           ebm?.taxServerUrl != null &&
           hasUser &&
           !isTaxServiceStoped &&
-          !isLoan &&
-          shouldComplete &&
-          isFullyPaid) {
+          issueReceiptNow) {
         ProxyService.box.writeString(
           key: "getServerUrl",
           value: ebm!.taxServerUrl!,
@@ -382,10 +399,10 @@ mixin TransactionMixinOld {
 
         // Branch is not EBM-registered (or EBM/tax checks above failed for
         // another reason): there's no RRA-signed receipt to print, but the
-        // sale is still a completed sale, so print a plain, non-fiscal
-        // receipt instead. Only for a real, fully paid sale completion —
-        // never for partial loan payments, which never got a receipt either.
-        if (!isLoan && shouldComplete && isFullyPaid && !sendDigitalReceipt) {
+        // sale still happened, so print a plain, non-fiscal receipt instead.
+        // It covers the full sale, so a credit or part-paid ticket gets one
+        // too; only later installments on a resumed loan skip it.
+        if (issueReceiptNow && !sendDigitalReceipt) {
           // Not awaited: building this PDF and pushing it at a printer took
           // 15.8s of a 28.7s Pay, and it ran *before* onComplete, so the cart
           // stayed on screen and the spinner kept turning until the printer was
@@ -438,9 +455,7 @@ mixin TransactionMixinOld {
         );
         return RwApiResponse(
           resultCd: "001",
-          resultMsg: isLoan && !isFullyPaid
-              ? "Payment recorded"
-              : "Sale completed",
+          resultMsg: parksAsLoan ? "Payment recorded" : "Sale completed",
         );
       }
 

--- a/packages/flipper_models/test/cart_line_doc_cache_test.dart
+++ b/packages/flipper_models/test/cart_line_doc_cache_test.dart
@@ -30,6 +30,28 @@ void main() {
         'doc-2');
   });
 
+  test('seeding replaces — a partial snapshot silently drops other lines', () {
+    cache.seed(transactionId: 'txn-1', rows: [
+      {'variantId': 'v1', '_id': 'doc-1', 'qty': 3},
+      {'variantId': 'v2', '_id': 'doc-2', 'qty': 1},
+    ]);
+
+    // What the cart's observer supplies: its query is filtered (active /
+    // doneWithTransaction / branchId), so a line the filter excludes — or one
+    // another device added — simply is not in the rows it seeds with.
+    cache.seed(transactionId: 'txn-1', rows: [
+      {'variantId': 'v1', '_id': 'doc-1', 'qty': 3},
+    ]);
+
+    expect(
+      cache.lineFor(transactionId: 'txn-1', variantId: 'v2'),
+      isNull,
+      reason: 'a miss here can be a lie, so the add path must confirm one '
+          'against the store before inserting — otherwise v2 gets a second row',
+    );
+    expect(cache.isSeeded('txn-1'), isTrue);
+  });
+
   test('rows without a variant id are not indexable and are skipped', () {
     cache.seed(transactionId: 'txn-1', rows: [
       {'_id': 'doc-1', 'qty': 3},

--- a/packages/flipper_models/test/sale_completion_helpers_test.dart
+++ b/packages/flipper_models/test/sale_completion_helpers_test.dart
@@ -397,4 +397,84 @@ void main() {
       expect(stamp!.day, 7, reason: 'sold on the 7th, not the cart-mint day');
     });
   });
+
+  group('decideSalePaymentReceipt', () {
+    test('a fully paid cash sale issues its receipt and does not park', () {
+      final d = decideSalePaymentReceipt(
+        transactionAlreadyLoan: false,
+        priorNonCreditPaid: 0,
+        tenderAmount: 1000,
+        creditTenderAmount: 0,
+        saleTotal: 1000,
+      );
+      expect(d.isFullyPaid, true);
+      expect(d.parksAsLoan, false);
+      expect(d.issueReceiptNow, true);
+    });
+
+    test('a part-paid sale parks as a loan and still issues the receipt', () {
+      final d = decideSalePaymentReceipt(
+        transactionAlreadyLoan: false,
+        priorNonCreditPaid: 0,
+        tenderAmount: 400,
+        creditTenderAmount: 0,
+        saleTotal: 1000,
+      );
+      expect(d.isFullyPaid, false);
+      expect(d.parksAsLoan, true);
+      expect(d.issueReceiptNow, true);
+    });
+
+    test('a full CREDIT sale is not paid, parks, and still gets a receipt', () {
+      final d = decideSalePaymentReceipt(
+        transactionAlreadyLoan: false,
+        priorNonCreditPaid: 0,
+        tenderAmount: 1000,
+        creditTenderAmount: 1000,
+        saleTotal: 1000,
+      );
+      expect(d.isFullyPaid, false);
+      expect(d.parksAsLoan, true);
+      expect(d.issueReceiptNow, true);
+    });
+
+    test('cash plus credit still parks — the credit half is owed, not paid', () {
+      final d = decideSalePaymentReceipt(
+        transactionAlreadyLoan: false,
+        priorNonCreditPaid: 0,
+        tenderAmount: 1000,
+        creditTenderAmount: 600,
+        saleTotal: 1000,
+      );
+      expect(d.isFullyPaid, false);
+      expect(d.parksAsLoan, true);
+      expect(d.issueReceiptNow, true);
+    });
+
+    test('a later installment on a parked loan issues no second receipt', () {
+      final d = decideSalePaymentReceipt(
+        transactionAlreadyLoan: true,
+        priorNonCreditPaid: 400,
+        tenderAmount: 600,
+        creditTenderAmount: 0,
+        saleTotal: 1000,
+      );
+      expect(d.isFullyPaid, true, reason: 'the loan is settled by this tender');
+      expect(d.parksAsLoan, false);
+      expect(d.issueReceiptNow, false,
+          reason: 'it was receipted when the goods went out');
+    });
+
+    test('a sub-epsilon shortfall counts as paid, not as a loan', () {
+      final d = decideSalePaymentReceipt(
+        transactionAlreadyLoan: false,
+        priorNonCreditPaid: 0,
+        tenderAmount: 999.99999,
+        creditTenderAmount: 0,
+        saleTotal: 1000,
+      );
+      expect(d.isFullyPaid, true);
+      expect(d.parksAsLoan, false);
+    });
+  });
 }

--- a/packages/flipper_models/test/settling_till_ticket_recovery_test.dart
+++ b/packages/flipper_models/test/settling_till_ticket_recovery_test.dart
@@ -1,0 +1,83 @@
+import 'package:flipper_models/providers/pos_payment_role_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_models/brick/models/transaction.model.dart';
+
+ITransaction _txn({
+  required String status,
+  String? ticketName,
+  String id = 'txn-abcdef123',
+  String? reference,
+}) {
+  return ITransaction(
+    id: id,
+    branchId: 'b1',
+    status: status,
+    transactionType: 'sale',
+    paymentType: 'Cash',
+    cashReceived: 0,
+    customerChangeDue: 0,
+    updatedAt: DateTime.utc(2026, 1, 1),
+    createdAt: DateTime.utc(2026, 1, 1),
+    isIncome: true,
+    isExpense: false,
+    agentId: 'a1',
+    ticketName: ticketName,
+    reference: reference,
+  );
+}
+
+void main() {
+  group('recoverSettlingTillTicketFromResumedCart', () {
+    test('rebuilds a session for a resumed ticket (PENDING + ticketName)', () {
+      final settling = recoverSettlingTillTicketFromResumedCart(
+        _txn(status: 'pending', ticketName: 'Till · E591A', reference: 'e591a'),
+      );
+
+      expect(settling, isNotNull);
+      expect(settling!.transactionId, 'txn-abcdef123');
+      expect(settling.displayRef, 'E591A');
+      expect(settling.ticketName, 'Till · E591A');
+      expect(settling.createdAt, DateTime.utc(2026, 1, 1));
+    });
+
+    test('falls back to a truncated id when the row has no reference', () {
+      final settling = recoverSettlingTillTicketFromResumedCart(
+        _txn(status: 'pending', ticketName: 'Walk-in'),
+      );
+
+      expect(settling?.displayRef, 'TXN-AB');
+    });
+
+    test('ignores a plain pending cart (no ticket name)', () {
+      expect(
+        recoverSettlingTillTicketFromResumedCart(_txn(status: 'pending')),
+        isNull,
+      );
+      expect(
+        recoverSettlingTillTicketFromResumedCart(
+          _txn(status: 'pending', ticketName: '   '),
+        ),
+        isNull,
+      );
+    });
+
+    test('ignores a ticket that is not resumed', () {
+      expect(
+        recoverSettlingTillTicketFromResumedCart(
+          _txn(status: 'parked', ticketName: 'Till · E591A'),
+        ),
+        isNull,
+      );
+      expect(
+        recoverSettlingTillTicketFromResumedCart(
+          _txn(status: 'completed', ticketName: 'Till · E591A'),
+        ),
+        isNull,
+      );
+    });
+
+    test('ignores a null row', () {
+      expect(recoverSettlingTillTicketFromResumedCart(null), isNull);
+    });
+  });
+}

--- a/packages/flipper_models/test/settling_till_ticket_recovery_test.dart
+++ b/packages/flipper_models/test/settling_till_ticket_recovery_test.dart
@@ -80,4 +80,66 @@ void main() {
       expect(recoverSettlingTillTicketFromResumedCart(null), isNull);
     });
   });
+
+  group('settlingRecoveryCartRow', () {
+    final cached = _txn(status: 'pending', ticketName: 'A', id: 'cached');
+    final streamed = _txn(status: 'pending', ticketName: 'B', id: 'streamed');
+    final pinned = _txn(status: 'pending', ticketName: 'C', id: 'pinned');
+
+    test('prefers the cache over the stream when nothing is pinned', () {
+      expect(
+        settlingRecoveryCartRow(cached: cached, streamed: streamed)?.id,
+        'cached',
+      );
+      expect(settlingRecoveryCartRow(streamed: streamed)?.id, 'streamed');
+      expect(settlingRecoveryCartRow(), isNull);
+    });
+
+    test('a pin wins over both, wherever the pinned row is found', () {
+      expect(
+        settlingRecoveryCartRow(
+          cached: cached,
+          streamed: pinned,
+          pinnedId: 'pinned',
+        )?.id,
+        'pinned',
+      );
+      expect(
+        settlingRecoveryCartRow(
+          cached: cached,
+          streamed: streamed,
+          pinnedRow: pinned,
+          pinnedId: 'pinned',
+        )?.id,
+        'pinned',
+      );
+    });
+
+    test('a pin nothing resolves yields no row — never a different cart', () {
+      expect(
+        settlingRecoveryCartRow(
+          cached: cached,
+          streamed: streamed,
+          pinnedId: 'pinned',
+        ),
+        isNull,
+      );
+    });
+
+    test('a suppressed id yields no row, pinned or not', () {
+      expect(
+        settlingRecoveryCartRow(cached: cached, suppressedId: 'cached'),
+        isNull,
+      );
+      expect(
+        settlingRecoveryCartRow(
+          cached: cached,
+          pinnedRow: pinned,
+          pinnedId: 'pinned',
+          suppressedId: 'pinned',
+        ),
+        isNull,
+      );
+    });
+  });
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credit and part-paid sales now remain as loans while issuing the appropriate receipt.
  * Resumed settling tickets retain their banner and controls after reloads or restarts.
  * Payment messages better reflect when a sale is parked as a loan.

* **Bug Fixes**
  * Fixed cart items reappearing or duplicating after edits or deletion.
  * Improved receipt printing when cash received is unavailable.
  * Improved settling-ticket recovery and re-parking using the latest sale information.
  * Prevented failed ticket lookups from orphaning pending tickets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->