### PR TITLE
ci: fix invalid release.yml — runner context in job-level env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,10 +444,6 @@ jobs:
     runs-on: windows-latest
     # Fail fast instead of burning the 6h default on a hung pub fetch.
     timeout-minutes: 60
-    env:
-      # Pin PUB_CACHE so it can be cached across runs and so the
-      # "Add pub cache to PATH" step below resolves to a real directory.
-      PUB_CACHE: ${{ runner.temp }}/pub-cache
     # needs: [unit-testing,build_web_deploy_firebase] # Requires Supabase to be initialized
     # 
     steps:
@@ -466,6 +462,13 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
+
+      - name: Pin PUB_CACHE
+        # Set here rather than in job-level `env:`, where the `runner`
+        # context is not available. Also makes "Add pub cache to PATH"
+        # below resolve to a real directory.
+        run: echo "PUB_CACHE=${RUNNER_TEMP}/pub-cache" >> "$GITHUB_ENV"
+        shell: bash
 
       - name: Cache pub packages
         uses: actions/cache@v4
@@ -579,10 +582,6 @@ jobs:
     runs-on: windows-latest
     # Fail fast instead of burning the 6h default on a hung pub fetch.
     timeout-minutes: 60
-    env:
-      # Pin PUB_CACHE so it can be cached across runs and so the
-      # "Add pub cache to PATH" step below resolves to a real directory.
-      PUB_CACHE: ${{ runner.temp }}/pub-cache
     # integration-testing-windows,build_web_deploy_firebase
     # For now intrested in unit testing as web deployment is broken we will re-add need to depend on integration-testing-windows,build_web_deploy_firebase later
     # needs: [unit-testing] # Requires Supabase to be initialized
@@ -605,6 +604,13 @@ jobs:
 
       - name: Initialize submodules
         run: git submodule update --init
+
+      - name: Pin PUB_CACHE
+        # Set here rather than in job-level `env:`, where the `runner`
+        # context is not available. Also makes "Add pub cache to PATH"
+        # below resolve to a real directory.
+        run: echo "PUB_CACHE=${RUNNER_TEMP}/pub-cache" >> "$GITHUB_ENV"
+        shell: bash
 
       - name: Cache pub packages
         uses: actions/cache@v4
@@ -723,10 +729,6 @@ jobs:
     runs-on: windows-latest
     # Fail fast instead of burning the 6h default on a hung pub fetch.
     timeout-minutes: 60
-    env:
-      # Pin PUB_CACHE so it can be cached across runs and so the
-      # "Add pub cache to PATH" step below resolves to a real directory.
-      PUB_CACHE: ${{ runner.temp }}/pub-cache
     steps:
       - uses: actions/checkout@v4
         with:
@@ -746,6 +748,13 @@ jobs:
 
       - name: Initialize submodules
         run: git submodule update --init
+
+      - name: Pin PUB_CACHE
+        # Set here rather than in job-level `env:`, where the `runner`
+        # context is not available. Also makes "Add pub cache to PATH"
+        # below resolve to a real directory.
+        run: echo "PUB_CACHE=${RUNNER_TEMP}/pub-cache" >> "$GITHUB_ENV"
+        shell: bash
 
       - name: Cache pub packages
         uses: actions/cache@v4


### PR DESCRIPTION
## Urgent: `release.yml` on `main` is currently invalid

#601 merged with `PUB_CACHE: ${{ runner.temp }}/pub-cache` in job-level `env:` on the three windows build jobs. The `runner` context isn't available there, so GitHub rejects the file:

```
Invalid workflow file: .github/workflows/release.yml#L1
(Line: 450, Col: 18): Unrecognized named-value: 'runner'
(Line: 585, Col: 18): Unrecognized named-value: 'runner'
(Line: 729, Col: 18): Unrecognized named-value: 'runner'
```

**A workflow file is validated as a unit**, so this doesn't just break the three jobs that carried the bad key — it takes down *every* job in `release.yml`: Unit Testing, `build_web_deploy_firebase`, `build_hr_deploy_firebase`, and the windows builds. Nothing from this file runs on `main` until it's fixed.

That's the whole content of this PR. The pub-cache / retry / timeout work from #601 is untouched and stays as merged.

## The fix

`PUB_CACHE` is now set from a step via `GITHUB_ENV`, which is exactly what `integration-testing-windows` in this same file already does:

```yaml
      - name: Pin PUB_CACHE
        run: echo "PUB_CACHE=${RUNNER_TEMP}/pub-cache" >> "$GITHUB_ENV"
        shell: bash
```

The `actions/cache` step keeps `${{ runner.temp }}` — that one is step-level, where the context *is* allowed.

Available contexts in `jobs.<job_id>.env` are `github`, `inputs`, `matrix`, `needs`, `secrets`, `strategy`, `vars` — [context availability](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability).

## Verification

Checked with [actionlint](https://github.com/rhysd/actionlint) 1.7.12, which reproduces GitHub's validator:

- **Against `main` as it stands**, it reports the same three lines GitHub named:
  `450:22: context "runner" is not allowed here. available contexts are "github", "inputs", "matrix", "needs", "secrets", "strategy", "vars"` — and likewise at 585 and 729.
- **Against this branch**, no expression or syntax findings. The remaining output is all pre-existing and info-level: SC2086 on `echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH` lines that predate this work, the `if: false` on the flaky integration job, and the `workflow_dispatch` `lane` default `internal` not being among its own options.

Step ordering re-confirmed in all three windows jobs: pin `PUB_CACHE` → restore cache → `dart pub global activate melos` (installs into that cache) → add to PATH → bootstrap.

## Worth fixing separately

This class of error can't be caught by the checks on a `ci/*` PR, because GitHub only validates a workflow file when it tries to *run* it, and `ci/*` isn't in this workflow's push-trigger list. An `actionlint` step on PRs touching `.github/workflows/**` would catch it at review time — happy to open that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)