### PR TITLE
ci(windows): survive pub.dev flakes instead of hanging for six hours

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,7 +380,7 @@ jobs:
 
       - name: Add pub cache to PATH (Windows)
         if: runner.os == 'Windows'
-        run: Add-Content -Path $env:GITHUB_PATH -Value "${PUB_CACHE}/bin"
+        run: Add-Content -Path $env:GITHUB_PATH -Value "$env:PUB_CACHE/bin"
         shell: pwsh
 
       - name: Add pub cache to PATH (Unix)
@@ -442,6 +442,12 @@ jobs:
     name: "Build windows app-debug"
     if: github.ref != 'refs/heads/main' # Skip on merge to main; prod build runs instead
     runs-on: windows-latest
+    # Fail fast instead of burning the 6h default on a hung pub fetch.
+    timeout-minutes: 60
+    env:
+      # Pin PUB_CACHE so it can be cached across runs and so the
+      # "Add pub cache to PATH" step below resolves to a real directory.
+      PUB_CACHE: ${{ runner.temp }}/pub-cache
     # needs: [unit-testing,build_web_deploy_firebase] # Requires Supabase to be initialized
     # 
     steps:
@@ -461,12 +467,20 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/pub-cache
+          key: pub-cache-windows-${{ hashFiles('**/pubspec.yaml', 'apps/flipper/pubspec.lock') }}
+          restore-keys: |
+            pub-cache-windows-
+
       - name: Setup melos
         run: dart pub global activate melos 7.3.0
 
       - name: Add pub cache to PATH (Windows)
         if: runner.os == 'Windows'
-        run: Add-Content -Path $env:GITHUB_PATH -Value "${PUB_CACHE}/bin"
+        run: Add-Content -Path $env:GITHUB_PATH -Value "$env:PUB_CACHE/bin"
         shell: pwsh
 
       - name: Add pub cache to PATH (Unix)
@@ -475,8 +489,18 @@ jobs:
         shell: bash
 
       - name: Get Dependencies
+        # Baseline for this step is under 2 minutes; 25 caps a hung pub fetch.
+        timeout-minutes: 25
         run: |
-          dart run melos bootstrap
+          for attempt in 1 2 3; do
+            if dart run melos bootstrap; then
+              exit 0
+            fi
+            echo "::warning::melos bootstrap failed (attempt $attempt/3), retrying in $((attempt * 30))s"
+            sleep $((attempt * 30))
+          done
+          echo "::error::melos bootstrap failed after 3 attempts"
+          exit 1
         shell: bash
 
       - name: Configure Missing files
@@ -553,6 +577,12 @@ jobs:
     name: "Build windows app-store"
     if: github.ref == 'refs/heads/main'
     runs-on: windows-latest
+    # Fail fast instead of burning the 6h default on a hung pub fetch.
+    timeout-minutes: 60
+    env:
+      # Pin PUB_CACHE so it can be cached across runs and so the
+      # "Add pub cache to PATH" step below resolves to a real directory.
+      PUB_CACHE: ${{ runner.temp }}/pub-cache
     # integration-testing-windows,build_web_deploy_firebase
     # For now intrested in unit testing as web deployment is broken we will re-add need to depend on integration-testing-windows,build_web_deploy_firebase later
     # needs: [unit-testing] # Requires Supabase to be initialized
@@ -576,12 +606,20 @@ jobs:
       - name: Initialize submodules
         run: git submodule update --init
 
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/pub-cache
+          key: pub-cache-windows-${{ hashFiles('**/pubspec.yaml', 'apps/flipper/pubspec.lock') }}
+          restore-keys: |
+            pub-cache-windows-
+
       - name: Setup melos
         run: dart pub global activate melos 7.3.0
 
       - name: Add pub cache to PATH (Windows)
         if: runner.os == 'Windows'
-        run: Add-Content -Path $env:GITHUB_PATH -Value "${PUB_CACHE}/bin"
+        run: Add-Content -Path $env:GITHUB_PATH -Value "$env:PUB_CACHE/bin"
         shell: pwsh
 
       - name: Add pub cache to PATH (Unix)
@@ -590,9 +628,19 @@ jobs:
         shell: bash
 
       - name: Initialize submodules and bootstrap melos
+        # Baseline for this step is under 2 minutes; 25 caps a hung pub fetch.
+        timeout-minutes: 25
         run: |
           git submodule update --init
-          dart run melos bootstrap
+          for attempt in 1 2 3; do
+            if dart run melos bootstrap; then
+              exit 0
+            fi
+            echo "::warning::melos bootstrap failed (attempt $attempt/3), retrying in $((attempt * 30))s"
+            sleep $((attempt * 30))
+          done
+          echo "::error::melos bootstrap failed after 3 attempts"
+          exit 1
         shell: bash
 
       - name: Configure Missing files
@@ -673,6 +721,12 @@ jobs:
     name: "Build windows app-store (prerelease)"
     if: github.ref == 'refs/heads/ditto-only-migration'
     runs-on: windows-latest
+    # Fail fast instead of burning the 6h default on a hung pub fetch.
+    timeout-minutes: 60
+    env:
+      # Pin PUB_CACHE so it can be cached across runs and so the
+      # "Add pub cache to PATH" step below resolves to a real directory.
+      PUB_CACHE: ${{ runner.temp }}/pub-cache
     steps:
       - uses: actions/checkout@v4
         with:
