### PR TITLE
feat(web): light mode on the Books landing page, and light by default

### DIFF
--- a/apps/flipper/pubspec.lock
+++ b/apps/flipper/pubspec.lock
@@ -1366,7 +1366,7 @@ packages:
       path: "../flipper_web"
       relative: true
     source: path
-    version: "1.0.786+1702"
+    version: "1.0.797+1713"
   flowy_svg:
     dependency: "direct overridden"
     description:

--- a/apps/flipper_web/lib/features/home/books_home_page.dart
+++ b/apps/flipper_web/lib/features/home/books_home_page.dart
@@ -75,10 +75,15 @@ class _BooksHomePageState extends ConsumerState<BooksHomePage> {
   Widget build(BuildContext context) {
     final l10n = booksHomeL10n(context);
 
+    final theme = BooksHomeTheme.of(Theme.of(context).brightness);
+    final overlay = theme.brightness == Brightness.dark
+        ? SystemUiOverlayStyle.light
+        : SystemUiOverlayStyle.dark;
+
     return Theme(
-      data: BooksHomeTheme.data,
+      data: theme,
       child: AnnotatedRegion<SystemUiOverlayStyle>(
-        value: SystemUiOverlayStyle.light.copyWith(
+        value: overlay.copyWith(
           statusBarColor: Colors.transparent,
           systemNavigationBarColor: AppColors.bg,
         ),

--- a/apps/flipper_web/lib/features/home/home_screen.dart
+++ b/apps/flipper_web/lib/features/home/home_screen.dart
@@ -4,13 +4,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Public entry for the Flipper Books marketing landing page.
+///
+/// The page follows the app's theme mode (light by default) — see
+/// [BooksHomeTheme.of], which installs the matching marketing palette.
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Theme(
-      data: BooksHomeTheme.data,
+      data: BooksHomeTheme.of(Theme.of(context).brightness),
       child: const BooksHomePage(),
     );
   }

--- a/apps/flipper_web/lib/features/home/sections/books_home_hero_mock.dart
+++ b/apps/flipper_web/lib/features/home/sections/books_home_hero_mock.dart
@@ -141,7 +141,7 @@ class _BkTopBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.015),
+        color: AppColors.wash(0.015),
         border: Border(bottom: BorderSide(color: AppColors.line)),
       ),
       child: Padding(
@@ -158,7 +158,7 @@ class _BkTopBar extends StatelessWidget {
                     height: 11,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      color: Colors.white.withValues(alpha: 0.14),
+                      color: AppColors.wash(0.14),
                     ),
                   ),
                 ),
@@ -407,7 +407,7 @@ class _BkKpi extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.02),
+        color: AppColors.wash(0.02),
         borderRadius: BorderRadius.circular(14),
         border: Border.all(color: AppColors.line),
       ),
@@ -448,18 +448,12 @@ class _RevenueChart extends StatelessWidget {
 
   final List<double> chartHeights;
 
-  static const _barGradient = LinearGradient(
-    begin: Alignment.topCenter,
-    end: Alignment.bottomCenter,
-    colors: [Color(0xD93F86FF), Color(0x403F86FF)],
-  );
-
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.fromLTRB(15, 14, 15, 14),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.015),
+        color: AppColors.wash(0.015),
         borderRadius: BorderRadius.circular(14),
         border: Border.all(color: AppColors.line),
       ),
@@ -521,7 +515,7 @@ class _ChartBar extends StatelessWidget {
           bottomLeft: Radius.circular(3),
           bottomRight: Radius.circular(3),
         ),
-        gradient: highlight ? AppGrad.brand : _RevenueChart._barGradient,
+        gradient: highlight ? AppGrad.brand : AppGrad.chartBar,
         boxShadow: highlight ? AppShadow.cyanGlow : null,
       ),
     );
@@ -529,19 +523,19 @@ class _ChartBar extends StatelessWidget {
 }
 
 class _ProfitLossPanel extends StatelessWidget {
-  static final _footerLabelStyle = AppText.small.copyWith(
-    fontSize: 13,
-    height: 1.1,
-    fontWeight: FontWeight.w700,
-    color: AppColors.green,
-  );
+  static TextStyle get _footerLabelStyle => AppText.small.copyWith(
+        fontSize: 13,
+        height: 1.1,
+        fontWeight: FontWeight.w700,
+        color: AppColors.green,
+      );
 
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.fromLTRB(15, 14, 15, 14),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.015),
+        color: AppColors.wash(0.015),
         borderRadius: BorderRadius.circular(14),
         border: Border.all(color: AppColors.line),
       ),