@@ -693,12 +747,20 @@ jobs:
       - name: Initialize submodules
         run: git submodule update --init
 
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/pub-cache
+          key: pub-cache-windows-${{ hashFiles('**/pubspec.yaml', 'apps/flipper/pubspec.lock') }}
+          restore-keys: |
+            pub-cache-windows-
+
       - name: Setup melos
         run: dart pub global activate melos 7.3.0
 
       - name: Add pub cache to PATH (Windows)
         if: runner.os == 'Windows'
-        run: Add-Content -Path $env:GITHUB_PATH -Value "${PUB_CACHE}/bin"
+        run: Add-Content -Path $env:GITHUB_PATH -Value "$env:PUB_CACHE/bin"
         shell: pwsh
 
       - name: Add pub cache to PATH (Unix)
@@ -707,9 +769,19 @@ jobs:
         shell: bash
 
       - name: Initialize submodules and bootstrap melos
+        # Baseline for this step is under 2 minutes; 25 caps a hung pub fetch.
+        timeout-minutes: 25
         run: |
           git submodule update --init
-          dart run melos bootstrap
+          for attempt in 1 2 3; do
+            if dart run melos bootstrap; then
+              exit 0
+            fi
+            echo "::warning::melos bootstrap failed (attempt $attempt/3), retrying in $((attempt * 30))s"
+            sleep $((attempt * 30))
+          done
+          echo "::error::melos bootstrap failed after 3 attempts"
+          exit 1
         shell: bash
 
       - name: Configure Missing files


### PR DESCRIPTION
## What broke

Run [34456175007](https://github.com/yegobox/flipper/actions/runs/34456175007) failed the **Build windows app-store** job twice, both times at `Initialize submodules and bootstrap melos`.

**First attempt** — a hard 403 from pub.dev on one package:

```
Because every version of flipper_rw from path depends on sqflite_common_ffi_web ^1.0.1+1
which depends on process_run >=0.12.3+2 <2.0.0, ...
So, because process_run doesn't exist (authorization failed) ..., version solving failed.

Insufficient permissions to the resource at the https://pub.dev package repository.
```

**Second attempt** — a hang. The step ran **40+ minutes** against a **1m44s** baseline (measured from the last green run, 34243906650) before it was cancelled.

## Why it isn't us

- pub.dev was healthy throughout: `process_run`, `sqflite_common_ffi_web` and the site root all returned 200 in under a second from outside CI.
- No pub token is configured in any workflow, and `process_run` is a public package — so "authorization failed" is pub.dev rejecting the runner, not a credentials problem.
- The head commit (`a6a3433`) touched only Dart UI files and two version bumps. No dependency changes.
- Every other package bootstrapped fine in the same job, and the three Linux jobs in the same run bootstrapped successfully at the same moment.

That points at the Windows runner's path to pub.dev. Re-running alone doesn't reliably clear it — we tried.

## Changes

Applied to all three windows build jobs (`app-debug`, `app-store`, `app-store (prerelease)`):

1. **Cache `PUB_CACHE`** between runs, so a warm cache serves package archives rather than re-downloading ~440 dependencies from pub.dev on every build. Follows the `actions/cache@v4` pattern already used for pdfium.
2. **Retry `melos bootstrap`** up to 3 times with 30/60/90s backoff. Bootstrap is idempotent, so this costs nothing on the happy path and absorbs the fast-fail case (the 403 surfaced in ~3 minutes, so all three attempts fit inside the step timeout).
3. **Bound the damage** — `timeout-minutes: 25` on the bootstrap step and `60` on the job. No job in this workflow set a timeout, so the hung run was on course to burn the **6 hour** GitHub default on a 2x-billed windows runner.

### Drive-by fix

The PATH step this depends on was already broken:

```yaml
run: Add-Content -Path $env:GITHUB_PATH -Value "${PUB_CACHE}/bin"
shell: pwsh
```

`${PUB_CACHE}` is a PowerShell *variable* reference, not an environment one, so it expanded to empty and appended a bare `/bin` to PATH. And `PUB_CACHE` was only ever set in `integration-testing-windows`, which is `if: false`. Now `$env:PUB_CACHE`, set at the job level in all four windows jobs.

Harmless until now because melos is invoked via `dart run`, not from PATH — but the cache change depends on the variable actually resolving.

## Verification

- YAML parses; all three jobs confirmed to carry the timeout, the `PUB_CACHE` env, the cache step and the 25-minute bootstrap guard.
- Retry loop exercised locally under `bash -eo pipefail` (what GitHub uses for `shell: bash`): exits 0 when a later attempt succeeds, exits 1 after three failures. `set -e` does not trip the loop early because the command sits in an `if` condition.

## Not addressed here

The **Unit Testing** job reports **28 failed tests** (713 passed) in its annotations but is still marked green, so test failures aren't gating this pipeline. Separate issue, flagging it for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of Windows release builds through better package caching and automatic retries.
  * Added safeguards to prevent stalled debug, production, and prerelease builds from running indefinitely.
  * Improved Windows integration-test stability with more consistent package-cache handling.
  * Enhanced failure reporting to make unsuccessful release and validation jobs easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->