@@ -637,24 +631,18 @@ class _ProfitLossPanel extends StatelessWidget {
 class _FlowToast extends StatelessWidget {
   const _FlowToast();
 
-  static const _bg = LinearGradient(
-    begin: Alignment.topCenter,
-    end: Alignment.bottomCenter,
-    colors: [Color(0xFA161E32), Color(0xFA0E1422)],
-  );
-
   @override
   Widget build(BuildContext context) {
     return Container(
       width: 290,
       padding: const EdgeInsets.fromLTRB(15, 14, 15, 14),
       decoration: BoxDecoration(
-        gradient: _bg,
+        gradient: AppGrad.toastFill,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(color: AppColors.cyan.withValues(alpha: 0.3)),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withValues(alpha: 0.75),
+            color: AppColors.shadow(0.75),
             blurRadius: 60,
             spreadRadius: -18,
             offset: const Offset(0, 24),
@@ -707,18 +695,18 @@ class _FlowToast extends StatelessWidget {
           Text.rich(
             TextSpan(
               style: AppText.body.copyWith(fontSize: 12.5, color: AppColors.ink2, height: 1.45),
-              children: const [
-                TextSpan(text: 'New sale on '),
+              children: [
+                const TextSpan(text: 'New sale on '),
                 TextSpan(
                   text: 'Flipper POS',
                   style: TextStyle(color: AppColors.ink0, fontWeight: FontWeight.w600),
                 ),
-                TextSpan(text: ' — categorized to '),
+                const TextSpan(text: ' — categorized to '),
                 TextSpan(
                   text: 'Sales Revenue',
                   style: TextStyle(color: AppColors.ink0, fontWeight: FontWeight.w600),
                 ),
-                TextSpan(text: ' and reconciled to MoMo.'),
+                const TextSpan(text: ' and reconciled to MoMo.'),
               ],
             ),
           ),
@@ -768,7 +756,7 @@ class _PosPhoneMock extends StatelessWidget {
         border: Border.all(color: AppColors.line2),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withValues(alpha: 0.8),
+            color: AppColors.shadow(0.8),
             blurRadius: 80,
             spreadRadius: -24,
             offset: const Offset(0, 40),
@@ -778,7 +766,7 @@ class _PosPhoneMock extends StatelessWidget {
       child: ClipRRect(
         borderRadius: BorderRadius.circular(24),
         child: ColoredBox(
-          color: const Color(0xFF0D1320),
+          color: AppColors.mockScreen,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -816,7 +804,7 @@ class _PosPhoneMock extends StatelessWidget {
                   height: 32,
                   padding: const EdgeInsets.symmetric(horizontal: 10),
                   decoration: BoxDecoration(
-                    color: Colors.white.withValues(alpha: 0.05),
+                    color: AppColors.wash(0.05),
                     borderRadius: BorderRadius.circular(9),
                   ),
                   child: Row(
@@ -854,7 +842,7 @@ class _PosPhoneMock extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(9),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.03),
+        color: AppColors.wash(0.03),
         borderRadius: BorderRadius.circular(11),
       ),
       child: Row(
@@ -872,7 +860,7 @@ class _PosPhoneMock extends StatelessWidget {
               style: AppText.small.copyWith(
                 fontSize: 10,
                 fontWeight: FontWeight.w700,
-                color: AppColors.ink0,
+                color: AppColors.onBrand,
               ),
             ),
           ),
@@ -904,12 +892,16 @@ class _PosPhoneMock extends StatelessWidget {
           Container(
             width: 24,
             height: 24,
-            decoration: const BoxDecoration(
+            decoration: BoxDecoration(
               shape: BoxShape.circle,
               color: AppColors.blue,
             ),
             child: const Center(
-              child: BooksLineIcon(BooksIcon.plus, size: 13, color: AppColors.ink0),
+              child: BooksLineIcon(
+                BooksIcon.plus,
+                size: 13,
+                color: AppColors.onBrand,
+              ),
             ),
           ),
         ],

--- a/apps/flipper_web/lib/features/home/sections/books_home_sections.dart
+++ b/apps/flipper_web/lib/features/home/sections/books_home_sections.dart
@@ -134,7 +134,7 @@ class BooksHomeHeader extends StatelessWidget {
                   onNavTap(link);
                 },
               ),
-            const BooksThemeToggleTile(),
+            BooksThemeToggleTile(onToggled: () => Navigator.pop(ctx)),
             const SizedBox(height: 12),
             GhostButton(
               label: 'Log in',

--- a/apps/flipper_web/lib/features/home/sections/books_home_sections.dart
+++ b/apps/flipper_web/lib/features/home/sections/books_home_sections.dart
@@ -4,6 +4,7 @@ import 'package:flipper_web/features/home/sections/books_home_hero_mock.dart';
 import 'package:flipper_web/features/home/theme/books_home_theme.dart';
 import 'package:flipper_web/features/home/widgets/books_home_widgets.dart';
 import 'package:flipper_web/features/home/widgets/books_line_icon.dart';
+import 'package:flipper_web/features/home/widgets/books_theme_toggle.dart';
 import 'package:flipper_web/l10n/app_localizations.dart';
 import 'package:flipper_web/l10n/app_localizations_en.dart';
 import 'package:flutter/material.dart';
@@ -40,6 +41,8 @@ class BooksHomeHeader extends StatelessWidget {
                     children: [
                       const BooksWordmark(logoSize: 30),
                       const Spacer(),
+                      const BooksThemeToggle(size: 34),
+                      const SizedBox(width: 4),
                       IconButton(
                         onPressed: () => _showMobileMenu(
                           context,
@@ -47,7 +50,7 @@ class BooksHomeHeader extends StatelessWidget {
                           onSignIn,
                           onStartFree,
                         ),
-                        icon: const Icon(
+                        icon: Icon(
                           Icons.menu_rounded,
                           color: AppColors.ink1,
                         ),
@@ -80,6 +83,8 @@ class BooksHomeHeader extends StatelessWidget {
                                 ),
                               ],
                               const SizedBox(width: 18),
+                              const BooksThemeToggle(),
+                              const SizedBox(width: 14),
                               NavTextLink(label: 'Log in', onTap: onSignIn),
                               const SizedBox(width: 12),
                               PrimaryButton(
@@ -129,6 +134,7 @@ class BooksHomeHeader extends StatelessWidget {
                   onNavTap(link);
                 },
               ),
+            const BooksThemeToggleTile(),
             const SizedBox(height: 12),
             GhostButton(
               label: 'Log in',
@@ -162,7 +168,7 @@ class _SuiteSwitcher extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(4),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.025),
+        color: AppColors.wash(0.025),
         borderRadius: BorderRadius.circular(999),
         border: Border.all(color: AppColors.line),
       ),
@@ -487,7 +493,7 @@ class BooksHomeSuiteSection extends StatelessWidget {
                     vertical: 16,
                   ),
                   child: ColoredBox(
-                    color: Colors.white.withValues(alpha: 0.015),
+                    color: AppColors.wash(0.015),
                     child: Row(
                       children: [
                         Expanded(
@@ -508,8 +514,8 @@ class BooksHomeSuiteSection extends StatelessWidget {
                                     fontSize: 14,
                                     color: AppColors.ink2,
                                   ),
-                                  children: const [
-                                    TextSpan(text: 'Sell on POS → '),
+                                  children: [
+                                    const TextSpan(text: 'Sell on POS → '),
                                     TextSpan(
                                       text: 'posts to Books',
                                       style: TextStyle(
@@ -517,7 +523,7 @@ class BooksHomeSuiteSection extends StatelessWidget {
                                         fontWeight: FontWeight.w600,
                                       ),
                                     ),
-                                    TextSpan(text: ' → '),
+                                    const TextSpan(text: ' → '),
                                     TextSpan(
                                       text: 'Flow reconciles',
                                       style: TextStyle(
@@ -525,7 +531,7 @@ class BooksHomeSuiteSection extends StatelessWidget {
                                         fontWeight: FontWeight.w600,
                                       ),
                                     ),
-                                    TextSpan(
+                                    const TextSpan(
                                       text:
                                           ' → you see profit in real time. One loop, fully automatic.',
                                     ),
@@ -604,7 +610,7 @@ class _SuiteCard extends StatelessWidget {
     this.highlighted = false,
   });
 
-  factory _SuiteCard.pos() => const _SuiteCard(
+  factory _SuiteCard.pos() => _SuiteCard(
     productLabel: 'FLIPPER POS',
     role: 'Sell',
     tagline: 'The front counter',
@@ -617,7 +623,7 @@ class _SuiteCard extends StatelessWidget {
     glowColor: AppColors.blue,
   );
 
-  factory _SuiteCard.books() => const _SuiteCard(
+  factory _SuiteCard.books() => _SuiteCard(
     productLabel: 'FLIPPER BOOKS',
     role: 'Account',
     tagline: 'The source of truth',
@@ -631,7 +637,7 @@ class _SuiteCard extends StatelessWidget {
     highlighted: true,
   );
 
-  factory _SuiteCard.flow() => const _SuiteCard(
+  factory _SuiteCard.flow() => _SuiteCard(
     productLabel: 'FLIPPER FLOW',
     role: 'Automate',
     tagline: 'The AI bookkeeper',
@@ -760,7 +766,7 @@ class BooksHomeFlowSection extends StatelessWidget {
           end: Alignment.bottomCenter,
           colors: [
             Colors.transparent,
-            AppColors.blue.withValues(alpha: 0.04),
+            AppColors.glow(AppColors.blue, 0.04),
             Colors.transparent,
           ],
         ),
@@ -856,7 +862,7 @@ class BooksHomeFlowSection extends StatelessWidget {
                   width: 42,
                   height: 42,
                   decoration: BoxDecoration(
-                    color: Colors.white.withValues(alpha: 0.03),
+                    color: AppColors.wash(0.03),
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(color: AppColors.line2),
                   ),
@@ -1026,7 +1032,7 @@ class _FlowChatPanel extends StatelessWidget {
         decoration: BoxDecoration(
           color: mine
               ? AppColors.blue.withValues(alpha: 0.16)
-              : Colors.white.withValues(alpha: 0.04),
+              : AppColors.wash(0.04),
           borderRadius: BorderRadius.only(
             topLeft: const Radius.circular(14),
             topRight: const Radius.circular(14),
@@ -1067,7 +1073,7 @@ class _FlowChatPanel extends StatelessWidget {
         children: [
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
-            color: Colors.white.withValues(alpha: 0.03),
+            color: AppColors.wash(0.03),
             child: Row(
               children: [
                 Expanded(
@@ -1082,7 +1088,7 @@ class _FlowChatPanel extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: 8),
-                const BooksLineIcon(
+                BooksLineIcon(
                   BooksIcon.check,
                   size: 13,
                   color: AppColors.green,
@@ -1388,7 +1394,7 @@ class _PricingCard extends StatelessWidget {
                 end: Alignment.bottomCenter,
                 colors: [
                   AppColors.green.withValues(alpha: 0.07),
-                  Colors.white.withValues(alpha: 0.012),
+                  AppColors.wash(0.012),
                 ],
               )
             : AppGrad.pricingCardFill,
@@ -1557,7 +1563,7 @@ class BooksHomeBrandBand extends StatelessWidget {
           constraints: BoxConstraints(maxWidth: h2Size * 7),
           child: Text(
             'Your shop, your books, all in one place.',
-            style: AppText.h2(h2Size).copyWith(color: AppColors.ink0),
+            style: AppText.h2(h2Size).copyWith(color: AppColors.onBrand),
           ),
         ),
         const SizedBox(height: 16),
@@ -1616,7 +1622,7 @@ class _BandStat extends StatelessWidget {
       children: [
         Text(
           value,
-          style: AppText.mono(size: 26, w: FontWeight.w700, c: AppColors.ink0),
+          style: AppText.mono(size: 26, w: FontWeight.w700, c: AppColors.onBrand),
         ),
         Text(
           label,
@@ -1714,7 +1720,7 @@ class _BandWhiteCard extends StatelessWidget {
       width: width,
       padding: const EdgeInsets.symmetric(horizontal: 17, vertical: 15),
       decoration: BoxDecoration(
-        color: AppColors.ink0,
+        color: AppColors.cardOnBrand,
         borderRadius: BorderRadius.circular(18),
         boxShadow: AppShadow.whiteCard,
       ),
@@ -1740,7 +1746,10 @@ class _BandChartCard extends StatelessWidget {
               Expanded(
                 child: Text(
                   'Revenue · this week',
-                  style: AppText.small.copyWith(fontWeight: FontWeight.w600),
+                  style: AppText.small.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.whiteCardMuted,
+                  ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -1750,7 +1759,7 @@ class _BandChartCard extends StatelessWidget {
                 style: AppText.mono(
                   size: 11,
                   w: FontWeight.w700,
-                  c: AppColors.greenInk,
+                  c: AppColors.whiteCardGain,
                 ),
               ),
             ],
@@ -1761,7 +1770,7 @@ class _BandChartCard extends StatelessWidget {
             style: AppText.mono(
               size: 19,
               w: FontWeight.w800,
-              c: AppColors.ink1,
+              c: AppColors.whiteCardInk,
             ),
           ),
           const SizedBox(height: 9),
@@ -1784,7 +1793,7 @@ class _BandChartCard extends StatelessWidget {
                               : null,
                           color: i == _bars.length - 1
                               ? null
-                              : AppColors.blue.withValues(alpha: 0.15),
+                              : AppColors.whiteCardBar,
                         ),
                         child: SizedBox(height: 48 * _bars[i]),
                       ),
@@ -1812,14 +1821,14 @@ class _BandSaleCard extends StatelessWidget {
             width: 36,
             height: 36,
             decoration: BoxDecoration(
-              color: AppColors.green.withValues(alpha: 0.15),
+              color: AppColors.saleCheckBg,
               borderRadius: BorderRadius.circular(10),
             ),
             child: Center(
               child: BooksLineIcon(
                 BooksIcon.check,
                 size: 16,
-                color: AppColors.greenInk,
+                color: AppColors.whiteCardGain,
               ),
             ),
           ),
@@ -1832,12 +1841,14 @@ class _BandSaleCard extends StatelessWidget {
                   'New sale',
                   style: AppText.h4.copyWith(
                     fontSize: 12.5,
-                    color: AppColors.ink1,
+                    color: AppColors.whiteCardInk,
                   ),
                 ),
                 Text(
                   'Solar Kit · MoMo',
-                  style: AppText.small.copyWith(color: AppColors.ink3),
+                  style: AppText.small.copyWith(
+                    color: AppColors.whiteCardMuted,
+                  ),
                 ),
               ],
             ),
@@ -1847,7 +1858,7 @@ class _BandSaleCard extends StatelessWidget {
             style: AppText.mono(
               size: 14,
               w: FontWeight.w800,
-              c: AppColors.greenInk,
+              c: AppColors.whiteCardGain,
             ),
           ),
         ],
@@ -1876,7 +1887,7 @@ class _BandStreakCard extends StatelessWidget {
               child: BooksLineIcon(
                 BooksIcon.flame,
                 size: 16,
-                color: AppColors.ink0,
+                color: AppColors.onBrand,
               ),
             ),
           ),
@@ -1889,12 +1900,14 @@ class _BandStreakCard extends StatelessWidget {
                 style: AppText.mono(
                   size: 16,
                   w: FontWeight.w800,
-                  c: AppColors.ink1,
+                  c: AppColors.whiteCardInk,
                 ),
               ),
               Text(
                 'Sales streak',
-                style: AppText.small.copyWith(color: AppColors.ink3),
+                style: AppText.small.copyWith(
+                  color: AppColors.whiteCardMuted,
+                ),
               ),
             ],
           ),

--- a/apps/flipper_web/lib/features/home/theme/books_home_theme.dart
+++ b/apps/flipper_web/lib/features/home/theme/books_home_theme.dart
@@ -1,39 +1,310 @@
 import 'package:flutter/material.dart';
 
+/// One resolved colour set for the Flipper Books marketing page.
+///
+/// The handoff was authored dark-only; [light] is the mirrored set, and it is
+/// the default so the marketing page matches the rest of flipper_web (the
+/// accounting workspace and sign-in are light surfaces).
+///
+/// Colours that sit on a *brand* surface (the blue brand band, the violet
+/// primary button, the brand-gradient chips) do not belong here — they are the
+/// same in both modes and live on [AppColors] as plain constants.
+@immutable
+class BooksPalette {
+  const BooksPalette({
+    required this.brightness,
+    required this.bg,
+    required this.bg2,
+    required this.panel,
+    required this.panel2,
+    required this.mockScreen,
+    required this.ink0,
+    required this.ink1,
+    required this.ink2,
+    required this.ink3,
+    required this.ink4,
+    required this.blue,
+    required this.royal,
+    required this.violet,
+    required this.indigo,
+    required this.cyan,
+    required this.green,
+    required this.greenInk,
+    required this.amber,
+    required this.amber2,
+    required this.downKpi,
+    required this.popularTagInk,
+    required this.washInk,
+    required this.lineAlpha,
+    required this.line2Alpha,
+    required this.washScale,
+    required this.glowScale,
+    required this.shadowScale,
+    required this.glassCard,
+    required this.suiteCardFill,
+    required this.pricingCardFill,
+    required this.toastFill,
+    required this.chartBar,
+  });
+
+  final Brightness brightness;
+
+  // Surfaces.
+  final Color bg;
+  final Color bg2;
+  final Color panel;
+  final Color panel2;
+
+  /// Screen fill of the POS phone mock in the hero stage.
+  final Color mockScreen;
+
+  // Ink ramp, strongest (ink0) to faintest (ink4).
+  final Color ink0;
+  final Color ink1;
+  final Color ink2;
+  final Color ink3;
+  final Color ink4;
+
+  // Accents.
+  final Color blue;
+  final Color royal;
+  final Color violet;
+  final Color indigo;
+  final Color cyan;
+  final Color green;
+  final Color greenInk;
+  final Color amber;
+  final Color amber2;
+  final Color downKpi;
+
+  /// Ink on the solid-green "Most Popular" pill.
+  final Color popularTagInk;
+
+  /// Base colour of hairlines and surface washes: white on dark, ink on light.
+  final Color washInk;
+
+  final double lineAlpha;
+  final double line2Alpha;
+
+  /// Multiplier applied to [wash] alphas. A 2% white film reads on near-black;
+  /// on white the same idea needs a slightly firmer ink film.
+  final double washScale;
+
+  /// Multiplier for the radial brand glows — they must not bloom on white.
+  final double glowScale;
+
+  /// Multiplier for drop-shadow alphas.
+  final double shadowScale;
+
+  // Surface gradients.
+  final Gradient glassCard;
+  final Gradient suiteCardFill;
+  final Gradient pricingCardFill;
+  final Gradient toastFill;
+  final Gradient chartBar;
+
+  bool get isDark => brightness == Brightness.dark;
+
+  Color get line => washInk.withValues(alpha: lineAlpha);
+  Color get line2 => washInk.withValues(alpha: line2Alpha);
+
+  /// Subtle film over the page background (the handoff's `rgba(255,255,255,.0x)`
+  /// panel fills). Inverts to an ink film in light mode.
+  Color wash(double alpha) =>
+      washInk.withValues(alpha: (alpha * washScale).clamp(0.0, 1.0));
+
+  /// A brand glow, damped in light mode.
+  Color glow(Color color, double alpha) =>
+      color.withValues(alpha: (alpha * glowScale).clamp(0.0, 1.0));
+
+  /// A drop shadow, damped in light mode.
+  Color shadow(double alpha) => (isDark ? Colors.black : const Color(0xFF0B1220))
+      .withValues(alpha: (alpha * shadowScale).clamp(0.0, 1.0));
+
+  static const dark = BooksPalette(
+    brightness: Brightness.dark,
+    bg: Color(0xFF06080D),
+    bg2: Color(0xFF0A0E16),
+    panel: Color(0xFF0E1422),
+    panel2: Color(0xFF121A2B),
+    mockScreen: Color(0xFF0D1320),
+    ink0: Color(0xFFFFFFFF),
+    ink1: Color(0xFFE9EEF6),
+    ink2: Color(0xFFAAB4C4),
+    ink3: Color(0xFF7D8798),
+    ink4: Color(0xFF586172),
+    blue: Color(0xFF3F7BFF),
+    royal: Color(0xFF2F5CF5),
+    violet: Color(0xFF6D5CF0),
+    indigo: Color(0xFF4F46E5),
+    cyan: Color(0xFF34C8E6),
+    green: Color(0xFF2FE0A0),
+    greenInk: Color(0xFF10B981),
+    amber: Color(0xFFFFB43D),
+    amber2: Color(0xFFFB9D00),
+    downKpi: Color(0xFFFF8B6B),
+    popularTagInk: Color(0xFF06140E),
+    washInk: Color(0xFFFFFFFF),
+    lineAlpha: 0.08,
+    line2Alpha: 0.14,
+    washScale: 1,
+    glowScale: 1,
+    shadowScale: 1,
+    glassCard: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xEB141C2E), Color(0xF00B101C)],
+    ),
+    suiteCardFill: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0x09FFFFFF), Color(0x03FFFFFF)],
+    ),
+    pricingCardFill: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0x12FFFFFF), Color(0x06FFFFFF)],
+    ),
+    toastFill: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xFA161E32), Color(0xFA0E1422)],
+    ),
+    chartBar: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xD93F86FF), Color(0x403F86FF)],
+    ),
+  );
+
+  /// Light mirror of [dark]. Inks are borrowed from the sign-in / accounting
+  /// token sets (`SITokens`, `AccountingTokens`) so the landing page and the
+  /// app behind it read as one product, and accents are darkened to keep
+  /// text-on-white contrast.
+  static const light = BooksPalette(
+    brightness: Brightness.light,
+    bg: Color(0xFFFFFFFF),
+    bg2: Color(0xFFF7F9FE),
+    panel: Color(0xFFFFFFFF),
+    panel2: Color(0xFFF4F6FB),
+    mockScreen: Color(0xFFFFFFFF),
+    ink0: Color(0xFF0B1220),
+    ink1: Color(0xFF16203A),
+    ink2: Color(0xFF4A5567),
+    ink3: Color(0xFF7E8AA0),
+    ink4: Color(0xFF9AA8BC),
+    blue: Color(0xFF2563EB),
+    royal: Color(0xFF1D4ED8),
+    violet: Color(0xFF5B4FE6),
+    indigo: Color(0xFF4338CA),
+    cyan: Color(0xFF0E93AE),
+    green: Color(0xFF0E9F6E),
+    greenInk: Color(0xFF047857),
+    amber: Color(0xFFB45309),
+    amber2: Color(0xFFC2740A),
+    downKpi: Color(0xFFD1483A),
+    popularTagInk: Color(0xFFFFFFFF),
+    washInk: Color(0xFF0B1220),
+    lineAlpha: 0.10,
+    line2Alpha: 0.18,
+    washScale: 1.1,
+    glowScale: 0.45,
+    shadowScale: 0.22,
+    glassCard: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xFFFFFFFF), Color(0xFFF7F9FE)],
+    ),
+    suiteCardFill: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xFFFFFFFF), Color(0xFFF9FBFF)],
+    ),
+    pricingCardFill: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xFFFFFFFF), Color(0xFFF7F9FE)],
+    ),
+    toastFill: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xFFFFFFFF), Color(0xFFF4F7FD)],
+    ),
+    chartBar: LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xD92563EB), Color(0x402563EB)],
+    ),
+  );
+}
+
 /// Design tokens for the Flipper Books marketing home page (handoff v1).
+///
+/// Every mode-dependent token reads from [AppColors.palette], which
+/// [BooksHomeTheme.of] swaps before the page's `ThemeData` is built. The page
+/// renders one palette at a time (it is a single full-screen route), so a
+/// process-wide active palette keeps the ~200 call sites free of a context
+/// lookup; nothing else in flipper_web reads these tokens.
 abstract final class AppColors {
-  static const bg = Color(0xFF06080D);
-  static const bg2 = Color(0xFF0A0E16);
-  static const panel = Color(0xFF0E1422);
-  static const panel2 = Color(0xFF121A2B);
-  static const ink0 = Color(0xFFFFFFFF);
-  static const ink1 = Color(0xFFE9EEF6);
-  static const ink2 = Color(0xFFAAB4C4);
-  static const ink3 = Color(0xFF7D8798);
-  static const ink4 = Color(0xFF586172);
-  static const blue = Color(0xFF3F7BFF);
-  static const royal = Color(0xFF2F5CF5);
-  static const violet = Color(0xFF6D5CF0);
-  static const indigo = Color(0xFF4F46E5);
-  static const cyan = Color(0xFF34C8E6);
-  static const green = Color(0xFF2FE0A0);
-  static const greenInk = Color(0xFF10B981);
-  static const amber = Color(0xFFFFB43D);
-  static const amber2 = Color(0xFFFB9D00);
+  /// The palette the page is currently rendering with. Installed by
+  /// [BooksHomeTheme.of]; light until something says otherwise.
+  static BooksPalette palette = BooksPalette.light;
+
+  static Color get bg => palette.bg;
+  static Color get bg2 => palette.bg2;
+  static Color get panel => palette.panel;
+  static Color get panel2 => palette.panel2;
+  static Color get mockScreen => palette.mockScreen;
+  static Color get ink0 => palette.ink0;
+  static Color get ink1 => palette.ink1;
+  static Color get ink2 => palette.ink2;
+  static Color get ink3 => palette.ink3;
+  static Color get ink4 => palette.ink4;
+  static Color get blue => palette.blue;
+  static Color get royal => palette.royal;
+  static Color get violet => palette.violet;
+  static Color get indigo => palette.indigo;
+  static Color get cyan => palette.cyan;
+  static Color get green => palette.green;
+  static Color get greenInk => palette.greenInk;
+  static Color get amber => palette.amber;
+  static Color get amber2 => palette.amber2;
+  static Color get downKpi => palette.downKpi;
+  static Color get popularTagInk => palette.popularTagInk;
+  static Color get line => palette.line;
+  static Color get line2 => palette.line2;
+
+  static Color wash(double alpha) => palette.wash(alpha);
+  static Color glow(Color color, double alpha) => palette.glow(color, alpha);
+  static Color shadow(double alpha) => palette.shadow(alpha);
+
+  // ── Mode-independent ───────────────────────────────────────────────────────
+  // These sit on a brand-coloured surface (the brand band, the violet primary
+  // button, a brand-gradient chip) or on a card that is white in both modes, so
+  // they must not follow the page palette.
+
+  /// Ink and small fills on top of a brand gradient or a saturated accent fill.
+  static const onBrand = Color(0xFFFFFFFF);
+
+  /// Fill of the floating cards inside the blue brand band.
+  static const cardOnBrand = Color(0xFFFFFFFF);
+
+  /// Ink on the brand-gradient suite chips / app tiles.
   static const suiteActiveInk = Color(0xFF061018);
-  static const downKpi = Color(0xFFFF8B6B);
+
+  static const whiteCardInk = Color(0xFF0B1220);
+  static const whiteCardMuted = Color(0xFF6B7689);
+
+  /// "Up"/gain green readable on those permanently-white cards.
+  static const whiteCardGain = Color(0xFF047857);
+  static const whiteCardBar = Color(0xFFDDE4F6);
+  static const saleCheckBg = Color(0xFFE6F9F1);
+  static const whiteButtonText = Color(0xFF2B50E0);
+
+  // POS mock product swatches — they sit on their own coloured tiles.
   static const posSo = Color(0xFFC4663D);
   static const posCc = Color(0xFF3F7FD6);
   static const posFc = Color(0xFF5F8A3C);
-  static const whiteCardInk = Color(0xFF0B1220);
-  static const whiteCardMuted = Color(0xFF6B7689);
-  static const whiteCardBar = Color(0xFFDDE4F6);
-  static const saleCheckBg = Color(0xFFE6F9F1);
-  static const popularTagInk = Color(0xFF06140E);
-  static const whiteButtonText = Color(0xFF2B50E0);
-
-  static final line = Colors.white.withValues(alpha: 0.08);
-  static final line2 = Colors.white.withValues(alpha: 0.14);
 }
 
 abstract final class AppGrad {
@@ -61,18 +332,6 @@ abstract final class AppGrad {
     begin: Alignment.topLeft,
     end: Alignment.bottomRight,
     colors: [Color(0xFF5E9BFF), Color(0xFF4B41D6)],
-  );
-
-  static const glassCard = LinearGradient(
-    begin: Alignment.topCenter,
-    end: Alignment.bottomCenter,
-    colors: [Color(0xEB141C2E), Color(0xF00B101C)],
-  );
-
-  static const suiteCardFill = LinearGradient(
-    begin: Alignment.topCenter,
-    end: Alignment.bottomCenter,
-    colors: [Color(0x09FFFFFF), Color(0x03FFFFFF)],
   );
 
   static const soft = LinearGradient(
@@ -110,11 +369,12 @@ abstract final class AppGrad {
     colors: [Color(0xFFFF9A4D), Color(0xFFFB5E00)],
   );
 
-  static const pricingCardFill = LinearGradient(
-    begin: Alignment.topCenter,
-    end: Alignment.bottomCenter,
-    colors: [Color(0x12FFFFFF), Color(0x06FFFFFF)],
-  );
+  // Mode-dependent surface fills.
+  static Gradient get glassCard => AppColors.palette.glassCard;
+  static Gradient get suiteCardFill => AppColors.palette.suiteCardFill;
+  static Gradient get pricingCardFill => AppColors.palette.pricingCardFill;
+  static Gradient get toastFill => AppColors.palette.toastFill;
+  static Gradient get chartBar => AppColors.palette.chartBar;
 }
 
 abstract final class AppSpace {
@@ -130,29 +390,31 @@ abstract final class AppSpace {
 }
 
 abstract final class AppShadow {
-  static final card = [
-    BoxShadow(
-      color: Colors.black.withValues(alpha: 0.7),
-      blurRadius: 50,
-      spreadRadius: -20,
-      offset: const Offset(0, 18),
-    ),
-    BoxShadow(
-      color: Colors.black.withValues(alpha: 0.4),
-      blurRadius: 14,
-      offset: const Offset(0, 4),
-    ),
-  ];
+  static List<BoxShadow> get card => [
+        BoxShadow(
+          color: AppColors.shadow(0.7),
+          blurRadius: 50,
+          spreadRadius: -20,
+          offset: const Offset(0, 18),
+        ),
+        BoxShadow(
+          color: AppColors.shadow(0.4),
+          blurRadius: 14,
+          offset: const Offset(0, 4),
+        ),
+      ];
 
-  static final violetGlow = [
-    BoxShadow(
-      color: AppColors.violet.withValues(alpha: 0.6),
-      blurRadius: 30,
-      spreadRadius: -10,
-      offset: const Offset(0, 12),
-    ),
-  ];
+  static List<BoxShadow> get violetGlow => [
+        BoxShadow(
+          color: AppColors.glow(AppColors.violet, 0.6),
+          blurRadius: 30,
+          spreadRadius: -10,
+          offset: const Offset(0, 12),
+        ),
+      ];
 
+  /// The brand band is the same saturated blue in both modes, so its shadow is
+  /// keyed to the band, not to the page.
   static final bandShadow = [
     BoxShadow(
       color: const Color(0xFF2B50E0).withValues(alpha: 0.7),
@@ -162,24 +424,25 @@ abstract final class AppShadow {
     ),
   ];
 
-  static final popularGlow = [
-    BoxShadow(
-      color: AppColors.green.withValues(alpha: 0.4),
-      blurRadius: 70,
-      spreadRadius: -30,
-      offset: const Offset(0, 30),
-    ),
-  ];
+  static List<BoxShadow> get popularGlow => [
+        BoxShadow(
+          color: AppColors.glow(AppColors.green, 0.4),
+          blurRadius: 70,
+          spreadRadius: -30,
+          offset: const Offset(0, 30),
+        ),
+      ];
 
-  static final cyanSuiteGlow = [
-    BoxShadow(
-      color: AppColors.cyan.withValues(alpha: 0.4),
-      blurRadius: 60,
-      spreadRadius: -28,
-      offset: const Offset(0, 24),
-    ),
-  ];
+  static List<BoxShadow> get cyanSuiteGlow => [
+        BoxShadow(
+          color: AppColors.glow(AppColors.cyan, 0.4),
+          blurRadius: 60,
+          spreadRadius: -28,
+          offset: const Offset(0, 24),
+        ),
+      ];
 
+  /// Lift under the white cards floating on the brand band.
   static final whiteCard = [
     BoxShadow(
       color: const Color(0xFF081034).withValues(alpha: 0.55),
@@ -189,23 +452,23 @@ abstract final class AppShadow {
     ),
   ];
 
-  static final greenGlow = [
-    BoxShadow(
-      color: AppColors.green.withValues(alpha: 0.35),
-      blurRadius: 32,
-      spreadRadius: -8,
-      offset: const Offset(0, 14),
-    ),
-  ];
+  static List<BoxShadow> get greenGlow => [
+        BoxShadow(
+          color: AppColors.glow(AppColors.green, 0.35),
+          blurRadius: 32,
+          spreadRadius: -8,
+          offset: const Offset(0, 14),
+        ),
+      ];
 
-  static final cyanGlow = [
-    BoxShadow(
-      color: AppColors.cyan.withValues(alpha: 0.28),
-      blurRadius: 28,
-      spreadRadius: -6,
-      offset: const Offset(0, 10),
-    ),
-  ];
+  static List<BoxShadow> get cyanGlow => [
+        BoxShadow(
+          color: AppColors.glow(AppColors.cyan, 0.28),
+          blurRadius: 28,
+          spreadRadius: -6,
+          offset: const Offset(0, 10),
+        ),
+      ];
 }
 
 abstract final class AppCurves {
@@ -220,6 +483,9 @@ abstract final class AppText {
   static const _sans = 'Geist';
   static const _mono = 'Geist Mono';
   static const _fallback = <String>['Inter', 'system-ui', 'sans-serif'];
+
+  // These are getters, not constants: they bake in a palette colour, and the
+  // palette can change when the viewer switches theme.
 
   static TextStyle h1(double size) => TextStyle(
         fontFamily: _sans,
@@ -241,58 +507,58 @@ abstract final class AppText {
         color: AppColors.ink0,
       );
 
-  static const h3 = TextStyle(
-    fontFamily: _sans,
-    fontFamilyFallback: _fallback,
-    fontSize: 21,
-    fontWeight: FontWeight.w700,
-    letterSpacing: -0.4,
-    color: AppColors.ink0,
-  );
+  static TextStyle get h3 => TextStyle(
+        fontFamily: _sans,
+        fontFamilyFallback: _fallback,
+        fontSize: 21,
+        fontWeight: FontWeight.w700,
+        letterSpacing: -0.4,
+        color: AppColors.ink0,
+      );
 
-  static const h4 = TextStyle(
-    fontFamily: _sans,
-    fontFamilyFallback: _fallback,
-    fontSize: 16.5,
-    fontWeight: FontWeight.w600,
-    letterSpacing: -0.165,
-    height: 1.5,
-    color: AppColors.ink0,
-  );
+  static TextStyle get h4 => TextStyle(
+        fontFamily: _sans,
+        fontFamilyFallback: _fallback,
+        fontSize: 16.5,
+        fontWeight: FontWeight.w600,
+        letterSpacing: -0.165,
+        height: 1.5,
+        color: AppColors.ink0,
+      );
 
-  static const body = TextStyle(
-    fontFamily: _sans,
-    fontFamilyFallback: _fallback,
-    fontSize: 16.5,
-    height: 1.55,
-    color: AppColors.ink2,
-  );
+  static TextStyle get body => TextStyle(
+        fontFamily: _sans,
+        fontFamilyFallback: _fallback,
+        fontSize: 16.5,
+        height: 1.55,
+        color: AppColors.ink2,
+      );
 
-  static const lead = TextStyle(
-    fontFamily: _sans,
-    fontFamilyFallback: _fallback,
-    fontSize: 18,
-    height: 1.55,
-    fontWeight: FontWeight.w400,
-    color: AppColors.ink2,
-  );
+  static TextStyle get lead => TextStyle(
+        fontFamily: _sans,
+        fontFamilyFallback: _fallback,
+        fontSize: 18,
+        height: 1.55,
+        fontWeight: FontWeight.w400,
+        color: AppColors.ink2,
+      );
 
-  static const small = TextStyle(
-    fontFamily: _sans,
-    fontFamilyFallback: _fallback,
-    fontSize: 13,
-    height: 1.5,
-    color: AppColors.ink3,
-  );
+  static TextStyle get small => TextStyle(
+        fontFamily: _sans,
+        fontFamilyFallback: _fallback,
+        fontSize: 13,
+        height: 1.5,
+        color: AppColors.ink3,
+      );
 
-  static const eyebrow = TextStyle(
-    fontFamily: _sans,
-    fontFamilyFallback: _fallback,
-    fontSize: 12,
-    fontWeight: FontWeight.w700,
-    letterSpacing: 1.7,
-    color: AppColors.ink2,
-  );
+  static TextStyle get eyebrow => TextStyle(
+        fontFamily: _sans,
+        fontFamilyFallback: _fallback,
+        fontSize: 12,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 1.7,
+        color: AppColors.ink2,
+      );
 
   static TextStyle mono({
     double size = 14,
@@ -309,14 +575,14 @@ abstract final class AppText {
         color: c ?? AppColors.ink1,
       );
 
-  static const buttonLabel = TextStyle(
-    fontFamily: _sans,
-    fontFamilyFallback: _fallback,
-    fontSize: 15.5,
-    fontWeight: FontWeight.w600,
-    letterSpacing: -0.01 * 15.5,
-    color: AppColors.ink0,
-  );
+  static TextStyle get buttonLabel => TextStyle(
+        fontFamily: _sans,
+        fontFamilyFallback: _fallback,
+        fontSize: 15.5,
+        fontWeight: FontWeight.w600,
+        letterSpacing: -0.01 * 15.5,
+        color: AppColors.ink0,
+      );
 
   /// Handoff `.btn` = 50px; `.btn-sm` (nav) = 42px.
   static const buttonHeightHero = 50.0;
@@ -343,36 +609,48 @@ int booksHomeCols(double width) =>
 
 /// Full [ThemeData] for the Books marketing page (handoff § Flutter theme setup).
 abstract final class BooksHomeTheme {
-  static const _colorScheme = ColorScheme(
-    brightness: Brightness.dark,
-    primary: AppColors.violet,
-    onPrimary: AppColors.ink0,
-    secondary: AppColors.cyan,
-    onSecondary: AppColors.ink0,
-    tertiary: AppColors.blue,
-    onTertiary: AppColors.ink0,
-    error: Color(0xFFCF6679),
-    onError: AppColors.ink0,
-    surface: AppColors.panel,
-    onSurface: AppColors.ink1,
-    surfaceContainerHighest: AppColors.panel2,
-    onSurfaceVariant: AppColors.ink2,
-    outline: AppColors.ink4,
-  );
+  /// Activates the palette for [brightness] and returns the matching theme.
+  ///
+  /// Call this before building any marketing-page widget — the tokens on
+  /// [AppColors] read the palette it installs.
+  static ThemeData of(Brightness brightness) {
+    AppColors.palette =
+        brightness == Brightness.dark ? BooksPalette.dark : BooksPalette.light;
+    return _build(brightness);
+  }
 
-  static ThemeData get data => ThemeData(
+  static ColorScheme _colorScheme(Brightness brightness) => ColorScheme(
+        brightness: brightness,
+        primary: AppColors.violet,
+        onPrimary: AppColors.onBrand,
+        secondary: AppColors.cyan,
+        onSecondary: AppColors.onBrand,
+        tertiary: AppColors.blue,
+        onTertiary: AppColors.onBrand,
+        error: brightness == Brightness.dark
+            ? const Color(0xFFCF6679)
+            : const Color(0xFFB3261E),
+        onError: AppColors.onBrand,
+        surface: AppColors.panel,
+        onSurface: AppColors.ink1,
+        surfaceContainerHighest: AppColors.panel2,
+        onSurfaceVariant: AppColors.ink2,
+        outline: AppColors.ink4,
+      );
+
+  static ThemeData _build(Brightness brightness) => ThemeData(
         useMaterial3: true,
-        brightness: Brightness.dark,
+        brightness: brightness,
         fontFamily: 'Geist',
         scaffoldBackgroundColor: AppColors.bg,
         canvasColor: AppColors.bg,
         cardColor: AppColors.panel,
-        dialogTheme: const DialogThemeData(backgroundColor: AppColors.panel),
+        dialogTheme: DialogThemeData(backgroundColor: AppColors.panel),
         dividerColor: AppColors.line,
         splashColor: AppColors.violet.withValues(alpha: 0.14),
-        highlightColor: Colors.white.withValues(alpha: 0.06),
-        hoverColor: Colors.white.withValues(alpha: 0.06),
-        colorScheme: _colorScheme,
+        highlightColor: AppColors.wash(0.06),
+        hoverColor: AppColors.wash(0.06),
+        colorScheme: _colorScheme(brightness),
         textTheme: TextTheme(
           displayLarge: AppText.h1(88),
           displayMedium: AppText.h2(52),
@@ -383,8 +661,8 @@ abstract final class BooksHomeTheme {
           bodySmall: AppText.small,
           labelSmall: AppText.eyebrow,
         ),
-        iconTheme: const IconThemeData(color: AppColors.ink2, size: 22),
-        appBarTheme: const AppBarTheme(
+        iconTheme: IconThemeData(color: AppColors.ink2, size: 22),
+        appBarTheme: AppBarTheme(
           backgroundColor: Colors.transparent,
           surfaceTintColor: Colors.transparent,
           shadowColor: Colors.transparent,
@@ -392,16 +670,16 @@ abstract final class BooksHomeTheme {
           scrolledUnderElevation: 0,
           foregroundColor: AppColors.ink1,
         ),
-        progressIndicatorTheme: const ProgressIndicatorThemeData(
+        progressIndicatorTheme: ProgressIndicatorThemeData(
           color: AppColors.violet,
           circularTrackColor: AppColors.panel2,
         ),
-        textSelectionTheme: const TextSelectionThemeData(
+        textSelectionTheme: TextSelectionThemeData(
           cursorColor: AppColors.blue,
-          selectionColor: Color(0x403F7BFF),
+          selectionColor: AppColors.blue.withValues(alpha: 0.25),
           selectionHandleColor: AppColors.blue,
         ),
-        bottomSheetTheme: const BottomSheetThemeData(
+        bottomSheetTheme: BottomSheetThemeData(
           backgroundColor: AppColors.panel,
           surfaceTintColor: Colors.transparent,
           modalBackgroundColor: AppColors.panel,

--- a/apps/flipper_web/lib/features/home/widgets/books_home_widgets.dart
+++ b/apps/flipper_web/lib/features/home/widgets/books_home_widgets.dart
@@ -127,7 +127,7 @@ class HeroTopBadge extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.fromLTRB(10, 6, 13, 6),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.03),
+        color: AppColors.wash(0.03),
         borderRadius: BorderRadius.circular(999),
         border: Border.all(color: AppColors.line2),
       ),
@@ -146,8 +146,8 @@ class HeroTopBadge extends StatelessWidget {
           Text.rich(
             TextSpan(
               style: AppText.small.copyWith(fontSize: 13, fontWeight: FontWeight.w500, color: AppColors.ink2),
-              children: const [
-                TextSpan(text: 'Flipper Books · powered by '),
+              children: [
+                const TextSpan(text: 'Flipper Books · powered by '),
                 TextSpan(
                   text: 'Flow AI',
                   style: TextStyle(color: AppColors.ink0, fontWeight: FontWeight.w600),
@@ -537,14 +537,14 @@ class PrimaryButton extends StatelessWidget {
           children: [
             Text(
               label,
-              style: AppText.buttonLabel.copyWith(fontSize: fontSize, color: AppColors.ink0),
+              style: AppText.buttonLabel.copyWith(fontSize: fontSize, color: AppColors.onBrand),
             ),
             if (showArrow) ...[
               const SizedBox(width: 9),
               BooksLineIcon(
                 BooksIcon.arrowRight,
                 size: compact ? 16 : 18,
-                color: AppColors.ink0,
+                color: AppColors.onBrand,
               ),
             ],
           ],
@@ -582,7 +582,7 @@ class GhostButton extends StatelessWidget {
         padding: EdgeInsets.symmetric(horizontal: padX),
         alignment: Alignment.center,
         decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.02),
+          color: AppColors.wash(0.02),
           borderRadius: BorderRadius.circular(999),
           border: Border.all(color: AppColors.line2),
         ),
@@ -629,7 +629,7 @@ class WhiteButton extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: AppText.buttonPadX),
         alignment: Alignment.center,
         decoration: BoxDecoration(
-          color: AppColors.ink0,
+          color: AppColors.cardOnBrand,
           borderRadius: BorderRadius.circular(999),
           boxShadow: AppShadow.whiteCard,
         ),
@@ -685,7 +685,7 @@ class OutlineWhiteButton extends StatelessWidget {
           label,
           style: AppText.buttonLabel.copyWith(
             fontSize: 15.5,
-            color: AppColors.ink0,
+            color: AppColors.onBrand,
           ),
         ),
       ),
@@ -710,7 +710,7 @@ class TrustChip extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 11),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.02),
+        color: AppColors.wash(0.02),
         borderRadius: BorderRadius.circular(999),
         border: Border.all(color: AppColors.line),
       ),
@@ -726,7 +726,7 @@ class TrustChip extends StatelessWidget {
                 if (bold != null && bold!.isNotEmpty) ...[
                   TextSpan(
                     text: bold,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.ink0,
                       fontWeight: FontWeight.w700,
                     ),
@@ -757,7 +757,7 @@ class MostPopularTag extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Text('★', style: TextStyle(fontSize: 11.5, color: AppColors.popularTagInk)),
+          Text('★', style: TextStyle(fontSize: 11.5, color: AppColors.popularTagInk)),
           const SizedBox(width: 4),
           Text(
             'Most Popular',
@@ -873,7 +873,7 @@ class HeroBackground extends StatelessWidget {
                   decoration: BoxDecoration(
                     gradient: RadialGradient(
                       colors: [
-                        AppColors.blue.withValues(alpha: 0.30),
+                        AppColors.glow(AppColors.blue, 0.30),
                         Colors.transparent,
                       ],
                       stops: const [0, 0.7],
@@ -894,7 +894,7 @@ class HeroBackground extends StatelessWidget {
               decoration: BoxDecoration(
                 gradient: RadialGradient(
                   colors: [
-                    AppColors.cyan.withValues(alpha: 0.20),
+                    AppColors.glow(AppColors.cyan, 0.20),
                     Colors.transparent,
                   ],
                   stops: const [0, 0.7],
@@ -913,7 +913,7 @@ class HeroBackground extends StatelessWidget {
               decoration: BoxDecoration(
                 gradient: RadialGradient(
                   colors: [
-                    AppColors.violet.withValues(alpha: 0.18),
+                    AppColors.glow(AppColors.violet, 0.18),
                     Colors.transparent,
                   ],
                   stops: const [0, 0.7],
@@ -932,7 +932,9 @@ class HeroBackground extends StatelessWidget {
                 stops: const [0, 0.75],
               ).createShader(rect),
               blendMode: BlendMode.dstIn,
-              child: CustomPaint(painter: _HeroGridPainter()),
+              child: CustomPaint(
+                painter: _HeroGridPainter(color: AppColors.wash(0.035)),
+              ),
             ),
           ),
         ),
@@ -943,10 +945,14 @@ class HeroBackground extends StatelessWidget {
 }
 
 class _HeroGridPainter extends CustomPainter {
+  _HeroGridPainter({required this.color});
+
+  final Color color;
+
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
-      ..color = Colors.white.withValues(alpha: 0.035)
+      ..color = color
       ..strokeWidth = 1;
     for (var x = 0.0; x <= size.width; x += 64) {
       canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
@@ -957,7 +963,8 @@ class _HeroGridPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+  bool shouldRepaint(covariant _HeroGridPainter oldDelegate) =>
+      oldDelegate.color != color;
 }
 
 class DashedOutlineContainer extends StatelessWidget {

--- a/apps/flipper_web/lib/features/home/widgets/books_line_icon.dart
+++ b/apps/flipper_web/lib/features/home/widgets/books_line_icon.dart
@@ -40,12 +40,15 @@ class BooksLineIcon extends StatelessWidget {
     this.icon, {
     super.key,
     this.size = 16,
-    this.color = AppColors.ink2,
+    this.color,
   });
 
   final BooksIcon icon;
   final double size;
-  final Color color;
+
+  /// Defaults to the palette's `ink2` — resolved at build time, because the
+  /// palette changes with the theme.
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
@@ -53,7 +56,7 @@ class BooksLineIcon extends StatelessWidget {
       icon.assetPath,
       width: size,
       height: size,
-      colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
+      colorFilter: ColorFilter.mode(color ?? AppColors.ink2, BlendMode.srcIn),
       excludeFromSemantics: true,
     );
   }

--- a/apps/flipper_web/lib/features/home/widgets/books_theme_toggle.dart
+++ b/apps/flipper_web/lib/features/home/widgets/books_theme_toggle.dart
@@ -1,0 +1,69 @@
+import 'package:flipper_web/features/home/theme/books_home_theme.dart';
+import 'package:flipper_web/features/home/widgets/books_home_widgets.dart';
+import 'package:flipper_web/features/login/theme_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Light/dark switch for the marketing page.
+///
+/// It drives the app-wide [themeProvider] (light by default), so the choice
+/// carries through to sign-in and the workspace behind it.
+class BooksThemeToggle extends ConsumerWidget {
+  const BooksThemeToggle({super.key, this.size = 38});
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isDark = ref.watch(themeProvider) == ThemeMode.dark;
+
+    // Semantics rather than Tooltip: the header sits inside a pinned
+    // SliverAppBar's LayoutBuilder, where an overlay-backed Tooltip is the
+    // known trigger for the `!_skipMarkNeedsLayout` assert.
+    return Semantics(
+      button: true,
+      label: isDark ? 'Switch to light mode' : 'Switch to dark mode',
+      child: PressScale(
+        onTap: () => ref.read(themeProvider.notifier).toggle(),
+        child: Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: AppColors.wash(0.03),
+            shape: BoxShape.circle,
+            border: Border.all(color: AppColors.line2),
+          ),
+          child: Icon(
+            isDark ? Icons.light_mode_outlined : Icons.dark_mode_outlined,
+            size: size * 0.48,
+            color: AppColors.ink2,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Row form of [BooksThemeToggle] for the compact nav sheet.
+class BooksThemeToggleTile extends ConsumerWidget {
+  const BooksThemeToggleTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isDark = ref.watch(themeProvider) == ThemeMode.dark;
+
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: Icon(
+        isDark ? Icons.light_mode_outlined : Icons.dark_mode_outlined,
+        size: 20,
+        color: AppColors.ink2,
+      ),
+      title: Text(
+        isDark ? 'Light mode' : 'Dark mode',
+        style: AppText.body.copyWith(color: AppColors.ink1),
+      ),
+      onTap: () => ref.read(themeProvider.notifier).toggle(),
+    );
+  }
+}

--- a/apps/flipper_web/lib/features/home/widgets/books_theme_toggle.dart
+++ b/apps/flipper_web/lib/features/home/widgets/books_theme_toggle.dart
@@ -46,7 +46,17 @@ class BooksThemeToggle extends ConsumerWidget {
 
 /// Row form of [BooksThemeToggle] for the compact nav sheet.
 class BooksThemeToggleTile extends ConsumerWidget {
-  const BooksThemeToggleTile({super.key});
+  const BooksThemeToggleTile({super.key, this.onToggled});
+
+  /// Run straight after the toggle. The nav sheet passes a dismiss here.
+  ///
+  /// A modal sheet does not repaint with the palette: its `backgroundColor`
+  /// is read once when it opens, and the rows around this one watch nothing,
+  /// so they keep the colours they were built with. Only this row rebuilds —
+  /// against the *new* palette — which on a light sheet leaves it near-white
+  /// on white. Closing the sheet is what the other rows already do before
+  /// they act.
+  final VoidCallback? onToggled;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -63,7 +73,10 @@ class BooksThemeToggleTile extends ConsumerWidget {
         isDark ? 'Light mode' : 'Dark mode',
         style: AppText.body.copyWith(color: AppColors.ink1),
       ),
-      onTap: () => ref.read(themeProvider.notifier).toggle(),
+      onTap: () {
+        ref.read(themeProvider.notifier).toggle();
+        onToggled?.call();
+      },
     );
   }
 }

--- a/apps/flipper_web/lib/features/login/auth_wrapper.dart
+++ b/apps/flipper_web/lib/features/login/auth_wrapper.dart
@@ -72,8 +72,8 @@ class AuthWrapper extends ConsumerWidget {
         }
       },
       loading: () => Theme(
-        data: BooksHomeTheme.data,
-        child: const Scaffold(
+        data: BooksHomeTheme.of(Theme.of(context).brightness),
+        child: Scaffold(
           backgroundColor: AppColors.bg,
           body: Center(
             child: CircularProgressIndicator(color: AppColors.violet),

--- a/apps/flipper_web/pubspec.yaml
+++ b/apps/flipper_web/pubspec.yaml
@@ -4,7 +4,7 @@ description: "A new Flutter project."
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.797+1713
+version: 1.0.798+1714
 
 
 environment:

--- a/apps/flipper_web/pubspec.yaml
+++ b/apps/flipper_web/pubspec.yaml
@@ -4,7 +4,7 @@ description: "A new Flutter project."
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.798+1714
+version: 1.0.799+1715
 
 
 environment:

--- a/apps/flipper_web/test/features/home/home_screen_test.dart
+++ b/apps/flipper_web/test/features/home/home_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flipper_web/features/home/home_screen.dart';
+import 'package:flipper_web/features/home/sections/books_home_sections.dart';
 import 'package:flipper_web/features/home/theme/books_home_theme.dart';
 import 'package:flipper_web/features/home/widgets/books_home_widgets.dart';
 
@@ -100,6 +101,55 @@ void main() {
         ),
       );
       expect(scaffold.backgroundColor, BooksPalette.dark.bg);
+    });
+
+    testWidgets('the nav sheet closes when the theme is switched from it', (
+      WidgetTester tester,
+    ) async {
+      // A modal sheet keeps the background colour it opened with, and its
+      // other rows watch nothing, so they keep the colours they were built
+      // with. Leaving it open would show this row alone in the new palette.
+      //
+      // The header is pumped on its own rather than the whole page: the
+      // pricing section puts Flexible children in a vertical Flex under
+      // unbounded height, so rendering the page below 860px throws before the
+      // menu can be opened. That is a separate, pre-existing bug.
+      tester.view.physicalSize = const Size(700, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: BooksHomeHeader(
+                scrolled: false,
+                onStartFree: () {},
+                onSignIn: () {},
+                onNavTap: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.menu_rounded));
+      await tester.pumpAndSettle();
+      expect(find.text('Dark mode'), findsOneWidget);
+
+      await tester.tap(find.text('Dark mode'));
+      await tester.pumpAndSettle();
+      expect(
+        find.text('Dark mode'),
+        findsNothing,
+        reason: 'the sheet dismisses instead of half-repainting',
+      );
+
+      // Reopening proves the toggle took effect rather than being swallowed.
+      await tester.tap(find.byIcon(Icons.menu_rounded));
+      await tester.pumpAndSettle();
+      expect(find.text('Light mode'), findsOneWidget);
     });
   });
 }

--- a/apps/flipper_web/test/features/home/home_screen_test.dart
+++ b/apps/flipper_web/test/features/home/home_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flipper_web/features/home/home_screen.dart';
+import 'package:flipper_web/features/home/theme/books_home_theme.dart';
 import 'package:flipper_web/features/home/widgets/books_home_widgets.dart';
 
 void main() {
@@ -10,7 +11,10 @@ void main() {
       booksHomeShowDeviceMocks = true;
     });
 
-    Future<void> pumpHomeScreen(WidgetTester tester) async {
+    Future<void> pumpHomeScreen(
+      WidgetTester tester, {
+      ThemeMode themeMode = ThemeMode.light,
+    }) async {
       tester.view.physicalSize = const Size(1920, 4000);
       tester.view.devicePixelRatio = 1.0;
       booksHomeShowDeviceMocks = false;
@@ -18,6 +22,9 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           child: MaterialApp(
+            theme: ThemeData(brightness: Brightness.light),
+            darkTheme: ThemeData(brightness: Brightness.dark),
+            themeMode: themeMode,
             home: MediaQuery(
               data: const MediaQueryData(disableAnimations: true),
               child: const HomeScreen(),
@@ -62,6 +69,37 @@ void main() {
       expect(find.text('12,400+'), findsWidgets);
       expect(find.text('RWF 1.2B'), findsOneWidget);
       expect(find.text('99.9%'), findsOneWidget);
+    });
+
+    testWidgets('renders light by default', (WidgetTester tester) async {
+      await pumpHomeScreen(tester);
+
+      expect(AppColors.palette, BooksPalette.light);
+      expect(AppColors.bg, BooksPalette.light.bg);
+
+      final scaffold = tester.widget<Scaffold>(
+        find.descendant(
+          of: find.byType(HomeScreen),
+          matching: find.byType(Scaffold),
+        ),
+      );
+      expect(scaffold.backgroundColor, BooksPalette.light.bg);
+    });
+
+    testWidgets('follows the app theme mode into dark', (
+      WidgetTester tester,
+    ) async {
+      await pumpHomeScreen(tester, themeMode: ThemeMode.dark);
+
+      expect(AppColors.palette, BooksPalette.dark);
+
+      final scaffold = tester.widget<Scaffold>(
+        find.descendant(
+          of: find.byType(HomeScreen),
+          matching: find.byType(Scaffold),
+        ),
+      );
+      expect(scaffold.backgroundColor, BooksPalette.dark.bg);
     });
   });
 }


### PR DESCRIPTION
MaterialApp already defaulted to ThemeMode.light and everything behind sign-in is built from light tokens, but the marketing page at `/` pinned Brightness.dark and painted ~200 call sites from a dark-only token set, so it ignored the app theme entirely.

BooksPalette now holds two sets: `dark` is the original handoff, `light` is its mirror, keyed to the inks the rest of flipper_web already uses (SITokens, AccountingTokens) so the landing page and the app behind it read as one product. AppColors, AppGrad, AppShadow and AppText resolve against the active palette rather than holding dark constants, and BooksHomeTheme.data becomes BooksHomeTheme.of(Brightness), which installs the palette before building the ThemeData. HomeScreen, BooksHomePage and the auth-wrapper loading state read Theme.of(context).brightness, so the page follows the app theme mode; the status-bar overlay style flips with it.

Three helpers carry the effects that cannot simply swap colour: wash() turns the handoff's rgba(255,255,255,.0x) surface films into ink films, glow() damps the brand glows so they do not bloom on white, and shadow() damps drop shadows. Tokens that sit on a brand surface — the blue band, the violet primary button, the white cards floating on the band — are separated out as onBrand/cardOnBrand/suiteActiveInk and stay fixed in both modes; without that split the "Start free" label would have gone dark-on-violet in light mode.

BooksThemeToggle in the marketing header drives the existing app-wide themeProvider, so dark stays reachable rather than merely swapping which mode is unavailable. It uses Semantics rather than Tooltip: the header sits inside a pinned SliverAppBar's LayoutBuilder, the known trigger for the !_skipMarkNeedsLayout assert.

Fixes a pre-existing bug while here. The white cards on the brand band styled their text with AppColors.ink1/ink3 — near-white ink on a white card. The whiteCardInk/whiteCardMuted/whiteCardBar/saleCheckBg tokens were defined for exactly this and had zero usages; they are used now.

Note the toggle sets the app-wide theme mode but only this page has a dark palette, so the workspace and sign-in stay light after switching. A dark workspace palette is a much larger piece of work. The choice is also session-scoped, not persisted; the default is light either way.

+2 tests, asserting the page renders light by default and follows the app theme mode into dark. 3 passing in the home suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added light and dark theme support for the Books home experience.
  * Added theme controls in the desktop header and mobile navigation.
  * Updated colors, gradients, icons, charts, and cards to adapt automatically to the selected theme.
  * Improved system status-bar contrast for light and dark modes.

* **Bug Fixes**
  * Corrected loading-screen styling so it matches the active theme.

* **Tests**
  * Added coverage for light- and dark-theme behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->